### PR TITLE
fix: 矢印コメント入力中のcellClickでノード追加を防止 #168

### DIFF
--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -908,6 +908,10 @@ export default function FlowEditor({ flow, onSave, saveStatus, onShareChange }: 
     if (ri === rows.length - 1) setRows((p) => [...p, { id: uid() }])
   }
   const cellClick = (lid: string, rid: string, _li: number, ri: number): void => {
+    if (editArrowComment) {
+      setEditArrowComment(null)
+      return
+    }
     const k = ky(lid, rid)
     if (connectFrom) {
       if (k !== connectFrom && tasks[k])


### PR DESCRIPTION
## Summary
- `cellClick` 関数の冒頭に `editArrowComment` ガードを追加
- 矢印コメントのインライン入力がアクティブな状態でキャンバスの空セルをクリックしても、ノードが作成されないようにした
- ガード発動時は `setEditArrowComment(null)` で入力欄を閉じて早期リターン

## Test plan
- [x] 902 tests all passing
- [x] ブラウザ目視確認: コメント入力中にセルクリック → ノードが作成されない
- [x] ブラウザ目視確認: コメント入力中でない場合 → 通常通りノード作成される

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)