### PR TITLE
feat: 設定ページヘッダー統一と自動保存 #136

### DIFF
--- a/src/features/settings/SettingsPage.module.css
+++ b/src/features/settings/SettingsPage.module.css
@@ -89,6 +89,12 @@
   margin-right: 8px;
 }
 
+.saveStatusError {
+  font-size: 12px;
+  color: #c62828;
+  margin-right: 8px;
+}
+
 /* Body */
 .body {
   display: flex;

--- a/src/features/settings/SettingsPage.test.tsx
+++ b/src/features/settings/SettingsPage.test.tsx
@@ -384,6 +384,39 @@ describe('SettingsPage', () => {
     )
   })
 
+  // === 自動保存: エラー時のtopbar表示 ===
+  it('should show error status in topbar when auto-save fails', async () => {
+    mockApiFetch.mockResolvedValueOnce(mockSettingsResponse)
+    renderSettingsPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('settings-content')).toBeInTheDocument()
+    })
+
+    mockApiFetch.mockClear()
+    mockApiFetch.mockRejectedValue(new Error('Network error'))
+
+    const user = userEvent.setup()
+    const editorNav = screen.getByTestId('nav-editor')
+    await user.click(editorNav)
+
+    await waitFor(() => {
+      const toggles = screen.getAllByRole('switch')
+      expect(toggles.length).toBeGreaterThan(0)
+    })
+
+    const firstToggle = screen.getAllByRole('switch')[0]
+    await user.click(firstToggle)
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('save-status-error')).toBeInTheDocument()
+        expect(screen.getByTestId('save-status-error')).toHaveTextContent('保存失敗')
+      },
+      { timeout: 3000 },
+    )
+  })
+
   // === UserMenuPanel: アバタークリックでメニュー表示 ===
   it('should open UserMenuPanel when avatar is clicked', async () => {
     mockApiFetch.mockResolvedValueOnce(mockSettingsResponse)
@@ -413,10 +446,8 @@ describe('SettingsPage', () => {
     expect(screen.getByTestId('settings-avatar')).toHaveAttribute('aria-label', 'メニュー')
   })
 
-  // === 空のユーザー名: フォールバック ===
-  it('should display U as fallback avatar initial when user name is empty', async () => {
-    // This tests the fallback behavior handled at JSX level
-    // We test it indirectly — the current mock has a name so it shows テ
+  // === アバターの頭文字表示 ===
+  it('should display first character of user name in avatar', async () => {
     mockApiFetch.mockResolvedValueOnce(mockSettingsResponse)
     renderSettingsPage()
 
@@ -424,7 +455,7 @@ describe('SettingsPage', () => {
       expect(screen.getByTestId('settings-avatar')).toBeInTheDocument()
     })
 
-    // With name 'テストユーザー', first char upper is 'テ'
+    // mockUser name is 'テストユーザー', first char upper is 'テ'
     expect(screen.getByTestId('settings-avatar')).toHaveTextContent('テ')
   })
 })

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -90,6 +90,7 @@ export function SettingsPage() {
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isInitialLoadRef = useRef(true)
+  const userNameRef = useRef(user?.name)
 
   const loadSettings = useCallback(async () => {
     try {
@@ -116,7 +117,11 @@ export function SettingsPage() {
         setProfileName(user.name)
         setProfileEmail(user.email)
       }
-      isInitialLoadRef.current = false
+      // Use setTimeout(0) to match success path — prevents auto-save from firing
+      // with DEFAULT_SETTINGS when initial load fails
+      setTimeout(() => {
+        isInitialLoadRef.current = false
+      }, 0)
     } finally {
       setLoading(false)
     }
@@ -125,6 +130,11 @@ export function SettingsPage() {
   useEffect(() => {
     loadSettings()
   }, [loadSettings])
+
+  // Keep userNameRef in sync with user.name
+  useEffect(() => {
+    userNameRef.current = user?.name
+  }, [user?.name])
 
   const toggle = (key: keyof Settings) => {
     setSettings((prev) => ({ ...prev, [key]: !prev[key] }))
@@ -148,7 +158,7 @@ export function SettingsPage() {
           method: 'PUT',
           body: JSON.stringify(settings),
         })
-        if (profileName !== user?.name) {
+        if (profileName !== userNameRef.current) {
           await apiFetch('/settings/profile', {
             method: 'PUT',
             body: JSON.stringify({ name: profileName }),
@@ -166,7 +176,7 @@ export function SettingsPage() {
     return () => {
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
     }
-  }, [settings, profileName, user?.name])
+  }, [settings, profileName])
 
   const handlePasswordChange = async (
     currentPassword: string,
@@ -254,6 +264,11 @@ export function SettingsPage() {
         {saveStatus === 'saved' && (
           <span className={styles.saveStatusDone} data-testid="save-status">
             &#10003; 保存済み
+          </span>
+        )}
+        {saveStatus === 'error' && (
+          <span className={styles.saveStatusError} data-testid="save-status-error">
+            保存失敗
           </span>
         )}
         <button


### PR DESCRIPTION
## Summary
- 設定ページのトップバーをダッシュボードと同じスタイル（Flowlineロゴ + アバター）に統一
- 手動保存ボタンを廃止し、800msデバウンスによる自動保存に置き換え
- UserMenuPanelを統合し、アバタークリックでアカウントメニューを表示
- 保存ステータスインジケーター（保存中.../保存済み/エラー）を追加

## Changes
- `SettingsPage.tsx`: ヘッダーJSXをロゴリンク+アバターに変更、`handleSave`を`useEffect`ベースの自動保存に置き換え、`UserMenuPanel`統合
- `SettingsPage.module.css`: 旧スタイル（backButton, saveButton, savedPop等）を削除し、新スタイル（logoLink, avatar, saveStatus等）を追加
- `SettingsPage.test.tsx`: 新ヘッダー・自動保存・UserMenuPanel統合のテスト21件（全パス）

## Test plan
- [x] 全809テストがパス（`npm test`）
- [x] Flowlineロゴがヘッダーに表示され、`/flows`にリンク
- [x] アバターがユーザー名の頭文字を表示
- [x] 手動保存ボタンが存在しない
- [x] トグル変更後800msで自動保存が発火
- [x] 保存ステータス表示（保存中/保存済み）
- [x] 保存失敗時にエラー表示
- [x] アバタークリックでUserMenuPanelが表示
- [ ] ブラウザでの目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)