### PR TITLE
fix: 矢印コメント吹き出しクリックで矢印が選択されるように修正 #154

### DIFF
--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -2715,7 +2715,15 @@ export default function FlowEditor({ flow, onSave, saveStatus, onShareChange }: 
                     style={{ pointerEvents: 'none' }}
                   />
                   {arrow.comment && (
-                    <g style={{ pointerEvents: 'none' }}>
+                    <g
+                      style={{ cursor: 'pointer' }}
+                      onClick={(e: React.MouseEvent) => {
+                        e.stopPropagation()
+                        setSelArrow(selArrow === arrow.id ? null : arrow.id)
+                        setSelTask(null)
+                        setSelLane(null)
+                      }}
+                    >
                       <rect
                         x={mx - Math.max(arrow.comment.length * 4, 14) - 12}
                         y={my - 22}


### PR DESCRIPTION
## Summary
- 矢印コメント（吹き出し）をクリックした際に、矢印が選択されるように修正
- 修正前: コメント吹き出しの `<g>` に `pointerEvents: 'none'` が設定されていたため、クリックが透過してキャンバスのノード作成処理が発火していた
- 修正後: `pointerEvents: 'none'` を削除し、`onClick` ハンドラと `cursor: 'pointer'` を追加

## Changes
- `src/features/editor/FlowEditor.tsx`: コメント吹き出しの `<g>` 要素に矢印選択ロジックを追加（既存の矢印ヒットエリアと同一のロジック）

## Test plan
- [x] 全894テストパス（`npm test`）
- [x] ブラウザ目視確認: コメント吹き出しクリックで矢印が選択される
- [x] ブラウザ目視確認: 新しいノードが作成されない
- [x] ブラウザ目視確認: フローティングコントロールが表示される
- [x] ブラウザ目視確認: `cursor: pointer` がホバー時に表示される

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)