### PR TITLE
feat: 行挿入ホバーゾーン拡大・空セル破線改善・空行削除 #192

### DIFF
--- a/src/features/editor/FlowEditor.test.tsx
+++ b/src/features/editor/FlowEditor.test.tsx
@@ -1131,6 +1131,81 @@ describe('row insertion UI (#91)', () => {
   })
 })
 
+describe('empty row deletion (#192)', () => {
+  beforeEach(() => {
+    cleanup()
+  })
+
+  it('should show trash icon on empty row hover', () => {
+    const flow = createMinimalFlow()
+    render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+    // All rows are empty in minimal flow, row 0 should show row number "1"
+    const rowLabel = document.querySelector('[data-testid="canvas-row-0"]')
+    expect(rowLabel).toBeTruthy()
+    expect(rowLabel!.textContent).toBe('1')
+    // Hover the row number hit rect
+    const hitRect = document.querySelector('[data-testid="rownum-hit-0"]')
+    expect(hitRect).toBeTruthy()
+    fireEvent.mouseEnter(hitRect!)
+    const updatedEl = document.querySelector('[data-testid="canvas-row-0"]')
+    // Trash icon is a <g> element (not <text>), indicating the icon changed
+    expect(updatedEl!.tagName.toLowerCase()).toBe('g')
+  })
+
+  it('should delete empty row when clicked', () => {
+    const flow = createMinimalFlow()
+    render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+    const initialRowCount = document.querySelectorAll('[data-testid^="canvas-row-"]').length
+    // Hover then click to delete
+    const hitRect = document.querySelector('[data-testid="rownum-hit-0"]')!
+    fireEvent.mouseEnter(hitRect)
+    fireEvent.click(hitRect)
+    const newRowCount = document.querySelectorAll('[data-testid^="canvas-row-"]').length
+    expect(newRowCount).toBe(initialRowCount - 1)
+  })
+
+  it('should not delete row with nodes', () => {
+    const flow: Flow = {
+      ...createMinimalFlow(),
+      nodes: [{ id: 'n1', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 }],
+    }
+    render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+    const initialRowCount = document.querySelectorAll('[data-testid^="canvas-row-"]').length
+    // Hover row 0 (has a node) — should stay as text
+    const hitRect = document.querySelector('[data-testid="rownum-hit-0"]')!
+    fireEvent.mouseEnter(hitRect)
+    const updatedEl = document.querySelector('[data-testid="canvas-row-0"]')
+    expect(updatedEl!.tagName.toLowerCase()).toBe('text')
+    // Click — row count should not change
+    fireEvent.click(hitRect)
+    const newRowCount = document.querySelectorAll('[data-testid^="canvas-row-"]').length
+    expect(newRowCount).toBe(initialRowCount)
+  })
+
+  it('should not delete the last remaining row', () => {
+    const flow = createMinimalFlow()
+    render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+    const initialRowCount = document.querySelectorAll('[data-testid^="canvas-row-"]').length
+    // Delete rows one by one until only 1 left
+    for (let i = 0; i < initialRowCount - 1; i++) {
+      const hitRect = document.querySelector('[data-testid="rownum-hit-0"]')!
+      fireEvent.mouseEnter(hitRect)
+      fireEvent.click(hitRect)
+    }
+    const afterDeleteCount = document.querySelectorAll('[data-testid^="canvas-row-"]').length
+    expect(afterDeleteCount).toBe(1)
+    // Try to delete the last row — should not work
+    const hitRect = document.querySelector('[data-testid="rownum-hit-0"]')!
+    fireEvent.mouseEnter(hitRect)
+    // Should show row number, not trash (canDelete is false)
+    const updatedEl = document.querySelector('[data-testid="canvas-row-0"]')
+    expect(updatedEl!.tagName.toLowerCase()).toBe('text')
+    fireEvent.click(hitRect)
+    const finalCount = document.querySelectorAll('[data-testid^="canvas-row-"]').length
+    expect(finalCount).toBe(1)
+  })
+})
+
 describe('lane gap UI header-only (#91)', () => {
   it('should render lane gap hit area with header-only height', () => {
     const flow = createMinimalFlow()

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -459,6 +459,7 @@ export default function FlowEditor({
   const [hovered, setHovered] = useState<string | null>(null)
   const [hoveredLaneGap, setHoveredLaneGap] = useState<number | null>(null)
   const [hoveredRowGap, setHoveredRowGap] = useState<number | null>(null)
+  const [hoveredRowNum, setHoveredRowNum] = useState<number | null>(null)
   const {
     toasts,
     addConfirmToast,
@@ -874,6 +875,14 @@ export default function FlowEditor({
     })
     setHoveredRowGap(null)
     setRecentInsertedRow({ rowId: newRowId })
+  }
+  const rmRowAt = (ri: number): void => {
+    if (rows.length <= 1) return
+    const row = rows[ri]
+    const hasNodes = Object.values(tasks).some((t) => t.rid === row.id)
+    if (hasNodes) return
+    setRows((p) => p.filter((_, i) => i !== ri))
+    setHoveredRowNum(null)
   }
   const cellFromPos = (sx: number, sy: number): CellInfo | null => {
     for (let li = 0; li < lanes.length; li++)
@@ -2373,74 +2382,64 @@ export default function FlowEditor({
               )
             })}
 
-            {rows.map((_, ri) => (
-              <text
-                key={ri}
-                data-testid={`canvas-row-${ri}`}
-                x={LM - 14}
-                y={TM + HH + ri * RH + RH / 2}
-                textAnchor="middle"
-                dominantBaseline="central"
-                fontSize={9}
-                fill={T.statusText}
-                fontWeight={500}
-              >
-                {ri + 1}
-              </text>
-            ))}
-
-            {/* Row gap "+" — left side, between rows and at the end */}
-            {Array.from({ length: rows.length + 1 }, (_, ri) => {
-              const gy = TM + HH + ri * RH
-              const gx = LM / 2
-              const isHov = hoveredRowGap === ri
+            {rows.map((row, ri) => {
+              const ry = TM + HH + ri * RH + RH / 2
+              const rx = LM / 2
+              const isEmptyRow = !Object.values(tasks).some((t) => t.rid === row.id)
+              const isHoveredRow = hoveredRowNum === ri
+              const canDelete = isEmptyRow && rows.length > 1
               return (
-                <g key={`rowgap-${ri}`}>
+                <g key={`rownum-${ri}`}>
                   <rect
-                    data-testid={`rowgap-hit-${ri}`}
+                    data-testid={`rownum-hit-${ri}`}
                     x={0}
-                    y={gy - 6}
+                    y={TM + HH + ri * RH}
                     width={LM}
-                    height={12}
+                    height={RH}
                     fill="transparent"
-                    style={{ cursor: 'pointer' }}
-                    onMouseEnter={() => setHoveredRowGap(ri)}
-                    onMouseLeave={() => setHoveredRowGap(null)}
-                    onClick={(e: React.MouseEvent) => {
-                      e.stopPropagation()
-                      insertRowAt(ri)
+                    style={{ cursor: canDelete ? 'pointer' : 'default' }}
+                    onMouseEnter={() => setHoveredRowNum(ri)}
+                    onMouseLeave={() => setHoveredRowNum(null)}
+                    onClick={() => {
+                      if (canDelete) rmRowAt(ri)
                     }}
                   />
-                  {isHov && (
-                    <g data-testid={`rowgap-feedback-${ri}`} style={{ pointerEvents: 'none' }}>
+                  {isHoveredRow && canDelete ? (
+                    <g data-testid={`canvas-row-${ri}`} style={{ pointerEvents: 'none' }}>
                       <line
-                        x1={LM}
-                        y1={gy}
-                        x2={laneX(lanes.length - 1) + LW}
-                        y2={gy}
-                        stroke={T.accent}
-                        strokeWidth={1.5}
-                        strokeDasharray="4,3"
-                        opacity={0.3}
+                        x1={rx - 4}
+                        y1={ry - 5}
+                        x2={rx + 4}
+                        y2={ry - 5}
+                        stroke={T.dangerColor}
+                        strokeWidth={1.2}
+                        strokeLinecap="round"
                       />
-                      <circle cx={gx} cy={gy} r={10} fill={T.accent} />
-                      <line
-                        x1={gx - 4}
-                        y1={gy}
-                        x2={gx + 4}
-                        y2={gy}
-                        stroke="#fff"
-                        strokeWidth={1.5}
-                      />
-                      <line
-                        x1={gx}
-                        y1={gy - 4}
-                        x2={gx}
-                        y2={gy + 4}
-                        stroke="#fff"
-                        strokeWidth={1.5}
+                      <rect
+                        x={rx - 3}
+                        y={ry - 4}
+                        width={6}
+                        height={8}
+                        rx={1}
+                        fill="none"
+                        stroke={T.dangerColor}
+                        strokeWidth={1.2}
                       />
                     </g>
+                  ) : (
+                    <text
+                      data-testid={`canvas-row-${ri}`}
+                      x={rx}
+                      y={ry}
+                      textAnchor="middle"
+                      dominantBaseline="central"
+                      fontSize={9}
+                      fill={T.statusText}
+                      fontWeight={500}
+                      style={{ pointerEvents: 'none' }}
+                    >
+                      {ri + 1}
+                    </text>
                   )}
                 </g>
               )
@@ -2497,9 +2496,9 @@ export default function FlowEditor({
                           rx={8}
                           fill="none"
                           stroke={p.dot}
-                          strokeWidth={0.8}
-                          strokeDasharray="3,3"
-                          opacity={0.25}
+                          strokeWidth={1.2}
+                          strokeDasharray="6,4"
+                          opacity={0.45}
                         />
                         <line
                           x1={c.x - 5}
@@ -2508,7 +2507,7 @@ export default function FlowEditor({
                           y2={c.y}
                           stroke={p.dot}
                           strokeWidth={1}
-                          opacity={0.3}
+                          opacity={0.5}
                         />
                         <line
                           x1={c.x}
@@ -2517,7 +2516,7 @@ export default function FlowEditor({
                           y2={c.y + 5}
                           stroke={p.dot}
                           strokeWidth={1}
-                          opacity={0.3}
+                          opacity={0.5}
                         />
                       </g>
                     )}
@@ -3088,6 +3087,63 @@ export default function FlowEditor({
                 />
               </g>
             )}
+
+            {/* Row gap "+" — full-width hit zone, rendered last for top z-order */}
+            {Array.from({ length: rows.length + 1 }, (_, ri) => {
+              const gy = TM + HH + ri * RH
+              const gx = LM / 2
+              const isHov = hoveredRowGap === ri
+              return (
+                <g key={`rowgap-${ri}`}>
+                  <rect
+                    data-testid={`rowgap-hit-${ri}`}
+                    x={0}
+                    y={gy - 10}
+                    width={laneX(lanes.length - 1) + LW}
+                    height={20}
+                    fill="transparent"
+                    style={{ cursor: 'pointer' }}
+                    onMouseEnter={() => setHoveredRowGap(ri)}
+                    onMouseLeave={() => setHoveredRowGap(null)}
+                    onClick={(e: React.MouseEvent) => {
+                      e.stopPropagation()
+                      insertRowAt(ri)
+                    }}
+                  />
+                  {isHov && (
+                    <g data-testid={`rowgap-feedback-${ri}`} style={{ pointerEvents: 'none' }}>
+                      <line
+                        x1={LM}
+                        y1={gy}
+                        x2={laneX(lanes.length - 1) + LW}
+                        y2={gy}
+                        stroke={T.accent}
+                        strokeWidth={1.5}
+                        strokeDasharray="4,3"
+                        opacity={0.3}
+                      />
+                      <circle cx={gx} cy={gy} r={10} fill={T.accent} />
+                      <line
+                        x1={gx - 4}
+                        y1={gy}
+                        x2={gx + 4}
+                        y2={gy}
+                        stroke="#fff"
+                        strokeWidth={1.5}
+                      />
+                      <line
+                        x1={gx}
+                        y1={gy - 4}
+                        x2={gx}
+                        y2={gy + 4}
+                        stroke="#fff"
+                        strokeWidth={1.5}
+                      />
+                    </g>
+                  )}
+                </g>
+              )
+            })}
           </svg>
         </div>
 


### PR DESCRIPTION
## Summary
- 行挿入ホバーゾーンを左端28px×12pxから全レーン幅×20pxに拡大し、SVG最後にレンダリングしてz-order確保
- 空セル破線の視認性を改善（strokeWidth 1.2, dasharray 6,4, opacity 0.45, +記号 opacity 0.5）
- 空行（ノードなし）の削除機能を追加：行番号エリアホバーでゴミ箱アイコン表示、行が2つ以上の場合のみ削除可能

## Test plan
- [x] 全1000テスト通過（67ファイル）
- [ ] 行間ホバーで全幅の破線ライン＋ピルボタン表示確認
- [ ] 空セル破線が以前より視認しやすくなっていること
- [ ] 空行の行番号エリアホバーでゴミ箱アイコン表示確認
- [ ] 空行クリックで行が削除されること
- [ ] ノードありの行では削除不可
- [ ] 最後の1行は削除不可

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)