### PR TITLE
fix: メール認証後にrefreshAuthで認証状態を再取得 #130

### DIFF
--- a/src/features/auth/VerifyPage.test.tsx
+++ b/src/features/auth/VerifyPage.test.tsx
@@ -21,6 +21,12 @@ vi.mock('../../lib/api', () => ({
   apiFetch: (...args: unknown[]) => mockApiFetch(...args),
 }))
 
+// Mock useAuth
+const mockRefreshAuth = vi.fn()
+vi.mock('../../hooks/useAuth', () => ({
+  useAuth: () => ({ refreshAuth: mockRefreshAuth }),
+}))
+
 function renderWithRouter(initialEntries: string[] = ['/verify']) {
   return render(
     <MemoryRouter initialEntries={initialEntries}>
@@ -173,6 +179,19 @@ describe('VerifyPage', () => {
       expect(screen.getByText('メール認証が完了しました！')).toBeInTheDocument()
     })
     expect(screen.queryByText('トップに戻る')).not.toBeInTheDocument()
+  })
+
+  // --- refreshAuth ---
+  it('should call refreshAuth after successful verification', async () => {
+    mockRefreshAuth.mockResolvedValue(undefined)
+    mockApiFetch.mockResolvedValue({ verified: true })
+    renderWithRouter(['/verify?token=valid-token'])
+
+    await waitFor(() => {
+      expect(screen.getByText('メール認証が完了しました！')).toBeInTheDocument()
+    })
+
+    expect(mockRefreshAuth).toHaveBeenCalledTimes(1)
   })
 
   // --- チェックアイコン表示 ---

--- a/src/features/auth/VerifyPage.tsx
+++ b/src/features/auth/VerifyPage.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react'
 import { useSearchParams, useNavigate } from 'react-router-dom'
 import { apiFetch } from '../../lib/api'
+import { useAuth } from '../../hooks/useAuth'
 import styles from './VerifyPage.module.css'
 
 export function VerifyPage() {
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
+  const { refreshAuth } = useAuth()
   const token = searchParams.get('token')
   const [status, setStatus] = useState<'verifying' | 'success' | 'error'>(
     token ? 'verifying' : 'error',
@@ -16,15 +18,16 @@ export function VerifyPage() {
     if (!token) return
 
     apiFetch<{ verified: boolean }>(`/auth/verify?token=${token}`)
-      .then(() => {
+      .then(async () => {
         setStatus('success')
+        await refreshAuth()
         setTimeout(() => navigate('/flows', { replace: true }), 2000)
       })
       .catch((err) => {
         setStatus('error')
         setError(err instanceof Error ? err.message : '認証に失敗しました')
       })
-  }, [token, navigate])
+  }, [token, navigate, refreshAuth])
 
   return (
     <div className={styles.container}>

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -172,6 +172,28 @@ describe('useAuth', () => {
     expect(mockApiFetch).toHaveBeenCalledWith('/auth/logout', { method: 'POST' })
   })
 
+  it('refreshAuth should re-fetch /auth/me and update user', async () => {
+    // First call: checkAuth - no user
+    mockApiFetch.mockRejectedValueOnce(new Error('Unauthorized'))
+    // Second call: refreshAuth - user now exists (e.g. after verify set cookie)
+    const mockUser = { id: '1', email: 'test@example.com', name: 'Test User' }
+    mockApiFetch.mockResolvedValueOnce({ user: mockUser })
+
+    const { result } = renderHook(() => useAuth(), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+    expect(result.current.user).toBeNull()
+
+    await act(async () => {
+      await result.current.refreshAuth()
+    })
+
+    expect(result.current.user).toEqual(mockUser)
+    expect(mockApiFetch).toHaveBeenLastCalledWith('/auth/me')
+  })
+
   it('login should throw when API returns error', async () => {
     // First call: checkAuth
     mockApiFetch.mockRejectedValueOnce(new Error('Unauthorized'))

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -19,6 +19,7 @@ interface AuthContextValue {
   register: (email: string, password: string, name: string) => Promise<RegisterResult>
   resendVerification: (email: string) => Promise<void>
   logout: () => Promise<void>
+  refreshAuth: () => Promise<void>
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
@@ -76,7 +77,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   return (
-    <AuthContext value={{ user, loading, login, register, resendVerification, logout }}>
+    <AuthContext
+      value={{ user, loading, login, register, resendVerification, logout, refreshAuth: checkAuth }}
+    >
       {children}
     </AuthContext>
   )


### PR DESCRIPTION
## Summary
- `AuthContext`に`refreshAuth`（= `checkAuth`）を公開
- `VerifyPage`でverify API成功後に`refreshAuth()`を呼び、cookieセット後の認証状態を反映
- これにより`ProtectedRoute`が正しく`user`を認識し、ダッシュボードへの遷移が成功する

Closes #130

## Test plan
- [x] 全793テストPASS（新規2件含む）
- [x] `refreshAuth`が`/auth/me`を再呼び出しして`user`を更新することを確認
- [x] `VerifyPage`がverify成功後に`refreshAuth`を呼ぶことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)