### PR TITLE
fix(#252): ゴースト表示時にノード・矢印の選択を解除

### DIFF
--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -1259,6 +1259,8 @@ export default function FlowEditor({
       // 1クリック目 — ゴースト表示のみ
       setGhostCell({ li, ri, lid, rid })
       setGhostRowGap(null)
+      setSelTask(null)
+      setSelArrow(null)
       return
     }
     let label = '作業'


### PR DESCRIPTION
## Summary
- `cellClick` のゴースト表示（1クリック目）分岐で `setSelTask(null)` / `setSelArrow(null)` を呼び出し
- 既存の選択状態がゴースト表示時に正しくクリアされるように修正

## Changes
- `src/features/editor/FlowEditor.tsx`: ゴースト表示分岐に2行追加

## Test plan
- [x] ノード選択 → 空セルクリック → ゴースト表示時にノード選択が解除される
- [x] 矢印選択 → 空セルクリック → ゴースト表示時に矢印選択が解除される
- [x] 全1197テスト通過
- [x] ブラウザ目視確認済み

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)