### PR TITLE
feat: MermaidエクスポートをsequenceDiagramからflowchartに変更 #123

### DIFF
--- a/src/features/editor/FlowEditor.test.tsx
+++ b/src/features/editor/FlowEditor.test.tsx
@@ -1208,3 +1208,219 @@ describe('editorSettings API sync (#89)', () => {
     })
   })
 })
+
+describe('Mermaid flowchart TD export (#mermaid)', () => {
+  beforeEach(() => {
+    cleanup()
+  })
+
+  /**
+   * Helper: mock navigator.clipboard.writeText and return spy.
+   * Each test sets up its own mock for independence.
+   */
+  const setupClipboardMock = () => {
+    const writeTextSpy = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: writeTextSpy },
+      writable: true,
+      configurable: true,
+    })
+    return writeTextSpy
+  }
+
+  /**
+   * Helper: click "Mermaid コードをコピー" button and return clipboard text.
+   * The button is in the right panel (default state, nothing selected).
+   */
+  const clickMermaidCopyButton = async (writeTextSpy: ReturnType<typeof vi.fn>) => {
+    const btns = screen.getAllByText('Mermaid コードをコピー')
+    await userEvent.click(btns[0])
+    await waitFor(() => {
+      expect(writeTextSpy).toHaveBeenCalled()
+    })
+    return writeTextSpy.mock.calls[0][0] as string
+  }
+
+  it('exportMermaid should output flowchart TD with subgraph per lane when flow has multiple lanes, nodes, and arrows', async () => {
+    const writeTextSpy = setupClipboardMock()
+    const flow: Flow = {
+      ...createMinimalFlow(),
+      lanes: [
+        { id: 'lane-1', name: '企画', colorIndex: 0, position: 0 },
+        { id: 'lane-2', name: '開発', colorIndex: 1, position: 1 },
+      ],
+      nodes: [
+        { id: 'n1', laneId: 'lane-1', rowIndex: 0, label: '要件定義', note: null, orderIndex: 0 },
+        { id: 'n2', laneId: 'lane-1', rowIndex: 1, label: '設計', note: null, orderIndex: 1 },
+        { id: 'n3', laneId: 'lane-2', rowIndex: 2, label: '実装', note: null, orderIndex: 2 },
+      ],
+      arrows: [
+        { id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: null },
+        { id: 'a2', fromNodeId: 'n2', toNodeId: 'n3', comment: null },
+      ],
+    }
+
+    render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+    const mermaid = await clickMermaidCopyButton(writeTextSpy)
+
+    // Should start with flowchart TD
+    expect(mermaid).toMatch(/^flowchart TD\n/)
+
+    // Should contain subgraph for each lane
+    expect(mermaid).toContain('subgraph 企画')
+    expect(mermaid).toContain('subgraph 開発')
+    expect(mermaid).toContain('end')
+
+    // Should contain node definitions with double-quoted labels in brackets
+    expect(mermaid).toMatch(/n1\["要件定義"\]/)
+    expect(mermaid).toMatch(/n2\["設計"\]/)
+    expect(mermaid).toMatch(/n3\["実装"\]/)
+
+    // Should contain arrow connections
+    expect(mermaid).toContain('n1 --> n2')
+    expect(mermaid).toContain('n2 --> n3')
+  })
+
+  it('exportMermaid should include isolated nodes inside subgraph when node has no arrows', async () => {
+    const writeTextSpy = setupClipboardMock()
+    const flow: Flow = {
+      ...createMinimalFlow(),
+      lanes: [{ id: 'lane-1', name: 'レーン1', colorIndex: 0, position: 0 }],
+      nodes: [
+        { id: 'n1', laneId: 'lane-1', rowIndex: 0, label: '孤立ノード', note: null, orderIndex: 0 },
+      ],
+      arrows: [],
+    }
+
+    render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+    const mermaid = await clickMermaidCopyButton(writeTextSpy)
+
+    // Should start with flowchart TD
+    expect(mermaid).toMatch(/^flowchart TD\n/)
+
+    // Isolated node should be inside subgraph
+    expect(mermaid).toContain('subgraph レーン1')
+    expect(mermaid).toMatch(/n1\["孤立ノード"\]/)
+
+    // No arrows in output
+    expect(mermaid).not.toContain('-->')
+  })
+
+  it('exportMermaid should escape double quotes in node labels as #quot;', async () => {
+    const writeTextSpy = setupClipboardMock()
+    const flow: Flow = {
+      ...createMinimalFlow(),
+      lanes: [{ id: 'lane-1', name: 'レーン1', colorIndex: 0, position: 0 }],
+      nodes: [
+        {
+          id: 'n1',
+          laneId: 'lane-1',
+          rowIndex: 0,
+          label: 'テスト"ラベル"です',
+          note: null,
+          orderIndex: 0,
+        },
+      ],
+      arrows: [],
+    }
+
+    render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+    const mermaid = await clickMermaidCopyButton(writeTextSpy)
+
+    // Double quotes in labels should be escaped as #quot; inside the quoted brackets
+    expect(mermaid).toContain('#quot;')
+    expect(mermaid).toMatch(/n1\["テスト#quot;ラベル#quot;です"\]/)
+  })
+
+  it('exportMermaid should output arrow comments with -->|comment| format', async () => {
+    const writeTextSpy = setupClipboardMock()
+    const flow: Flow = {
+      ...createMinimalFlow(),
+      lanes: [{ id: 'lane-1', name: 'レーン1', colorIndex: 0, position: 0 }],
+      nodes: [
+        { id: 'n1', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+        { id: 'n2', laneId: 'lane-1', rowIndex: 1, label: 'B', note: null, orderIndex: 1 },
+      ],
+      arrows: [{ id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: '承認後' }],
+    }
+
+    render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+    const mermaid = await clickMermaidCopyButton(writeTextSpy)
+
+    // Arrow with comment should use -->|comment| format
+    expect(mermaid).toContain('-->|承認後|')
+  })
+
+  it('exportMermaid should output only flowchart TD without error when flow has no nodes', async () => {
+    const writeTextSpy = setupClipboardMock()
+    const flow: Flow = {
+      ...createMinimalFlow(),
+      lanes: [{ id: 'lane-1', name: 'レーン1', colorIndex: 0, position: 0 }],
+      nodes: [],
+      arrows: [],
+    }
+
+    render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+    const mermaid = await clickMermaidCopyButton(writeTextSpy)
+
+    // Should start with flowchart TD
+    expect(mermaid).toMatch(/^flowchart TD\n/)
+
+    // Should not contain any arrow connections
+    expect(mermaid).not.toContain('-->')
+
+    // Should not throw error - the fact we get here means no error
+    expect(typeof mermaid).toBe('string')
+    expect(mermaid.length).toBeGreaterThan(0)
+  })
+
+  it('exportMermaid should escape brackets and pipe characters in labels', async () => {
+    const writeTextSpy = setupClipboardMock()
+    const flow: Flow = {
+      ...createMinimalFlow(),
+      lanes: [{ id: 'lane-1', name: 'レーン1', colorIndex: 0, position: 0 }],
+      nodes: [
+        {
+          id: 'n1',
+          laneId: 'lane-1',
+          rowIndex: 0,
+          label: 'テスト[注釈]',
+          note: null,
+          orderIndex: 0,
+        },
+      ],
+      arrows: [],
+    }
+
+    render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+    const mermaid = await clickMermaidCopyButton(writeTextSpy)
+
+    // Brackets should be escaped
+    expect(mermaid).toContain('#lsqb;')
+    expect(mermaid).toContain('#rsqb;')
+    expect(mermaid).not.toContain('[注釈]')
+  })
+
+  it('exportMermaid should escape pipe characters in arrow comments', async () => {
+    const writeTextSpy = setupClipboardMock()
+    const flow: Flow = {
+      ...createMinimalFlow(),
+      lanes: [
+        { id: 'lane-1', name: 'A', colorIndex: 0, position: 0 },
+        { id: 'lane-2', name: 'B', colorIndex: 1, position: 1 },
+      ],
+      nodes: [
+        { id: 'n1', laneId: 'lane-1', rowIndex: 0, label: 'ノード1', note: null, orderIndex: 0 },
+        { id: 'n2', laneId: 'lane-2', rowIndex: 1, label: 'ノード2', note: null, orderIndex: 1 },
+      ],
+      arrows: [{ id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: 'A|B選択' }],
+    }
+
+    render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+    const mermaid = await clickMermaidCopyButton(writeTextSpy)
+
+    // Pipe in comment should be escaped
+    expect(mermaid).toContain('#vert;')
+    expect(mermaid).toContain('A#vert;B選択')
+  })
+})

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -1021,32 +1021,67 @@ export default function FlowEditor({ flow, onSave, saveStatus, onShareChange }: 
   }
 
   const exportMermaid = (): string => {
-    let m = 'sequenceDiagram\n'
-    lanes.forEach((l) => {
-      m += `    participant ${l.name}\n`
-    })
-    m += '\n'
-    arrows.forEach((a) => {
-      const ft = tasks[a.from],
-        tt = tasks[a.to]
-      if (!ft || !tt) return
-      const fl = lanes.find((l) => l.id === ft.lid),
-        tl = lanes.find((l) => l.id === tt.lid)
-      if (!fl || !tl) return
-      if (fl.id === tl.id) m += `    Note over ${fl.name}: ${ft.label}\n`
-      else m += `    ${fl.name}->>${tl.name}: ${a.comment || ft.label}\n`
-    })
-    const used = new Set<string>()
-    arrows.forEach((a) => {
-      used.add(a.from)
-      used.add(a.to)
-    })
-    order.forEach((k) => {
-      if (!used.has(k) && tasks[k]) {
-        const l = lanes.find((x) => x.id === tasks[k].lid)
-        if (l) m += `    Note over ${l.name}: ${tasks[k].label}\n`
+    // Collect all task entries with their row index for sorting
+    const taskEntries: { key: string; task: TaskData; rowIdx: number }[] = []
+    for (const key of order) {
+      const t = tasks[key]
+      if (!t) continue
+      const ri = rows.findIndex((r) => r.id === t.rid)
+      taskEntries.push({ key, task: t, rowIdx: ri >= 0 ? ri : Infinity })
+    }
+    // Also include any tasks not in order
+    const includedKeys = new Set(taskEntries.map((e) => e.key))
+    Object.keys(tasks).forEach((key) => {
+      if (!includedKeys.has(key)) {
+        const t = tasks[key]
+        const ri = rows.findIndex((r) => r.id === t.rid)
+        taskEntries.push({ key, task: t, rowIdx: ri >= 0 ? ri : Infinity })
       }
     })
+    taskEntries.sort((a, b) => a.rowIdx - b.rowIdx)
+
+    // Assign sequential Mermaid-safe node IDs
+    const nodeIdMap = new Map<string, string>()
+    taskEntries.forEach((e, i) => {
+      nodeIdMap.set(e.key, `n${i + 1}`)
+    })
+
+    // Escape helper for Mermaid labels
+    const esc = (s: string): string =>
+      s
+        .replace(/"/g, '#quot;')
+        .replace(/\[/g, '#lsqb;')
+        .replace(/\]/g, '#rsqb;')
+        .replace(/\|/g, '#vert;')
+        .replace(/\n/g, ' ')
+
+    let m = 'flowchart TD\n'
+
+    // Group tasks by lane and output subgraphs
+    lanes.forEach((lane) => {
+      const laneTasks = taskEntries.filter((e) => e.task.lid === lane.id)
+      if (laneTasks.length === 0) return
+      m += `    subgraph ${esc(lane.name)}\n`
+      laneTasks.forEach((e) => {
+        const nid = nodeIdMap.get(e.key)!
+        m += `        ${nid}["${esc(e.task.label)}"]\n`
+      })
+      m += '    end\n'
+    })
+
+    // Output connections
+    m += '\n'
+    arrows.forEach((a) => {
+      const fromId = nodeIdMap.get(a.from)
+      const toId = nodeIdMap.get(a.to)
+      if (!fromId || !toId) return
+      if (a.comment) {
+        m += `    ${fromId} -->|${esc(a.comment)}| ${toId}\n`
+      } else {
+        m += `    ${fromId} --> ${toId}\n`
+      }
+    })
+
     return m
   }
 


### PR DESCRIPTION
## Summary
- `exportMermaid()` を `sequenceDiagram` 形式から `flowchart TD` 形式に変更
- `subgraph` でレーンをグループ化し、スイムレーン構造を正確に表現
- ノードを `rowIndex` 順にソートし、連番ID（`n1`, `n2`...）を割り当て
- Mermaid特殊文字（`"`, `[`, `]`, `|`, 改行）のエスケープ処理を実装
- 7件のMermaidエクスポートテストを追加（基本フロー、孤立ノード、特殊文字、コメント付き矢印、空フロー、角括弧エスケープ、パイプエスケープ）

## Test plan
- [x] 基本フロー（複数レーン、ノード、矢印）の出力確認
- [x] 孤立ノード（矢印なし）がsubgraph内に含まれることの確認
- [x] ダブルクォートが `#quot;` にエスケープされることの確認
- [x] コメント付き矢印が `-->|コメント|` 形式で出力されることの確認
- [x] 空フロー（ノードなし）でもエラーにならないことの確認
- [x] 角括弧・パイプ文字のエスケープ確認
- [x] Mermaid Live Editor での描画検証（mermaid.ink APIで確認済み）
- [x] 全テスト791件パス

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)