### PR TITLE
feat: サイドバー「共有ファイル」で共有中フローを絞り込み #120

### DIFF
--- a/src/features/dashboard/Dashboard.test.tsx
+++ b/src/features/dashboard/Dashboard.test.tsx
@@ -962,12 +962,7 @@ describe('Dashboard', () => {
   describe('shared view (#120)', () => {
     it('should show only shared flows when shared nav is selected', async () => {
       mockApiFetch.mockResolvedValueOnce({ flows: mockFlows })
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>,
-      )
+      renderDashboard()
 
       await waitFor(() => {
         expect(screen.queryByTestId('dashboard-skeleton')).not.toBeInTheDocument()
@@ -984,12 +979,7 @@ describe('Dashboard', () => {
     it('should show shared empty state when no shared flows', async () => {
       const noSharedFlows = [{ ...mockFlows[1], shareToken: null }]
       mockApiFetch.mockResolvedValueOnce({ flows: noSharedFlows })
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>,
-      )
+      renderDashboard()
 
       await waitFor(() => {
         expect(screen.queryByTestId('dashboard-skeleton')).not.toBeInTheDocument()
@@ -1005,12 +995,7 @@ describe('Dashboard', () => {
 
     it('should show shared title when in shared view', async () => {
       mockApiFetch.mockResolvedValueOnce({ flows: mockFlows })
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>,
-      )
+      renderDashboard()
 
       await waitFor(() => {
         expect(screen.queryByTestId('dashboard-skeleton')).not.toBeInTheDocument()
@@ -1022,6 +1007,20 @@ describe('Dashboard', () => {
       await waitFor(() => {
         expect(screen.getByRole('heading', { name: '共有ファイル' })).toBeInTheDocument()
       })
+    })
+
+    it('should not show create card in shared grid view', async () => {
+      mockApiFetch.mockResolvedValueOnce({ flows: mockFlows })
+      renderDashboard()
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('dashboard-skeleton')).not.toBeInTheDocument()
+      })
+
+      const sharedNav = screen.getByTestId('nav-item-shared')
+      await userEvent.click(sharedNav)
+
+      expect(screen.queryByTestId('create-flow-card')).not.toBeInTheDocument()
     })
   })
 

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -430,8 +430,14 @@ export function Dashboard() {
                 selectedNav === 'shared' ? (
                   <div data-testid="shared-empty" className={styles.empty}>
                     <div className={styles.emptyIcon}>⊡</div>
-                    <p className={styles.emptyTitle}>共有中のフローはありません</p>
-                    <p className={styles.emptySubtitle}>フローを共有するとここに表示されます</p>
+                    <p className={styles.emptyTitle}>
+                      {searchQuery.trim()
+                        ? '検索条件に一致する共有フローがありません'
+                        : '共有中のフローはありません'}
+                    </p>
+                    {!searchQuery.trim() && (
+                      <p className={styles.emptySubtitle}>フローを共有するとここに表示されます</p>
+                    )}
                   </div>
                 ) : (
                   <div data-testid="dashboard-empty" className={styles.empty}>
@@ -464,17 +470,19 @@ export function Dashboard() {
                 )
               ) : viewMode === 'grid' ? (
                 <div data-testid="dashboard-grid" className={styles.grid}>
-                  <button
-                    data-testid="create-flow-card"
-                    onClick={handleCreate}
-                    disabled={creating}
-                    className={`${styles.createCard} ${creating ? styles.createCardDisabled : ''}`}
-                  >
-                    <CreateCardIcon />
-                    <span className={styles.createCardText}>
-                      {creating ? '作成中...' : '新規作成'}
-                    </span>
-                  </button>
+                  {selectedNav !== 'shared' && (
+                    <button
+                      data-testid="create-flow-card"
+                      onClick={handleCreate}
+                      disabled={creating}
+                      className={`${styles.createCard} ${creating ? styles.createCardDisabled : ''}`}
+                    >
+                      <CreateCardIcon />
+                      <span className={styles.createCardText}>
+                        {creating ? '作成中...' : '新規作成'}
+                      </span>
+                    </button>
+                  )}
                   {displayedFlows.map((flow) => (
                     <FlowCard
                       key={flow.id}


### PR DESCRIPTION
## Summary
- `displayedFlows` useMemoを追加し、`selectedNav === 'shared'`のとき`shareToken !== null`でフィルタリング
- タイトル分岐に「共有ファイル」を追加
- 共有フロー0件時の空状態メッセージ（`shared-empty`）を追加
- ソート・検索は共有ビューでも維持

Closes #120

## Test plan
- [x] 全783テストPASS（新規3件含む）
- [x] 共有フローのみ表示されることを確認
- [x] 共有フローがない場合の空状態表示を確認
- [x] タイトルが「共有ファイル」に変わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)