### PR TITLE
fix: OGPデザイン崩れ修正（タイトル位置・幅・フェード削除）#165

### DIFF
--- a/tests/workers/ogp/index.test.ts
+++ b/tests/workers/ogp/index.test.ts
@@ -352,6 +352,96 @@ describe('OGP Worker', () => {
       expect(findAbsoluteTitle(lastCall[0] as Record<string, never>)).toBe(true)
     })
 
+    it('should position title overlay at top 128px to overlap swimlane preview', async () => {
+      const satori = await import('satori/standalone')
+      insertFlowWithShareToken(db, 'flow-1', USER_ID, 'My Flow', 'position-check')
+
+      await getRequest('/share/position-check.png', env)
+
+      const satoriMock = vi.mocked(satori.default)
+      const lastCall = satoriMock.mock.calls[satoriMock.mock.calls.length - 1]
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      function findTitleOverlayTop(node: Record<string, any>): string | number | null {
+        if (!node?.props) return null
+        const { style, children } = node.props
+        if (style?.position === 'absolute' && style?.zIndex >= 10) {
+          if (findText(node, 'My Flow')) return style.top
+        }
+        if (Array.isArray(children)) {
+          for (const child of children) {
+            const result = findTitleOverlayTop(child as Record<string, never>)
+            if (result !== null) return result
+          }
+        }
+        return null
+      }
+
+      const top = findTitleOverlayTop(lastCall[0] as Record<string, never>)
+      // Title overlay should be at top: 128 (body-relative) to overlap the swimlane preview
+      expect(top).toBe(128)
+    })
+
+    it('should use maxWidth on title overlay instead of fixed width', async () => {
+      const satori = await import('satori/standalone')
+      insertFlowWithShareToken(db, 'flow-1', USER_ID, 'My Flow', 'maxwidth-check')
+
+      await getRequest('/share/maxwidth-check.png', env)
+
+      const satoriMock = vi.mocked(satori.default)
+      const lastCall = satoriMock.mock.calls[satoriMock.mock.calls.length - 1]
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      function findTitleOverlayStyle(node: Record<string, any>): Record<string, any> | null {
+        if (!node?.props) return null
+        const { style, children } = node.props
+        if (style?.position === 'absolute' && style?.zIndex >= 10) {
+          if (findText(node, 'My Flow')) return style
+        }
+        if (Array.isArray(children)) {
+          for (const child of children) {
+            const result = findTitleOverlayStyle(child as Record<string, never>)
+            if (result !== null) return result
+          }
+        }
+        return null
+      }
+
+      const style = findTitleOverlayStyle(lastCall[0] as Record<string, never>)
+      expect(style).not.toBeNull()
+      expect(style!.maxWidth).toBeDefined()
+      expect(style!.width).toBeUndefined()
+    })
+
+    it('should not have bottom gradient fade in preview card', async () => {
+      const satori = await import('satori/standalone')
+      insertFlowWithShareToken(db, 'flow-1', USER_ID, 'My Flow', 'no-fade-check')
+
+      await getRequest('/share/no-fade-check.png', env)
+
+      const satoriMock = vi.mocked(satori.default)
+      const lastCall = satoriMock.mock.calls[satoriMock.mock.calls.length - 1]
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      function hasGradientFade(node: Record<string, any>): boolean {
+        if (!node?.props) return false
+        const { style, children } = node.props
+        if (
+          style?.background &&
+          typeof style.background === 'string' &&
+          style.background.includes('linear-gradient') &&
+          style.background.includes('#FFFFFF')
+        )
+          return true
+        if (Array.isArray(children)) {
+          return children.some((child: Record<string, never>) => hasGradientFade(child))
+        }
+        return false
+      }
+
+      expect(hasGradientFade(lastCall[0] as Record<string, never>)).toBe(false)
+    })
+
     it('should return 500 with error message when SVG generation (satori) fails', async () => {
       const satori = await import('satori/standalone')
       vi.mocked(satori.default).mockRejectedValueOnce(new Error('SVG generation failed'))

--- a/workers/ogp/src/index.ts
+++ b/workers/ogp/src/index.ts
@@ -241,20 +241,20 @@ function buildOgpElement(title: string, authorName: string) {
               position: 'relative',
             },
             children: [
-              // Title + Catchcopy overlay (absolute, spans both columns over swimlane)
-              // top: 180px = visually centered in body area (578px height - title block)
-              // width: 1000px = extends from left column across preview card for overlap effect
+              // Title + Catchcopy overlay (absolute, overlaps swimlane preview card)
+              // top: 128px positions title band to overlay the swimlane content area
+              // maxWidth: 1000px allows the band to shrink to fit content
               {
                 type: 'div',
                 props: {
                   style: {
                     position: 'absolute',
-                    top: '180px',
-                    left: '40px',
+                    top: 128,
+                    left: 40,
                     zIndex: 10,
                     display: 'flex',
                     flexDirection: 'column',
-                    width: '1000px',
+                    maxWidth: 1000,
                   },
                   children: [
                     // Title
@@ -552,20 +552,6 @@ function buildOgpElement(title: string, authorName: string) {
                               height: '100%',
                               style: {
                                 objectFit: 'cover',
-                              },
-                            },
-                          },
-                          // Bottom gradient fade
-                          {
-                            type: 'div',
-                            props: {
-                              style: {
-                                position: 'absolute',
-                                bottom: 0,
-                                left: 0,
-                                right: 0,
-                                height: '80px',
-                                background: 'linear-gradient(transparent, #FFFFFF)',
                               },
                             },
                           },


### PR DESCRIPTION
## Summary
- タイトルオーバーレイ位置を `top: 180px` → `top: 128px` に変更し、スイムレーンプレビューカードに正しく重なるように修正
- タイトルオーバーレイの `width: 1000px` → `maxWidth: 1000px` に変更し、コンテンツ幅に応じて縮小するように
- プレビューカード下部の白グラデーションフェードを削除（フェーディング行のopacity低下で十分）

## Test plan
- [x] 新規テスト3件追加: タイトル位置(128px)、maxWidth、グラデーションフェードなし
- [x] 既存テスト20件全パス
- [x] 全テストスイート1801件パス

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)