### PR TITLE
feat(#251): AI生成モデルをフロー複雑度に応じて動的切り替え

### DIFF
--- a/api/routes/ai.ts
+++ b/api/routes/ai.ts
@@ -14,7 +14,7 @@ import type { LaneRow, NodeRow, ArrowRow } from '../lib/flow-transform'
 import { toLane, toNode, toArrow } from '../lib/flow-transform'
 
 const MODEL_HAIKU = 'claude-haiku-4-5-20251001'
-const MODEL_SONNET = 'claude-sonnet-4-6-20250514'
+const MODEL_SONNET = 'claude-sonnet-4-6'
 const COMPLEXITY_THRESHOLD = 10
 
 function selectModel(nodeCount: number): typeof MODEL_HAIKU | typeof MODEL_SONNET {

--- a/tests/api/routes/ai.test.ts
+++ b/tests/api/routes/ai.test.ts
@@ -299,7 +299,7 @@ describe('AI API', () => {
       const res = await postJson('/api/ai/flow-1/edit', { prompt: '整理して' }, env, cookie)
       expect(res.status).toBe(200)
       const body = await res.json()
-      expect(body.model).toBe('claude-sonnet-4-6-20250514')
+      expect(body.model).toBe('claude-sonnet-4-6')
     })
 
     it('should return haiku model for flow with exactly threshold-1 nodes', async () => {
@@ -312,6 +312,18 @@ describe('AI API', () => {
       expect(res.status).toBe(200)
       const body = await res.json()
       expect(body.model).toBe('claude-haiku-4-5-20251001')
+    })
+
+    it('should return sonnet model for flow with exactly threshold nodes', async () => {
+      // Insert nodes to reach 10 total (1 already exists from beforeEach)
+      for (let i = 2; i <= 10; i++) {
+        insertNode(db, `node-${i}`, 'flow-1', 'lane-1', i - 1, `Task ${i}`, 0)
+      }
+      const cookie = await authCookie(AI_USER_ID, AI_USER_EMAIL)
+      const res = await postJson('/api/ai/flow-1/edit', { prompt: '整理して' }, env, cookie)
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.model).toBe('claude-sonnet-4-6')
     })
   })
 })


### PR DESCRIPTION
## Summary
- `/generate` は常に Haiku 4.5 を使用（高速・低コスト）
- `/:flowId/edit` はノード数10以上で Sonnet 4.6 に切り替え
- レスポンスに使用モデル名を含める（`model` フィールド追加）

## Changes
- `api/routes/ai.ts`: `AI_MODEL` 定数を `MODEL_HAIKU` / `MODEL_SONNET` に分離、`selectModel(nodeCount)` 関数追加
- `tests/api/routes/ai.test.ts`: モデル切り替えテスト4件追加（境界値含む）

## Test plan
- [x] `/generate` がレスポンスに `model: claude-haiku-4-5-20251001` を返す
- [x] ノード数1の `/edit` が Haiku を返す
- [x] ノード数11の `/edit` が Sonnet を返す
- [x] ノード数9（境界値-1）の `/edit` が Haiku を返す
- [x] 全1197テスト通過

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)