### PR TITLE
fix: 行gapヒットゾーンを左マージンに限定し矢印クリックとの干渉を解消

### DIFF
--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -3024,18 +3024,19 @@ export default function FlowEditor({
                 </g>
               )
             })}
-            {/* Row gap "+" — full-width hit zone, rendered before arrow hit paths so arrows and controls have higher z-order */}
+            {/* Row gap "+" — split into clickable left-margin zone + hover-only body zone so arrows are not blocked */}
             {Array.from({ length: rows.length + 1 }, (_, ri) => {
               const gy = TM + HH + ri * RH
               const gx = LM / 2
               const isHov = hoveredRowGap === ri
               return (
                 <g key={`rowgap-${ri}`}>
+                  {/* Clickable hit zone limited to left margin where "+" icon appears */}
                   <rect
                     data-testid={`rowgap-hit-${ri}`}
                     x={0}
                     y={gy - 10}
-                    width={laneX(lanes.length - 1) + LW}
+                    width={LM}
                     height={20}
                     fill="transparent"
                     style={{ cursor: 'pointer' }}
@@ -3045,6 +3046,17 @@ export default function FlowEditor({
                       e.stopPropagation()
                       insertRowAt(ri)
                     }}
+                  />
+                  {/* Hover-detection zone across body (no click handler — arrows keep priority) */}
+                  <rect
+                    x={LM}
+                    y={gy - 10}
+                    width={laneX(lanes.length - 1) + LW - LM}
+                    height={20}
+                    fill="transparent"
+                    style={{ pointerEvents: 'auto' }}
+                    onMouseEnter={() => setHoveredRowGap(ri)}
+                    onMouseLeave={() => setHoveredRowGap(null)}
                   />
                   {isHov && (
                     <g data-testid={`rowgap-feedback-${ri}`} style={{ pointerEvents: 'none' }}>


### PR DESCRIPTION
## Summary
- 行gapの全幅ヒットゾーンを2分割:
  - 左マージン領域（`width=LM`）: クリック+ホバー → 行追加可能
  - ボディ領域: ホバー検知のみ（`onClick`なし） → 矢印クリックを妨害しない
- ホバー時のフィードバック表示（ダッシュ線・+アイコン）は従来通り全幅で表示

## 問題の原因
行gapヒットゾーンが全幅20px高の透明rectで、矢印ヒットパス（`pointerEvents="stroke"`）のカバー外領域でクリックを奪っていた

## Test plan
- [x] 全1088テストpass
- [ ] ブラウザ検証: 矢印の上をクリックで矢印選択できること
- [ ] ブラウザ検証: 左端の+エリアをクリックで行追加できること
- [ ] ブラウザ検証: 行境界ホバーでフィードバック表示されること

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)