### PR TITLE
fix: D1マイグレーション自動適用でフロー自動保存500エラーを修正 #66

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,15 @@ jobs:
         with:
           name: dist
           path: dist
-      - uses: cloudflare/wrangler-action@v3
+      - name: Apply D1 migrations
+        uses: cloudflare/wrangler-action@v3
+        with:
+          wranglerVersion: '4'
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: d1 migrations apply FLOWLINE_DB --remote
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
         with:
           wranglerVersion: '4'
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- 本番D1にマイグレーション `0002_node_arrow_styles.sql` を手動適用済み（即座修正）
- `deploy.yml` に `wrangler d1 migrations apply` ステップを追加（再発防止）
- デプロイ前にマイグレーションが自動適用されるため、今後新しいマイグレーションを追加しても本番に自動反映される

## 根本原因
本番D1に `0002_node_arrow_styles.sql`（nodes テーブルに `bg`, `stroke_color`, `dash` カラム追加）が未適用だった。INSERT INTO nodes が存在しないカラムを参照し 500 エラーが発生。

### 本番での再現結果（マイグレーション適用前）
- ノードなしフロー作成 → 200 OK
- ノードありフロー作成 → **500 Internal Server Error**

### 修正後の確認（マイグレーション適用後）
- ノードありフロー作成 → 200 OK
- PUT /api/flows/:id（ノード+矢印の構造更新）→ 200 OK

## Test plan
- [x] 本番D1にマイグレーション手動適用済み
- [x] 本番でノード付きフロー作成成功を確認
- [x] 本番でPUT自動保存（構造更新）成功を確認
- [x] 全405テスト PASS

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)