### PR TITLE
fix(#241): 自動接続で isolated tail にフォールバック

### DIFF
--- a/src/features/editor/auto-connect.test.ts
+++ b/src/features/editor/auto-connect.test.ts
@@ -128,6 +128,26 @@ describe('findClosestUpstream', () => {
     const result = findClosestUpstream(tasks, rows, lanes, 0, 1, arrows)
     expect(result).toBeNull()
   })
+
+  it('should fall back to isolated tail when flow-connected tails are all downstream (#241)', () => {
+    // lane2: 1→2→3 (row0→row1→row2), lane3: 4 (row0), new node 5 at lane3 row1
+    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      N1: { lid: 'l0', rid: 'r0' },
+      N2: { lid: 'l0', rid: 'r1' },
+      N3: { lid: 'l0', rid: 'r2' },
+      N4: { lid: 'l1', rid: 'r0' },
+    }
+    const arrows = [
+      { id: 'a1', from: 'N1', to: 'N2', comment: '' },
+      { id: 'a2', from: 'N2', to: 'N3', comment: '' },
+    ]
+    // Adding node 5 at lane3(l1) row1(r1) — N4 is isolated tail at row0, upstream
+    // N3 is flow-connected tail at row2, but downstream (row2 > row1)
+    const result = findClosestUpstream(tasks, rows, lanes, 1, 1, arrows)
+    expect(result).toBe('N4')
+  })
 })
 
 describe('findCrossingArrows', () => {

--- a/src/features/editor/auto-connect.ts
+++ b/src/features/editor/auto-connect.ts
@@ -24,31 +24,38 @@ export function findClosestUpstream(
 
   // Prefer flow-connected tails (have incoming), fall back to all tails
   const flowTails = tails.filter((k) => incoming.has(k))
-  const candidates = flowTails.length > 0 ? flowTails : tails
 
-  let bestKey: string | null = null
-  let bestRi = -1
-  let bestLi = -1
+  const findBest = (candidates: string[]): string | null => {
+    let bestKey: string | null = null
+    let bestRi = -1
+    let bestLi = -1
 
-  for (const key of candidates) {
-    const task = tasks[key]
-    const tRi = rows.findIndex((r) => r.id === task.rid)
-    const tLi = lanes.findIndex((l) => l.id === task.lid)
-    if (tRi < 0 || tLi < 0) continue
+    for (const key of candidates) {
+      const task = tasks[key]
+      const tRi = rows.findIndex((r) => r.id === task.rid)
+      const tLi = lanes.findIndex((l) => l.id === task.lid)
+      if (tRi < 0 || tLi < 0) continue
 
-    // Must be upstream: higher row, or same row with left lane
-    if (tRi > newRi) continue
-    if (tRi === newRi && tLi >= newLi) continue
+      // Must be upstream: higher row, or same row with left lane
+      if (tRi > newRi) continue
+      if (tRi === newRi && tLi >= newLi) continue
 
-    // Pick closest: maximize row index, then lane index
-    if (tRi > bestRi || (tRi === bestRi && tLi > bestLi)) {
-      bestKey = key
-      bestRi = tRi
-      bestLi = tLi
+      // Pick closest: maximize row index, then lane index
+      if (tRi > bestRi || (tRi === bestRi && tLi > bestLi)) {
+        bestKey = key
+        bestRi = tRi
+        bestLi = tLi
+      }
     }
+
+    return bestKey
   }
 
-  return bestKey
+  // Try flow-connected tails first, fall back to all tails
+  const result = flowTails.length > 0 ? findBest(flowTails) : null
+  if (result) return result
+
+  return findBest(tails)
 }
 
 /**


### PR DESCRIPTION
## Summary

- `findClosestUpstream` で flow-connected tails が全て downstream の場合、isolated tail が候補から除外されていた問題を修正
- 探索ロジックを `findBest` ヘルパーに抽出し、flowTails → 全tails の2段階探索を実装
- Issue #241 の再現テストケースを追加

## Test plan

- [x] 新規テスト: flow-connected tails が全て downstream 時に isolated tail にフォールバック（#241再現）
- [x] 既存テスト: flow-connected tail 優先動作が維持されていることを確認
- [x] 全テストスイート通過（75ファイル, 1190テスト）

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)