### PR TITLE
fix: SharedFlowViewer lint エラー修正（Deploy復旧）

### DIFF
--- a/src/features/shared/SharedFlowViewer.tsx
+++ b/src/features/shared/SharedFlowViewer.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import type { Flow, ThemeId, Node as FlowNode, Arrow } from '../editor/types'
 import { PALETTES, THEMES } from '../editor/theme-constants'
 import styles from './SharedFlowViewer.module.css'
@@ -53,11 +53,11 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
   const totalW = LM + sortedLanes.length * LW + (sortedLanes.length - 1) * G + 28
   const totalH = TM + HH + rowCount * RH + 40
 
-  const laneX = useCallback((li: number) => LM + li * (LW + G), [LW, G])
-  const ct = useCallback(
-    (li: number, ri: number): Point => ({ x: laneX(li) + LW / 2, y: TM + HH + ri * RH + RH / 2 }),
-    [laneX, LW],
-  )
+  const laneX = (li: number) => LM + li * (LW + G)
+  const ct = (li: number, ri: number): Point => ({
+    x: laneX(li) + LW / 2,
+    y: TM + HH + ri * RH + RH / 2,
+  })
 
   // Build lane index map
   const laneIdToIndex: Record<string, number> = {}


### PR DESCRIPTION
## Summary
- SharedFlowViewer.tsx の `react-hooks/preserve-manual-memoization` lint エラーを修正
- `useCallback` を plain function に変更し、React Compiler lint ルール違反を解消
- これにより GitHub Actions の Deploy ワークフロー（`npm run lint`）が通るようになる

## Test plan
- [x] `npx eslint src/features/shared/SharedFlowViewer.tsx` でlintエラーなし
- [x] `npm test` で全299テスト通過
- [x] 機能に変更なし（useCallback → plain function は同じ動作）

🤖 Generated with [Claude Code](https://claude.com/claude-code)