### PR TITLE
fix(#258): ヘルスチェックレポートを日本語でわかりやすく改善

### DIFF
--- a/.github/scripts/health-score.js
+++ b/.github/scripts/health-score.js
@@ -35,21 +35,46 @@ try {
 
 if (score < 0) score = 0
 
-const status = score >= 80 ? '✅' : '❌'
+// Status indicator: green (80+), yellow (60-79), red (<60)
+const indicator = score >= 80 ? '🟢' : score >= 60 ? '🟡' : '🔴'
 
-const lines = ['## 🤖 Repository Health', '', `Health Score: ${score} ${status}`, '']
+// Progress bar (20 chars wide)
+const filled = Math.round(score / 5)
+const empty = 20 - filled
+const bar = '█'.repeat(filled) + '░'.repeat(empty)
+
+const lines = [
+  '## 🏥 リポジトリ健康診断',
+  '',
+  `${indicator} **スコア: ${score} / 100**`,
+  '',
+  `\`${bar}\``,
+  '',
+]
 
 const total = categories.files + categories.dependencies + categories.exports + categories.types
 
 if (!knipAvailable) {
-  lines.push('knip result unavailable')
+  lines.push('> ⚠️ knip の結果を取得できませんでした')
 } else if (total > 0) {
-  if (categories.files > 0) lines.push(`Unused files: ${categories.files}`)
-  if (categories.dependencies > 0) lines.push(`Unused dependencies: ${categories.dependencies}`)
-  if (categories.exports > 0) lines.push(`Unused exports: ${categories.exports}`)
-  if (categories.types > 0) lines.push(`Unused types: ${categories.types}`)
+  lines.push('| 項目 | 件数 | 減点 |')
+  lines.push('|---|:---:|:---:|')
+  if (categories.files > 0)
+    lines.push(`| 📄 未使用ファイル | ${categories.files} | -${categories.files * 5} |`)
+  if (categories.dependencies > 0)
+    lines.push(
+      `| 📦 未使用パッケージ | ${categories.dependencies} | -${categories.dependencies * 5} |`,
+    )
+  if (categories.exports > 0)
+    lines.push(`| 📤 未使用エクスポート | ${categories.exports} | -${categories.exports * 5} |`)
+  if (categories.types > 0)
+    lines.push(`| 🏷️ 未使用の型定義 | ${categories.types} | -${categories.types * 5} |`)
+  lines.push('')
+  lines.push(
+    `> 💡 **ヒント:** \`npm run knip\` で詳細を確認し、不要なコードを削除するとスコアが上がります`,
+  )
 } else {
-  lines.push('No issues found 🎉')
+  lines.push('🎉 問題は見つかりませんでした！コードはきれいな状態です。')
 }
 
 lines.push('')

--- a/tests/health-score.test.ts
+++ b/tests/health-score.test.ts
@@ -26,11 +26,11 @@ function runScript(knipData: unknown): string {
 }
 
 describe('health-score.js', () => {
-  it('should output score 100 and no issues message when knip finds nothing', () => {
+  it('should output score 100 with celebration when knip finds nothing', () => {
     const report = runScript({ files: [], issues: [] })
-    expect(report).toContain('Health Score: 100')
-    expect(report).toContain('✅')
-    expect(report).toContain('No issues found')
+    expect(report).toContain('スコア: 100 / 100')
+    expect(report).toContain('🟢')
+    expect(report).toContain('問題は見つかりませんでした')
   })
 
   it('should deduct 5 points per unused file', () => {
@@ -38,8 +38,8 @@ describe('health-score.js', () => {
       files: ['a.ts', 'b.ts'],
       issues: [],
     })
-    expect(report).toContain('Health Score: 90')
-    expect(report).toContain('✅')
+    expect(report).toContain('スコア: 90 / 100')
+    expect(report).toContain('🟢')
   })
 
   it('should deduct 5 points per unused export/type/dependency in issues', () => {
@@ -57,31 +57,39 @@ describe('health-score.js', () => {
       ],
     })
     // 2 items * 5 = 10, score = 90
-    expect(report).toContain('Health Score: 90')
+    expect(report).toContain('スコア: 90 / 100')
   })
 
-  it('should show warning when score is below 80', () => {
+  it('should show yellow warning when score is 60-79', () => {
     const files = Array.from({ length: 5 }, (_, i) => `file${i}.ts`)
     const report = runScript({ files, issues: [] })
     // 100 - 25 = 75
-    expect(report).toContain('Health Score: 75')
-    expect(report).toContain('❌')
+    expect(report).toContain('スコア: 75 / 100')
+    expect(report).toContain('🟡')
+  })
+
+  it('should show red warning when score is below 60', () => {
+    const files = Array.from({ length: 10 }, (_, i) => `file${i}.ts`)
+    const report = runScript({ files, issues: [] })
+    // 100 - 50 = 50
+    expect(report).toContain('スコア: 50 / 100')
+    expect(report).toContain('🔴')
   })
 
   it('should clamp score to 0 when many unused items', () => {
     const files = Array.from({ length: 30 }, (_, i) => `file${i}.ts`)
     const report = runScript({ files, issues: [] })
-    expect(report).toContain('Health Score: 0')
-    expect(report).toContain('❌')
+    expect(report).toContain('スコア: 0 / 100')
+    expect(report).toContain('🔴')
   })
 
   it('should handle missing knip-output.json gracefully', () => {
     const report = runScript(null)
-    expect(report).toContain('Health Score: 100')
-    expect(report).toContain('knip result unavailable')
+    expect(report).toContain('スコア: 100 / 100')
+    expect(report).toContain('knip の結果を取得できませんでした')
   })
 
-  it('should include category breakdown in report', () => {
+  it('should include Japanese category breakdown in report', () => {
     const report = runScript({
       files: ['a.ts'],
       issues: [
@@ -95,16 +103,18 @@ describe('health-score.js', () => {
         },
       ],
     })
-    expect(report).toContain('Unused files: 1')
-    expect(report).toContain('Unused exports: 1')
-    expect(report).toContain('Unused dependencies: 1')
+    expect(report).toContain('未使用ファイル')
+    expect(report).toContain('未使用エクスポート')
+    expect(report).toContain('未使用パッケージ')
   })
 
-  it('should show no issues message when knip succeeds with zero counts', () => {
-    const report = runScript({ files: [], issues: [] })
-    expect(report).toContain('Health Score: 100')
-    expect(report).not.toContain('Unused files')
-    expect(report).toContain('No issues found')
+  it('should show progress bar', () => {
+    const report = runScript({
+      files: ['a.ts', 'b.ts'],
+      issues: [],
+    })
+    // Score 90 -> progress bar should have filled and empty portions
+    expect(report).toMatch(/[█]+[░]+/)
   })
 
   it('should handle malformed knip-output.json gracefully', () => {
@@ -117,7 +127,7 @@ describe('health-score.js', () => {
     const report = fs.readFileSync(reportPath, 'utf-8')
     fs.rmSync(tmpDir, { recursive: true })
 
-    expect(report).toContain('Health Score: 100')
-    expect(report).toContain('knip result unavailable')
+    expect(report).toContain('スコア: 100 / 100')
+    expect(report).toContain('knip の結果を取得できませんでした')
   })
 })


### PR DESCRIPTION
## Summary
- ヘルスチェックレポートを全面日本語化
- プログレスバー・色分け・減点テーブルで視覚的にわかりやすく
- 改善ヒントを追加

## Before
```
## 🤖 Repository Health
Health Score: 30 ❌
Unused dependencies: 4
Unused exports: 1
Unused types: 9
```

## After
```
## 🏥 リポジトリ健康診断

🔴 スコア: 30 / 100

`██████░░░░░░░░░░░░░░`

| 項目 | 件数 | 減点 |
|---|:---:|:---:|
| 📦 未使用パッケージ | 4 | -20 |
| 📤 未使用エクスポート | 1 | -5 |
| 🏷️ 未使用の型定義 | 9 | -45 |

> 💡 ヒント: `npm run knip` で詳細を確認し、不要なコードを削除するとスコアが上がります
```

## Test plan
- [x] ユニットテスト10ケース全パス
- [x] 全プロジェクトテスト1208ケース全パス
- [ ] PR上でレポートが日本語で表示される

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)