### PR TITLE
fix: ドメインをflowline.six1.jpに変更、メール送信元を更新

### DIFF
--- a/api/lib/email.ts
+++ b/api/lib/email.ts
@@ -18,7 +18,7 @@ export async function sendVerificationEmail(
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      from: 'Flowline <noreply@flowline.pages.dev>',
+      from: 'Flowline <flowline@six1.jp>',
       to: [email],
       subject: 'Flowline へようこそ！ メールアドレスを確認してください',
       html: buildEmailHtml(email, verifyUrl),

--- a/api/routes/ogp.ts
+++ b/api/routes/ogp.ts
@@ -251,7 +251,7 @@ function buildOgpElement(title: string, authorName: string, laneCount: number, n
               color: 'rgba(255,255,255,0.5)',
             },
             // Branding text shown in the PNG image (intentionally static, not baseUrl)
-            children: 'flowline.pages.dev',
+            children: 'flowline.six1.jp',
           },
         },
       ],

--- a/index.html
+++ b/index.html
@@ -16,13 +16,13 @@
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://flowline.pages.dev" />
+    <meta property="og:url" content="https://flowline.six1.jp" />
     <meta property="og:title" content="Flowline — フローを描く。チームが動く。" />
     <meta
       property="og:description"
       content="業務プロセスを視覚化するスイムレーンエディタ。ドラッグ&amp;ドロップで直感的にフロー図を作成、チームで共有。"
     />
-    <meta property="og:image" content="https://flowline.pages.dev/ogp/default.png" />
+    <meta property="og:image" content="https://flowline.six1.jp/ogp/default.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:site_name" content="Flowline" />
@@ -32,7 +32,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Flowline — フローを描く。チームが動く。" />
     <meta name="twitter:description" content="業務プロセスを視覚化するスイムレーンエディタ" />
-    <meta name="twitter:image" content="https://flowline.pages.dev/ogp/default.png" />
+    <meta name="twitter:image" content="https://flowline.six1.jp/ogp/default.png" />
 
     <!-- Theme -->
     <meta name="theme-color" content="#7C5CFC" />

--- a/tests/api/lib/email.test.ts
+++ b/tests/api/lib/email.test.ts
@@ -3,23 +3,23 @@ import { sendVerificationEmail, buildVerificationUrl } from '../../../api/lib/em
 
 describe('buildVerificationUrl', () => {
   it('should return URL with token parameter', () => {
-    const url = buildVerificationUrl('abc123', 'https://flowline.pages.dev')
-    expect(url).toBe('https://flowline.pages.dev/verify?token=abc123')
+    const url = buildVerificationUrl('abc123', 'https://flowline.six1.jp')
+    expect(url).toBe('https://flowline.six1.jp/verify?token=abc123')
   })
 
   it('should handle empty token string', () => {
-    const url = buildVerificationUrl('', 'https://flowline.pages.dev')
-    expect(url).toBe('https://flowline.pages.dev/verify?token=')
+    const url = buildVerificationUrl('', 'https://flowline.six1.jp')
+    expect(url).toBe('https://flowline.six1.jp/verify?token=')
   })
 
   it('should handle base URL with trailing slash', () => {
-    const url = buildVerificationUrl('abc123', 'https://flowline.pages.dev/')
+    const url = buildVerificationUrl('abc123', 'https://flowline.six1.jp/')
     // Should not produce double slash in path
     expect(url).toContain('verify?token=abc123')
   })
 
   it('should encode special characters in token', () => {
-    const url = buildVerificationUrl('abc+123&foo=bar', 'https://flowline.pages.dev')
+    const url = buildVerificationUrl('abc+123&foo=bar', 'https://flowline.six1.jp')
     expect(url).toContain('verify?token=')
     // Token should be included (encoding is implementation detail)
     expect(url).toContain('abc')
@@ -43,7 +43,7 @@ describe('sendVerificationEmail', () => {
       'test@example.com',
       'token123',
       'resend-key',
-      'https://flowline.pages.dev',
+      'https://flowline.six1.jp',
     )
 
     expect(mockFetch).toHaveBeenCalledWith(
@@ -66,7 +66,7 @@ describe('sendVerificationEmail', () => {
   it('should throw error when Resend API returns error', async () => {
     mockFetch.mockResolvedValue({ ok: false, status: 422, text: async () => 'Bad request' })
     await expect(
-      sendVerificationEmail('bad@example.com', 'token', 'key', 'https://flowline.pages.dev'),
+      sendVerificationEmail('bad@example.com', 'token', 'key', 'https://flowline.six1.jp'),
     ).rejects.toThrow()
   })
 
@@ -83,33 +83,33 @@ describe('sendVerificationEmail', () => {
       text: async () => 'Internal Server Error',
     })
     await expect(
-      sendVerificationEmail('test@example.com', 'token', 'key', 'https://flowline.pages.dev'),
+      sendVerificationEmail('test@example.com', 'token', 'key', 'https://flowline.six1.jp'),
     ).rejects.toThrow(/500/)
   })
 
   it('should throw error when Resend API returns 404', async () => {
     mockFetch.mockResolvedValue({ ok: false, status: 404, text: async () => 'Not Found' })
     await expect(
-      sendVerificationEmail('test@example.com', 'token', 'key', 'https://flowline.pages.dev'),
+      sendVerificationEmail('test@example.com', 'token', 'key', 'https://flowline.six1.jp'),
     ).rejects.toThrow()
   })
 
   it('should throw error when fetch rejects (network error)', async () => {
     mockFetch.mockRejectedValue(new Error('Network timeout'))
     await expect(
-      sendVerificationEmail('test@example.com', 'token', 'key', 'https://flowline.pages.dev'),
+      sendVerificationEmail('test@example.com', 'token', 'key', 'https://flowline.six1.jp'),
     ).rejects.toThrow('Network timeout')
   })
 
   it('should include from address in request body', async () => {
-    await sendVerificationEmail('test@example.com', 'token', 'key', 'https://flowline.pages.dev')
+    await sendVerificationEmail('test@example.com', 'token', 'key', 'https://flowline.six1.jp')
     const body = JSON.parse(mockFetch.mock.calls[0][1].body)
     expect(body.from).toBeDefined()
     expect(body.from).toContain('Flowline')
   })
 
   it('should send valid HTML content', async () => {
-    await sendVerificationEmail('user@test.com', 'tok', 'key', 'https://flowline.pages.dev')
+    await sendVerificationEmail('user@test.com', 'tok', 'key', 'https://flowline.six1.jp')
     const body = JSON.parse(mockFetch.mock.calls[0][1].body)
     expect(body.html).toContain('<!DOCTYPE html>')
     expect(body.html).toContain('</html>')

--- a/tests/api/lib/ogp.test.ts
+++ b/tests/api/lib/ogp.test.ts
@@ -135,7 +135,7 @@ describe('OGP Utility', () => {
       laneCount: 3,
       nodeCount: 10,
       shareToken: 'abc123',
-      baseUrl: 'https://flowline.pages.dev',
+      baseUrl: 'https://flowline.six1.jp',
     }
 
     it('should include correct og:title meta tag', () => {
@@ -156,7 +156,7 @@ describe('OGP Utility', () => {
     it('should include og:url with share token', () => {
       const html = generateOgpHtml(defaultParams)
       expect(html).toContain(
-        '<meta property="og:url" content="https://flowline.pages.dev/shared/abc123">',
+        '<meta property="og:url" content="https://flowline.six1.jp/shared/abc123">',
       )
     })
 
@@ -170,7 +170,7 @@ describe('OGP Utility', () => {
     it('should include dynamic og:image URL with share token', () => {
       const html = generateOgpHtml(defaultParams)
       expect(html).toContain(
-        '<meta property="og:image" content="https://flowline.pages.dev/api/ogp/share/abc123.png">',
+        '<meta property="og:image" content="https://flowline.six1.jp/api/ogp/share/abc123.png">',
       )
     })
 
@@ -210,7 +210,7 @@ describe('OGP Utility', () => {
     it('should include twitter:image', () => {
       const html = generateOgpHtml(defaultParams)
       expect(html).toContain(
-        '<meta name="twitter:image" content="https://flowline.pages.dev/api/ogp/share/abc123.png">',
+        '<meta name="twitter:image" content="https://flowline.six1.jp/api/ogp/share/abc123.png">',
       )
     })
 
@@ -247,8 +247,8 @@ describe('OGP Utility', () => {
         ...defaultParams,
         shareToken: 'xyz789',
       })
-      expect(html).toContain('https://flowline.pages.dev/shared/xyz789')
-      expect(html).toContain('https://flowline.pages.dev/api/ogp/share/xyz789.png')
+      expect(html).toContain('https://flowline.six1.jp/shared/xyz789')
+      expect(html).toContain('https://flowline.six1.jp/api/ogp/share/xyz789.png')
       expect(html).toContain("'/shared/xyz789'")
     })
 

--- a/tests/api/routes/ogp.test.ts
+++ b/tests/api/routes/ogp.test.ts
@@ -241,7 +241,7 @@ describe('OGP Image API', () => {
       expect(body).toHaveProperty('error')
     })
 
-    it('should use flowline.pages.dev as branding text in generated image', async () => {
+    it('should use flowline.six1.jp as branding text in generated image', async () => {
       const satori = await import('satori')
       insertFlowWithShareToken(db, 'flow-1', USER_ID, 'My Flow', 'brand-check')
 
@@ -271,7 +271,7 @@ describe('OGP Image API', () => {
       }
 
       const brandingText = findBrandingText(lastCall[0] as Record<string, never>)
-      expect(brandingText).toBe('flowline.pages.dev')
+      expect(brandingText).toBe('flowline.six1.jp')
     })
 
     it('should return 500 with error message when SVG generation (satori) fails', async () => {

--- a/tests/functions/middleware.test.ts
+++ b/tests/functions/middleware.test.ts
@@ -123,7 +123,7 @@ describe('Shared page middleware logic', () => {
       laneCount,
       nodeCount,
       shareToken: flow.share_token,
-      baseUrl: 'https://flowline.pages.dev',
+      baseUrl: 'https://flowline.six1.jp',
     })
 
     expect(html).toContain('受注管理フロー — Flowline')
@@ -175,7 +175,7 @@ describe('Shared page middleware logic', () => {
       laneCount,
       nodeCount,
       shareToken: flow.share_token,
-      baseUrl: 'https://flowline.pages.dev',
+      baseUrl: 'https://flowline.six1.jp',
     })
 
     expect(html).toContain('空のフロー — Flowline')
@@ -219,7 +219,7 @@ describe('Shared page middleware logic', () => {
       laneCount,
       nodeCount,
       shareToken: flow.share_token,
-      baseUrl: 'https://flowline.pages.dev',
+      baseUrl: 'https://flowline.six1.jp',
     })
 
     expect(html).toContain('ミニフロー — Flowline')
@@ -249,7 +249,7 @@ describe('Shared page middleware logic', () => {
       laneCount: 0,
       nodeCount: 0,
       shareToken: flow.share_token,
-      baseUrl: 'https://flowline.pages.dev',
+      baseUrl: 'https://flowline.six1.jp',
     })
 
     // User-supplied content should be escaped (not raw HTML injection)

--- a/tests/index-html.test.ts
+++ b/tests/index-html.test.ts
@@ -11,17 +11,17 @@ describe('index.html OGP meta tags', () => {
     expect(matches).toBeNull()
   })
 
-  it('should have og:url pointing to flowline.pages.dev', () => {
-    expect(html).toContain('content="https://flowline.pages.dev"')
+  it('should have og:url pointing to flowline.six1.jp', () => {
+    expect(html).toContain('content="https://flowline.six1.jp"')
   })
 
-  it('should have og:image pointing to flowline.pages.dev', () => {
-    expect(html).toContain('content="https://flowline.pages.dev/ogp/default.png"')
+  it('should have og:image pointing to flowline.six1.jp', () => {
+    expect(html).toContain('content="https://flowline.six1.jp/ogp/default.png"')
   })
 
-  it('should have twitter:image pointing to flowline.pages.dev', () => {
+  it('should have twitter:image pointing to flowline.six1.jp', () => {
     expect(html).toContain(
-      'name="twitter:image" content="https://flowline.pages.dev/ogp/default.png"',
+      'name="twitter:image" content="https://flowline.six1.jp/ogp/default.png"',
     )
   })
 })


### PR DESCRIPTION
## Summary
- OGPメタタグ・ブランディングテキストのドメインを `flowline.pages.dev` → `flowline.six1.jp` に変更
- メール送信元を `noreply@flowline.pages.dev` → `flowline@six1.jp` に変更（Resendドメイン認証対応）
- 関連テスト8ファイルを更新

## 変更ファイル
- `index.html` — OGP URL (og:url, og:image, twitter:image)
- `api/lib/email.ts` — from アドレス
- `api/routes/ogp.ts` — ブランディングテキスト
- テスト5ファイル — ドメイン参照を更新

## Test plan
- [x] 全778テスト通過確認
- [ ] Cloudflare Pagesにカスタムドメイン `flowline.six1.jp` を設定
- [ ] Resendで `six1.jp` ドメイン認証を設定
- [ ] デプロイ後にメール認証メールが届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)