### PR TITLE
fix: 共有ビューのグラデーション開始色を#fffに修正 #183

### DIFF
--- a/src/features/shared/SharedFlowViewer.module.css
+++ b/src/features/shared/SharedFlowViewer.module.css
@@ -132,7 +132,7 @@
 /* Hero title area */
 .titleHero {
   padding: 28px 28px 18px;
-  background: linear-gradient(180deg, var(--theme-canvas-bg) 0%, transparent 100%);
+  background: linear-gradient(180deg, var(--theme-hero-gradient) 0%, transparent 100%);
   margin: -40px -40px 0 -40px;
   position: relative;
   z-index: 1;

--- a/src/features/shared/SharedFlowViewer.test.tsx
+++ b/src/features/shared/SharedFlowViewer.test.tsx
@@ -137,4 +137,21 @@ describe('SharedFlowViewer', () => {
     expect(heroMatch).not.toBeNull()
     expect(heroMatch![0]).toMatch(/linear-gradient/)
   })
+
+  it('should use white gradient for light theme (not canvas-bg)', () => {
+    render(<SharedFlowViewer flow={mockFlow} />)
+    const root = screen.getByTestId('shared-flow-view')
+    const style = root.getAttribute('style') || ''
+    expect(style).toContain('--theme-hero-gradient')
+    expect(style).toContain('#fff')
+  })
+
+  it('should use dark gradient for midnight theme', () => {
+    const darkFlow = { ...mockFlow, themeId: 'midnight' }
+    render(<SharedFlowViewer flow={darkFlow} />)
+    const root = screen.getByTestId('shared-flow-view')
+    const style = root.getAttribute('style') || ''
+    expect(style).toContain('--theme-hero-gradient')
+    expect(style).not.toContain('#fff')
+  })
 })

--- a/src/features/shared/SharedFlowViewer.tsx
+++ b/src/features/shared/SharedFlowViewer.tsx
@@ -130,6 +130,7 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
           '--theme-status-bg': T.statusBg,
           '--theme-status-border': T.statusBorder,
           '--theme-status-text': T.statusText,
+          '--theme-hero-gradient': isDark ? T.canvasBg : '#fff',
         } as React.CSSProperties
       }
     >


### PR DESCRIPTION
## Summary
- グラデーション開始色を `var(--theme-canvas-bg)` から `#fff` に変更
- `var(--theme-canvas-bg)` はキャンバス背景と同一色のため、グラデーション効果が視覚的に見えなかった
- ライトテーマ: `#fff`（白→透明）、ダークテーマ: `canvasBg`色を使用する `--theme-hero-gradient` CSS変数を導入

## Test plan
- [x] ライトテーマ(cloud)で `--theme-hero-gradient` が `#fff` に設定されるテスト
- [x] ダークテーマ(midnight)で `--theme-hero-gradient` が `#fff` でないテスト
- [x] 全921テストPASS
- [x] ブラウザ目視確認: 白→透明グラデーションがドットグリッドに自然に溶け込む

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)