### PR TITLE
fix(#239): change demo editor initial lanes from 2 to 4

### DIFF
--- a/src/features/editor/hooks/useDemoFlow.test.ts
+++ b/src/features/editor/hooks/useDemoFlow.test.ts
@@ -16,12 +16,14 @@ describe('useDemoFlow', () => {
   // =============================================
 
   describe('initial state', () => {
-    it('should return a flow with default 2 lanes', () => {
+    it('should return a flow with default 4 lanes', () => {
       const { result } = renderHook(() => useDemoFlow())
       expect(result.current.flow).not.toBeNull()
-      expect(result.current.flow.lanes).toHaveLength(2)
-      expect(result.current.flow.lanes[0].name).toBe('レーン1')
-      expect(result.current.flow.lanes[1].name).toBe('レーン2')
+      expect(result.current.flow.lanes).toHaveLength(4)
+      expect(result.current.flow.lanes[0].name).toBe('lane1')
+      expect(result.current.flow.lanes[1].name).toBe('lane2')
+      expect(result.current.flow.lanes[2].name).toBe('lane3')
+      expect(result.current.flow.lanes[3].name).toBe('lane4')
     })
 
     it('should return empty nodes and arrows', () => {
@@ -103,12 +105,15 @@ describe('useDemoFlow', () => {
       const lanes = result.current.flow.lanes
       expect(lanes[0].position).toBe(0)
       expect(lanes[1].position).toBe(1)
+      expect(lanes[2].position).toBe(2)
+      expect(lanes[3].position).toBe(3)
     })
 
-    it('should have lanes with different colorIndex values', () => {
+    it('should have lanes with unique colorIndex values', () => {
       const { result } = renderHook(() => useDemoFlow())
       const lanes = result.current.flow.lanes
-      expect(lanes[0].colorIndex).not.toBe(lanes[1].colorIndex)
+      const colorIndices = lanes.map((l) => l.colorIndex)
+      expect(new Set(colorIndices).size).toBe(colorIndices.length)
     })
   })
 

--- a/src/features/editor/hooks/useDemoFlow.ts
+++ b/src/features/editor/hooks/useDemoFlow.ts
@@ -9,8 +9,10 @@ const DEMO_FLOW: Flow = {
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-01T00:00:00Z',
   lanes: [
-    { id: 'lane-1', name: 'レーン1', colorIndex: 0, position: 0 },
-    { id: 'lane-2', name: 'レーン2', colorIndex: 1, position: 1 },
+    { id: 'lane-1', name: 'lane1', colorIndex: 0, position: 0 },
+    { id: 'lane-2', name: 'lane2', colorIndex: 1, position: 1 },
+    { id: 'lane-3', name: 'lane3', colorIndex: 2, position: 2 },
+    { id: 'lane-4', name: 'lane4', colorIndex: 3, position: 3 },
   ],
   nodes: [],
   arrows: [],


### PR DESCRIPTION
## Summary

- デモエディタ（/try）の初期レーン数を2→4に変更し、ログイン後の新規フロー作成と統一
- レーン名をDEFAULT_LANESと同じ 'lane1'〜'lane4' に変更

## Test plan

- [x] useDemoFlow.test.ts のレーン数・名前・位置アサーション更新
- [x] 全1186テストPASS

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)