### PR TITLE
fix: 行gapを矢印ヒットパスより前に描画し矢印クリックを優先

### DIFF
--- a/src/features/editor/FlowEditor.test.tsx
+++ b/src/features/editor/FlowEditor.test.tsx
@@ -1970,6 +1970,36 @@ describe('arrow reorganization toast (#182)', () => {
 })
 
 describe('z-order: arrow controls above row gap (#212)', () => {
+  it('should render arrow hit paths after row gap hit zones in SVG DOM order', () => {
+    const flow = createMinimalFlow()
+    flow.nodes = [
+      { id: 'n1', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+      { id: 'n2', laneId: 'lane-1', rowIndex: 1, label: 'B', note: null, orderIndex: 1 },
+    ]
+    flow.arrows = [{ id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: null }]
+    const { container } = render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+
+    const allElements = Array.from(container.querySelectorAll('*'))
+
+    const rowGapIndices = allElements
+      .map((el, i) => (el.getAttribute('data-testid')?.startsWith('rowgap-hit-') ? i : -1))
+      .filter((i) => i !== -1)
+    expect(rowGapIndices.length).toBeGreaterThan(0)
+    const lastRowGapIndex = Math.max(...rowGapIndices)
+
+    // Arrow hit path: transparent stroke-width=20 path
+    const arrowHitIndex = allElements.findIndex(
+      (el) =>
+        el.tagName === 'path' &&
+        el.getAttribute('pointer-events') === 'stroke' &&
+        el.getAttribute('stroke-width') === '20',
+    )
+    expect(arrowHitIndex).not.toBe(-1)
+
+    // Arrow hit paths should come AFTER row gaps = higher z-order, so arrow clicks win
+    expect(arrowHitIndex).toBeGreaterThan(lastRowGapIndex)
+  })
+
   it('should render arrow floating controls after row gap hit zones in SVG DOM order', () => {
     const flow = createMinimalFlow()
     flow.nodes = [

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -3024,25 +3024,7 @@ export default function FlowEditor({
                 </g>
               )
             })}
-            {arrowPaths.map(({ arrow, path }) => (
-              <path
-                key={`ah-${arrow.id}`}
-                d={path.d}
-                stroke="rgba(0,0,0,0)"
-                strokeWidth={20}
-                fill="none"
-                pointerEvents="stroke"
-                style={{ cursor: 'pointer' }}
-                onClick={(e: React.MouseEvent) => {
-                  e.stopPropagation()
-                  setSelArrow(selArrow === arrow.id ? null : arrow.id)
-                  setSelTask(null)
-                  setSelLane(null)
-                }}
-              />
-            ))}
-
-            {/* Row gap "+" — full-width hit zone, rendered before floating controls so controls have higher z-order */}
+            {/* Row gap "+" — full-width hit zone, rendered before arrow hit paths so arrows and controls have higher z-order */}
             {Array.from({ length: rows.length + 1 }, (_, ri) => {
               const gy = TM + HH + ri * RH
               const gx = LM / 2
@@ -3098,6 +3080,24 @@ export default function FlowEditor({
                 </g>
               )
             })}
+
+            {arrowPaths.map(({ arrow, path }) => (
+              <path
+                key={`ah-${arrow.id}`}
+                d={path.d}
+                stroke="rgba(0,0,0,0)"
+                strokeWidth={20}
+                fill="none"
+                pointerEvents="stroke"
+                style={{ cursor: 'pointer' }}
+                onClick={(e: React.MouseEvent) => {
+                  e.stopPropagation()
+                  setSelArrow(selArrow === arrow.id ? null : arrow.id)
+                  setSelTask(null)
+                  setSelLane(null)
+                }}
+              />
+            ))}
 
             {/* Floating arrow controls */}
             {selArrow &&


### PR DESCRIPTION
## Summary
- #213 の修正で行gapを矢印ヒットパスの後に配置したため、矢印クリック時にも行追加が発火するリグレッションがあった
- 行gapを矢印ビジュアルパスの後・矢印ヒットパスの前に移動し、矢印・コントロール・接続ハンドル全てが行gapより上のz-orderになるよう修正
- 矢印ヒットパスのz-order検証テスト1件を追加（計3件）

## 修正後のSVG描画順
```
矢印ビジュアルパス → 行gap "+" → 矢印ヒットパス → コントロール → 接続ハンドル
```

## Test plan
- [x] 矢印ヒットパスが行gapより後にDOMに存在することを検証
- [x] 矢印フローティングコントロールが行gapより後にDOMに存在することを検証
- [x] 接続ハンドルが行gapより後にDOMに存在することを検証
- [x] 全1075テストがpass

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)