### PR TITLE
feat: 行の途中挿入UI + レーン追加UIのヘッダー限定化 #91

### DIFF
--- a/src/features/editor/FlowEditor.test.tsx
+++ b/src/features/editor/FlowEditor.test.tsx
@@ -1107,9 +1107,7 @@ describe('row insertion UI (#91)', () => {
 describe('lane gap UI header-only (#91)', () => {
   it('should render lane gap hit area with header-only height', () => {
     const flow = createMinimalFlow()
-    const { container } = render(
-      <FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />,
-    )
+    const { container } = render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
     // Lane gap hit areas should exist (for 1 lane: 2 gaps, left and right)
     const laneGapHitAreas = container.querySelectorAll('[data-testid^="lanegap-hit-"]')
     expect(laneGapHitAreas.length).toBe(2)

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -2276,8 +2276,22 @@ export default function FlowEditor({ flow, onSave, saveStatus, onShareChange }: 
                         opacity={0.3}
                       />
                       <circle cx={gx} cy={gy} r={10} fill={T.accent} />
-                      <line x1={gx - 4} y1={gy} x2={gx + 4} y2={gy} stroke="#fff" strokeWidth={1.5} />
-                      <line x1={gx} y1={gy - 4} x2={gx} y2={gy + 4} stroke="#fff" strokeWidth={1.5} />
+                      <line
+                        x1={gx - 4}
+                        y1={gy}
+                        x2={gx + 4}
+                        y2={gy}
+                        stroke="#fff"
+                        strokeWidth={1.5}
+                      />
+                      <line
+                        x1={gx}
+                        y1={gy - 4}
+                        x2={gx}
+                        y2={gy + 4}
+                        stroke="#fff"
+                        strokeWidth={1.5}
+                      />
                     </g>
                   )}
                 </g>


### PR DESCRIPTION
## Summary
- 行の途中に新しい行を挿入するUI（左端の行番号エリアにホバー→＋ボタン表示→クリックで挿入）
- レーン追加UIのホバーエリアをヘッダー領域のみに限定（以前はキャンバス全高）
- ＋ボタンの表示位置をヘッダー中央に修正

## Changes
- `hoveredRowGap` ステートと `insertRowAt` 関数を追加
- 行間ホバーUI（SVG）: 透明ヒットエリア + 紫＋ボタン + 横方向破線ガイドライン
- レーン追加UIヒットエリア: `height` を `HH + rows*RH` → `TM + HH` (70px) に変更
- テスト4件追加（行間UI描画、ホバーフィードバック、行挿入、ヘッダー限定高さ）

## Test plan
- [x] 行間ホバーUIが正しいtestidで描画される
- [x] ホバー時にフィードバック（破線＋＋ボタン）が表示される
- [x] クリックで行が挿入される
- [x] レーン追加UIのヒットエリア高さがTM+HH=70px
- [x] 全693テスト通過

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)