### PR TITLE
fix: 共有ビューのグラデーションがキャンバス幅に追従しない #191

### DIFF
--- a/src/features/shared/SharedFlowViewer.module.css
+++ b/src/features/shared/SharedFlowViewer.module.css
@@ -134,6 +134,7 @@
   padding: 28px 28px 18px;
   background: linear-gradient(180deg, var(--theme-hero-gradient) 0%, transparent 100%);
   margin: -40px -40px 0 -40px;
+  min-width: calc(100% + 80px);
   position: relative;
   z-index: 1;
 }


### PR DESCRIPTION
## Summary
- `.titleHero` に `min-width: calc(100% + 80px)` を追加
- スマホでキャンバスが横スクロール可能な場合も、グラデーションがスクロール幅全体をカバーする

## Test plan
- [x] 全999テスト通過
- [ ] ブラウザ目視: スマホサイズで共有ビューのグラデーションが右端まで届くこと

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)