### PR TITLE
fix: 行gapヒットゾーンのz-orderを修正し矢印操作UIのクリックを優先

### DIFF
--- a/src/features/editor/FlowEditor.test.tsx
+++ b/src/features/editor/FlowEditor.test.tsx
@@ -1968,3 +1968,73 @@ describe('arrow reorganization toast (#182)', () => {
     expect(container.querySelector('[data-testid="toast-confirm"]')).toBeNull()
   })
 })
+
+describe('z-order: arrow controls above row gap (#212)', () => {
+  it('should render arrow floating controls after row gap hit zones in SVG DOM order', () => {
+    const flow = createMinimalFlow()
+    flow.nodes = [
+      { id: 'n1', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+      { id: 'n2', laneId: 'lane-1', rowIndex: 1, label: 'B', note: null, orderIndex: 1 },
+    ]
+    flow.arrows = [{ id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: null }]
+    const { container } = render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+
+    // Click arrow to show floating controls
+    const arrowHit = container.querySelector('path[pointer-events="stroke"][stroke-width="20"]')
+    expect(arrowHit).toBeTruthy()
+    fireEvent.click(arrowHit!)
+
+    const controls = container.querySelector('[data-testid="arrow-floating-controls"]')
+    expect(controls).toBeTruthy()
+
+    // Check DOM order within the full container (jsdom doesn't fully parse SVG children via svg.querySelectorAll)
+    const allElements = Array.from(container.querySelectorAll('*'))
+
+    const rowGapIndices = allElements
+      .map((el, i) => (el.getAttribute('data-testid')?.startsWith('rowgap-hit-') ? i : -1))
+      .filter((i) => i !== -1)
+    expect(rowGapIndices.length).toBeGreaterThan(0)
+    const lastRowGapIndex = Math.max(...rowGapIndices)
+
+    const controlsIndex = allElements.findIndex(
+      (el) => el.getAttribute('data-testid') === 'arrow-floating-controls',
+    )
+    expect(controlsIndex).not.toBe(-1)
+
+    // Floating controls should come AFTER row gaps in DOM = higher z-order in SVG
+    expect(controlsIndex).toBeGreaterThan(lastRowGapIndex)
+  })
+
+  it('should render connection handles after row gap hit zones in SVG DOM order', () => {
+    const flow = createMinimalFlow()
+    flow.nodes = [
+      { id: 'n1', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+    ]
+    const { container } = render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+
+    // Click node rect to select it and show connection handles
+    const nodeRects = container.querySelectorAll('rect[rx="10"]')
+    const nodeRect = Array.from(nodeRects).find((r) => r.getAttribute('width') === '152')
+    expect(nodeRect).toBeTruthy()
+    fireEvent.click(nodeRect!)
+
+    const handles = container.querySelectorAll('[data-testid="connection-handle"]')
+    expect(handles.length).toBeGreaterThan(0)
+
+    // Check DOM order within the full container (jsdom doesn't fully parse SVG children via svg.querySelectorAll)
+    const allElements = Array.from(container.querySelectorAll('*'))
+
+    const rowGapIndices = allElements
+      .map((el, i) => (el.getAttribute('data-testid')?.startsWith('rowgap-hit-') ? i : -1))
+      .filter((i) => i !== -1)
+    expect(rowGapIndices.length).toBeGreaterThan(0)
+    const lastRowGapIndex = Math.max(...rowGapIndices)
+
+    const handleIndex = allElements.findIndex(
+      (el) => el.getAttribute('data-testid') === 'connection-handle',
+    )
+    expect(handleIndex).not.toBe(-1)
+
+    expect(handleIndex).toBeGreaterThan(lastRowGapIndex)
+  })
+})

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -3032,6 +3032,63 @@ export default function FlowEditor({
               />
             ))}
 
+            {/* Row gap "+" — full-width hit zone, rendered before floating controls so controls have higher z-order */}
+            {Array.from({ length: rows.length + 1 }, (_, ri) => {
+              const gy = TM + HH + ri * RH
+              const gx = LM / 2
+              const isHov = hoveredRowGap === ri
+              return (
+                <g key={`rowgap-${ri}`}>
+                  <rect
+                    data-testid={`rowgap-hit-${ri}`}
+                    x={0}
+                    y={gy - 10}
+                    width={laneX(lanes.length - 1) + LW}
+                    height={20}
+                    fill="transparent"
+                    style={{ cursor: 'pointer' }}
+                    onMouseEnter={() => setHoveredRowGap(ri)}
+                    onMouseLeave={() => setHoveredRowGap(null)}
+                    onClick={(e: React.MouseEvent) => {
+                      e.stopPropagation()
+                      insertRowAt(ri)
+                    }}
+                  />
+                  {isHov && (
+                    <g data-testid={`rowgap-feedback-${ri}`} style={{ pointerEvents: 'none' }}>
+                      <line
+                        x1={LM}
+                        y1={gy}
+                        x2={laneX(lanes.length - 1) + LW}
+                        y2={gy}
+                        stroke={T.accent}
+                        strokeWidth={1.5}
+                        strokeDasharray="4,3"
+                        opacity={0.3}
+                      />
+                      <circle cx={gx} cy={gy} r={10} fill={T.accent} />
+                      <line
+                        x1={gx - 4}
+                        y1={gy}
+                        x2={gx + 4}
+                        y2={gy}
+                        stroke="#fff"
+                        strokeWidth={1.5}
+                      />
+                      <line
+                        x1={gx}
+                        y1={gy - 4}
+                        x2={gx}
+                        y2={gy + 4}
+                        stroke="#fff"
+                        strokeWidth={1.5}
+                      />
+                    </g>
+                  )}
+                </g>
+              )
+            })}
+
             {/* Floating arrow controls */}
             {selArrow &&
               (() => {
@@ -3394,63 +3451,6 @@ export default function FlowEditor({
                 }
                 return null
               })()}
-
-            {/* Row gap "+" — full-width hit zone, rendered last for top z-order */}
-            {Array.from({ length: rows.length + 1 }, (_, ri) => {
-              const gy = TM + HH + ri * RH
-              const gx = LM / 2
-              const isHov = hoveredRowGap === ri
-              return (
-                <g key={`rowgap-${ri}`}>
-                  <rect
-                    data-testid={`rowgap-hit-${ri}`}
-                    x={0}
-                    y={gy - 10}
-                    width={laneX(lanes.length - 1) + LW}
-                    height={20}
-                    fill="transparent"
-                    style={{ cursor: 'pointer' }}
-                    onMouseEnter={() => setHoveredRowGap(ri)}
-                    onMouseLeave={() => setHoveredRowGap(null)}
-                    onClick={(e: React.MouseEvent) => {
-                      e.stopPropagation()
-                      insertRowAt(ri)
-                    }}
-                  />
-                  {isHov && (
-                    <g data-testid={`rowgap-feedback-${ri}`} style={{ pointerEvents: 'none' }}>
-                      <line
-                        x1={LM}
-                        y1={gy}
-                        x2={laneX(lanes.length - 1) + LW}
-                        y2={gy}
-                        stroke={T.accent}
-                        strokeWidth={1.5}
-                        strokeDasharray="4,3"
-                        opacity={0.3}
-                      />
-                      <circle cx={gx} cy={gy} r={10} fill={T.accent} />
-                      <line
-                        x1={gx - 4}
-                        y1={gy}
-                        x2={gx + 4}
-                        y2={gy}
-                        stroke="#fff"
-                        strokeWidth={1.5}
-                      />
-                      <line
-                        x1={gx}
-                        y1={gy - 4}
-                        x2={gx}
-                        y2={gy + 4}
-                        stroke="#fff"
-                        strokeWidth={1.5}
-                      />
-                    </g>
-                  )}
-                </g>
-              )
-            })}
           </svg>
         </div>
 


### PR DESCRIPTION
## Summary
- 行gap "+" ヒットゾーンがSVG最後に描画され矢印操作UI（フローティングコントロール・接続ハンドル）のクリックを奪っていた問題を修正
- 行gapブロックを矢印ヒットパスの直後に移動し、操作UIが上位z-orderになるよう描画順を変更
- z-orderを検証するテスト2件を追加

## Test plan
- [x] z-orderテスト: 矢印フローティングコントロールが行gapより後にDOMに存在することを検証
- [x] z-orderテスト: 接続ハンドルが行gapより後にDOMに存在することを検証
- [x] 全1074テストがpass

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)