### PR TITLE
feat: デフォルトレーン名をlane1〜lane4に変更 (#21)

### DIFF
--- a/src/features/dashboard/constants.ts
+++ b/src/features/dashboard/constants.ts
@@ -12,10 +12,10 @@ export interface DefaultLane {
 }
 
 export const DEFAULT_LANES: DefaultLane[] = [
-  { name: '企業', colorIndex: 0, position: 0 },
-  { name: 'システム', colorIndex: 1, position: 1 },
-  { name: '事務局', colorIndex: 2, position: 2 },
-  { name: 'ユーザー', colorIndex: 3, position: 3 },
+  { name: 'lane1', colorIndex: 0, position: 0 },
+  { name: 'lane2', colorIndex: 1, position: 1 },
+  { name: 'lane3', colorIndex: 2, position: 2 },
+  { name: 'lane4', colorIndex: 3, position: 3 },
 ]
 
 /**

--- a/src/features/editor/pages/FlowListPage.tsx
+++ b/src/features/editor/pages/FlowListPage.tsx
@@ -1,6 +1,11 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { apiFetch } from '../../../lib/api'
+import {
+  DEFAULT_FLOW_TITLE,
+  DEFAULT_FLOW_THEME_ID,
+  createDefaultLanes,
+} from '../../dashboard/constants'
 import type { FlowListResponse, FlowSummary } from '../types'
 
 export function FlowListPage() {
@@ -34,14 +39,9 @@ export function FlowListPage() {
       const data = await apiFetch<{ flow: { id: string } }>('/flows', {
         method: 'POST',
         body: JSON.stringify({
-          title: '無題のフロー',
-          themeId: 'cloud',
-          lanes: [
-            { id: crypto.randomUUID(), name: '企業', colorIndex: 0, position: 0 },
-            { id: crypto.randomUUID(), name: 'システム', colorIndex: 1, position: 1 },
-            { id: crypto.randomUUID(), name: '事務局', colorIndex: 2, position: 2 },
-            { id: crypto.randomUUID(), name: 'ユーザー', colorIndex: 3, position: 3 },
-          ],
+          title: DEFAULT_FLOW_TITLE,
+          themeId: DEFAULT_FLOW_THEME_ID,
+          lanes: createDefaultLanes(),
           nodes: [],
           arrows: [],
         }),


### PR DESCRIPTION
## Summary
- デフォルトレーン名を日本語（企業/システム/事務局/ユーザー）から汎用的な名前（lane1/lane2/lane3/lane4）に変更
- FlowListPage.tsxのハードコードされたレーン定義をcreateDefaultLanes()に統一（重複排除）
- FlowListPage.tsxのハードコードされたtitle/themeIdも定数に統一

## Test plan
- [x] 全283テスト通過
- [x] ブラウザで新規フロー作成時にレーン名がlane1〜lane4になることを確認
- [x] ESLint/Prettier チェック通過

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)