### PR TITLE
feat: 自動接続の候補をTailノードに限定 #188

### DIFF
--- a/src/features/editor/auto-connect.test.ts
+++ b/src/features/editor/auto-connect.test.ts
@@ -8,7 +8,7 @@ describe('findClosestUpstream', () => {
     const tasks: Record<string, { lid: string; rid: string }> = {
       l0_r0: { lid: 'l0', rid: 'r0' },
     }
-    const result = findClosestUpstream(tasks, rows, lanes, 1, 0)
+    const result = findClosestUpstream(tasks, rows, lanes, 1, 0, [])
     expect(result).toBe('l0_r0')
   })
 
@@ -19,7 +19,7 @@ describe('findClosestUpstream', () => {
       l0_r0: { lid: 'l0', rid: 'r0' },
       l0_r1: { lid: 'l0', rid: 'r1' },
     }
-    const result = findClosestUpstream(tasks, rows, lanes, 2, 0)
+    const result = findClosestUpstream(tasks, rows, lanes, 2, 0, [])
     expect(result).toBe('l0_r1')
   })
 
@@ -29,7 +29,7 @@ describe('findClosestUpstream', () => {
     const tasks: Record<string, { lid: string; rid: string }> = {
       l0_r0: { lid: 'l0', rid: 'r0' },
     }
-    const result = findClosestUpstream(tasks, rows, lanes, 0, 1)
+    const result = findClosestUpstream(tasks, rows, lanes, 0, 1, [])
     expect(result).toBe('l0_r0')
   })
 
@@ -39,7 +39,7 @@ describe('findClosestUpstream', () => {
     const tasks: Record<string, { lid: string; rid: string }> = {
       l0_r1: { lid: 'l0', rid: 'r1' },
     }
-    const result = findClosestUpstream(tasks, rows, lanes, 0, 0)
+    const result = findClosestUpstream(tasks, rows, lanes, 0, 0, [])
     expect(result).toBeNull()
   })
 
@@ -47,7 +47,7 @@ describe('findClosestUpstream', () => {
     const rows = [{ id: 'r0' }]
     const lanes = [{ id: 'l0' }]
     const tasks: Record<string, { lid: string; rid: string }> = {}
-    const result = findClosestUpstream(tasks, rows, lanes, 0, 0)
+    const result = findClosestUpstream(tasks, rows, lanes, 0, 0, [])
     expect(result).toBeNull()
   })
 
@@ -57,7 +57,7 @@ describe('findClosestUpstream', () => {
     const tasks: Record<string, { lid: string; rid: string }> = {
       l1_r0: { lid: 'l1', rid: 'r0' },
     }
-    const result = findClosestUpstream(tasks, rows, lanes, 0, 0)
+    const result = findClosestUpstream(tasks, rows, lanes, 0, 0, [])
     expect(result).toBeNull()
   })
 
@@ -68,8 +68,65 @@ describe('findClosestUpstream', () => {
       l0_r0: { lid: 'l0', rid: 'r0' },
       l1_r1: { lid: 'l1', rid: 'r1' },
     }
-    const result = findClosestUpstream(tasks, rows, lanes, 1, 2)
+    const result = findClosestUpstream(tasks, rows, lanes, 1, 2, [])
     expect(result).toBe('l1_r1')
+  })
+
+  it('should prefer tail node (no outgoing arrow) over mid-chain node', () => {
+    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }, { id: 'r3' }]
+    const lanes = [{ id: 'l0' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      A: { lid: 'l0', rid: 'r0' },
+      B: { lid: 'l0', rid: 'r1' },
+      C: { lid: 'l0', rid: 'r2' },
+    }
+    const arrows = [
+      { id: 'a1', from: 'A', to: 'B', comment: '' },
+      { id: 'a2', from: 'B', to: 'C', comment: '' },
+    ]
+    const result = findClosestUpstream(tasks, rows, lanes, 3, 0, arrows)
+    expect(result).toBe('C')
+  })
+
+  it('should prefer flow-connected tail over isolated tail', () => {
+    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      A: { lid: 'l0', rid: 'r0' },
+      B: { lid: 'l0', rid: 'r1' },
+      X: { lid: 'l1', rid: 'r1' },
+    }
+    const arrows = [{ id: 'a1', from: 'A', to: 'B', comment: '' }]
+    const result = findClosestUpstream(tasks, rows, lanes, 2, 0, arrows)
+    expect(result).toBe('B')
+  })
+
+  it('should fall back to isolated tails when no flow-connected tails exist', () => {
+    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+    const lanes = [{ id: 'l0' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      X: { lid: 'l0', rid: 'r0' },
+      Y: { lid: 'l0', rid: 'r1' },
+    }
+    const arrows: { id: string; from: string; to: string; comment: string }[] = []
+    const result = findClosestUpstream(tasks, rows, lanes, 2, 0, arrows)
+    expect(result).toBe('Y')
+  })
+
+  it('should return null when all upstream nodes have outgoing arrows', () => {
+    const rows = [{ id: 'r0' }, { id: 'r1' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      A: { lid: 'l0', rid: 'r0' },
+      B: { lid: 'l0', rid: 'r1' },
+      C: { lid: 'l1', rid: 'r1' },
+    }
+    const arrows = [
+      { id: 'a1', from: 'A', to: 'B', comment: '' },
+      { id: 'a2', from: 'A', to: 'C', comment: '' },
+    ]
+    const result = findClosestUpstream(tasks, rows, lanes, 0, 1, arrows)
+    expect(result).toBeNull()
   })
 })
 

--- a/src/features/editor/auto-connect.ts
+++ b/src/features/editor/auto-connect.ts
@@ -12,12 +12,26 @@ export function findClosestUpstream(
   lanes: { id: string }[],
   newRi: number,
   newLi: number,
+  arrows: { from: string; to: string }[],
 ): string | null {
+  // Build outgoing/incoming sets from arrows
+  const outgoing = new Set(arrows.map((a) => a.from))
+  const incoming = new Set(arrows.map((a) => a.to))
+
+  // Tail nodes: no outgoing arrows
+  const allKeys = Object.keys(tasks)
+  const tails = allKeys.filter((k) => !outgoing.has(k))
+
+  // Prefer flow-connected tails (have incoming), fall back to all tails
+  const flowTails = tails.filter((k) => incoming.has(k))
+  const candidates = flowTails.length > 0 ? flowTails : tails
+
   let bestKey: string | null = null
   let bestRi = -1
   let bestLi = -1
 
-  for (const [key, task] of Object.entries(tasks)) {
+  for (const key of candidates) {
+    const task = tasks[key]
     const tRi = rows.findIndex((r) => r.id === task.rid)
     const tLi = lanes.findIndex((l) => l.id === task.lid)
     if (tRi < 0 || tLi < 0) continue

--- a/src/features/editor/hooks/useArrows.ts
+++ b/src/features/editor/hooks/useArrows.ts
@@ -17,7 +17,7 @@ export function useArrows({ initialArrows, tasks, rows, lanes, autoConnect }: Us
 
   const autoConnectOnCreate = (taskKey: string, ri: number, li: number): void => {
     if (!autoConnect || Object.keys(tasks).length < 1) return
-    const bestKey = findClosestUpstream(tasks, rows, lanes, ri, li)
+    const bestKey = findClosestUpstream(tasks, rows, lanes, ri, li, arrows)
     if (bestKey) {
       setArrows((p) => [...p, { id: uid(), from: bestKey, to: taskKey, comment: '' }])
     }


### PR DESCRIPTION
## Summary
- `findClosestUpstream` に `arrows` 引数を追加し、Tail（末端）ノード優先ロジックを実装
- フロー参加中のTail（incoming矢印あり）を優先、孤立Tailにフォールバック
- 既存テスト7件更新 + 新規テスト4件追加（全16テスト通過）

## Test plan
- [x] Tailノードが中間ノードより優先されることを確認
- [x] フロー接続済みTailが孤立Tailより優先されることを確認
- [x] 矢印なし時に全ノードがfallback候補になることを確認
- [x] 上流にTailがない場合nullが返ることを確認
- [x] 全991テスト通過

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)