### PR TITLE
fix: deploy commit message to use SHA for Cloudflare API compatibility #128

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,4 +51,4 @@ jobs:
           wranglerVersion: '4'
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=flowline
+          command: pages deploy dist --project-name=flowline --commit-message="${{ github.sha }}"


### PR DESCRIPTION
## Summary
- `wrangler pages deploy` に `--commit-message` オプションを追加し、コミットSHAを明示指定
- 日本語コミットメッセージがCloudflare APIで `Invalid commit message` エラーを起こす問題を修正
- 直近4回のデプロイ失敗を解消

Closes #128

## Test plan
- [x] 全784テストPASS
- [ ] マージ後のデプロイが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)