### PR TITLE
fix: スマホ共有ビューでタイトルエリアのグラデーションがキャンバス幅に追従しない #191

### DIFF
--- a/src/features/shared/SharedFlowViewer.module.css
+++ b/src/features/shared/SharedFlowViewer.module.css
@@ -134,8 +134,9 @@
   padding: 28px 28px 18px;
   background: linear-gradient(180deg, var(--theme-hero-gradient) 0%, transparent 100%);
   margin: -40px -40px 0 -40px;
-  min-width: calc(100% + 80px);
-  position: relative;
+  padding-right: 40px;
+  position: sticky;
+  left: 0;
   z-index: 1;
 }
 
@@ -209,6 +210,7 @@
 @media (max-width: 640px) {
   .titleHero {
     padding: 16px 16px 12px;
+    padding-right: 40px;
   }
   .heroTitle {
     font-size: 22px;

--- a/src/features/shared/SharedFlowViewer.test.tsx
+++ b/src/features/shared/SharedFlowViewer.test.tsx
@@ -154,4 +154,12 @@ describe('SharedFlowViewer', () => {
     expect(style).toContain('--theme-hero-gradient')
     expect(style).not.toContain('#fff')
   })
+
+  it('should have position sticky and left 0 on titleHero for scroll-proof gradient', () => {
+    const css = readFileSync(resolve(__dirname, './SharedFlowViewer.module.css'), 'utf-8')
+    const heroMatch = css.match(/\.titleHero\s*\{[^}]*\}/s)
+    expect(heroMatch).not.toBeNull()
+    expect(heroMatch![0]).toMatch(/position:\s*sticky/)
+    expect(heroMatch![0]).toMatch(/left:\s*0/)
+  })
 })


### PR DESCRIPTION
## Summary
- `.titleHero` に `position: sticky; left: 0` を追加し、横スクロール時もグラデーションがビューポート全幅をカバーするよう修正
- `padding-right: 40px` を追加して右マージンの打ち消し分を補填
- モバイルメディアクエリでも `padding-right: 40px` を維持

## Changes
- `SharedFlowViewer.module.css`: `.titleHero` に `position: sticky`, `left: 0`, `padding-right: 40px` を追加。モバイルメディアクエリにも `padding-right: 40px` を追加
- `SharedFlowViewer.test.tsx`: `position: sticky` と `left: 0` の存在を確認するテストを追加

## Test plan
- [x] 新規テスト（position sticky + left 0 の確認）が通過
- [x] 全1000テストが通過
- [x] スマホ幅（375px）で横スクロール時にグラデーションが途切れないことを目視確認
- [x] デスクトップ幅（1280px）で既存レイアウトに影響がないことを確認

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)