### PR TITLE
feat: 認証メールをリッチなウェルカムメールに変更 #124

### DIFF
--- a/api/lib/email.ts
+++ b/api/lib/email.ts
@@ -46,7 +46,8 @@ function formatDateJa(): string {
   return `${jst.getFullYear()}年${jst.getMonth() + 1}月${jst.getDate()}日`
 }
 
-function buildEmailHtml(_email: string, verifyUrl: string): string {
+function buildEmailHtml(email: string, verifyUrl: string): string {
+  const safeEmail = escapeHtml(email)
   const safeVerifyUrl = escapeHtml(verifyUrl)
   return `<!DOCTYPE html>
 <html lang="ja" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
@@ -130,10 +131,11 @@ function buildEmailHtml(_email: string, verifyUrl: string): string {
           <h1 class="hero-title" style="margin:0 0 12px;font-size:30px;font-weight:800;color:#ffffff;line-height:1.25;letter-spacing:-0.03em;">
             ようこそ。<br>あなたのフロー、<br>お待ちしてました
           </h1>
-          <p style="margin:0;font-size:14px;color:rgba(255,255,255,0.8);line-height:1.6;font-weight:400;">
+          <p style="margin:0 0 12px;font-size:14px;color:rgba(255,255,255,0.8);line-height:1.6;font-weight:400;">
             アカウントの作成が完了しました。<br>
             さっそく業務フローを描きはじめましょう。
           </p>
+          <p style="margin:0;font-size:12px;color:rgba(255,255,255,0.55);font-weight:400;">${safeEmail}</p>
         </td></tr>
 
         <!-- Body -->

--- a/tests/api/lib/email.test.ts
+++ b/tests/api/lib/email.test.ts
@@ -166,7 +166,7 @@ describe('sendVerificationEmail', () => {
   it('should include footer with copyright and links', async () => {
     await sendVerificationEmail('test@example.com', 'token', 'key', 'https://flowline.six1.jp')
     const body = JSON.parse(mockFetch.mock.calls[0][1].body)
-    expect(body.html).toContain('© 2026 Flowline')
+    expect(body.html).toContain(`© ${new Date().getFullYear()} Flowline`)
     expect(body.html).toContain('ヘルプセンター')
     expect(body.html).toContain('プライバシー')
     expect(body.html).toContain('配信停止')


### PR DESCRIPTION
## Summary
- 認証メールのHTMLテンプレートを、参考デザインに基づくリッチなウェルカムメールに差し替え
- プリヘッダー、ヒーローセクション、豆知識、3ステップガイド、ショートカット一覧、フッターを含む本格的なメールデザイン
- `formatDateJa()` ヘルパーを追加し、ロゴバーに日本語形式の日付を表示

## Changes
- `api/lib/email.ts`: `buildEmailHtml()` 関数のテンプレートを完全に差し替え、`formatDateJa()` ヘルパーを追加
- `tests/api/lib/email.test.ts`: 8つの新テストを追加（プリヘッダー、ヒーロー、豆知識、3ステップ、ショートカット、CTA、日付、フッター）

## Test plan
- [x] 新規8テストが全てパス（Red -> Green確認済み）
- [x] 既存12テストが全てパス（回帰なし）
- [x] 全799テストがパス（`npm test`）
- [x] Prettier/ESLintチェック通過

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)