### PR TITLE
fix: wrangler.tomlから空のRESEND_API_KEYを削除 #110

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,9 +3,6 @@ compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "dist"
 
-[vars]
-RESEND_API_KEY = ""
-
 [[d1_databases]]
 binding = "FLOWLINE_DB"
 database_name = "flowline-db"


### PR DESCRIPTION
## Summary
- `wrangler.toml`の`RESEND_API_KEY = ""`を削除
- 空文字がfalsyのため`if (c.env.RESEND_API_KEY)`チェックでメール送信がスキップされていた
- APIキーは`.dev.vars`（ローカル）とCloudflare Pagesシークレット（本番）で管理

## 対応内容
- [x] `wrangler.toml`から`RESEND_API_KEY = ""`を削除
- [x] `.dev.vars`にAPIキーを追加（gitignore済み）
- [x] Cloudflare Pagesに本番用シークレットを設定済み

Closes #110

## Test plan
- [x] 全776テスト通過確認
- [ ] デプロイ後にユーザー登録でメール認証メールが届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)