### PR TITLE
fix: サイトタイトルを「Flowline」に修正 & 共有ページタイトル動的設定 #54

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>vite-temp</title>
+    <title>Flowline</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/features/shared/SharedFlowPage.test.tsx
+++ b/src/features/shared/SharedFlowPage.test.tsx
@@ -161,6 +161,32 @@ describe('SharedFlowPage', () => {
   })
 
   // ========================================
+  // Document title
+  // ========================================
+  it('should set document.title to "Flowline - {flow title}" when flow loads', async () => {
+    mockApiFetch.mockResolvedValueOnce({ flow: mockSharedFlow })
+
+    renderSharedPage()
+
+    await waitFor(() => {
+      expect(document.title).toBe('Flowline - Shared Test Flow')
+    })
+  })
+
+  it('should reset document.title to "Flowline" on unmount', async () => {
+    mockApiFetch.mockResolvedValueOnce({ flow: mockSharedFlow })
+
+    const { unmount } = renderSharedPage()
+
+    await waitFor(() => {
+      expect(document.title).toBe('Flowline - Shared Test Flow')
+    })
+
+    unmount()
+    expect(document.title).toBe('Flowline')
+  })
+
+  // ========================================
   // Edge cases
   // ========================================
   it('should handle flow with empty lanes, nodes, and arrows', async () => {

--- a/src/features/shared/SharedFlowPage.tsx
+++ b/src/features/shared/SharedFlowPage.tsx
@@ -22,6 +22,7 @@ export function SharedFlowPage() {
       .then((data) => {
         if (!cancelled) {
           setFlow(data.flow)
+          document.title = `Flowline - ${data.flow.title}`
           setLoading(false)
         }
       })
@@ -38,6 +39,7 @@ export function SharedFlowPage() {
 
     return () => {
       cancelled = true
+      document.title = 'Flowline'
     }
   }, [token])
 


### PR DESCRIPTION
## Summary
- `index.html` の `<title>` を `vite-temp` → `Flowline` に修正
- 共有ページ (`/shared/:token`) でフロー読み込み後に `document.title` を `Flowline - {フロータイトル}` に動的設定
- アンマウント時に `Flowline` にリセット

## Test plan
- [x] テスト2件追加（タイトル設定・リセット）
- [x] 全387テスト通過
- [x] ブラウザで LP のタブタイトルが「Flowline」であることを確認

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)