### PR TITLE
fix(#265): 自動接続が同行の孤立ノードを優先するように修正

### DIFF
--- a/src/features/editor/auto-connect.test.ts
+++ b/src/features/editor/auto-connect.test.ts
@@ -148,6 +148,36 @@ describe('findClosestUpstream', () => {
     const result = findClosestUpstream(tasks, rows, lanes, 1, 1, arrows)
     expect(result).toBe('N4')
   })
+
+  it('should prefer same-row isolated tail over previous-row flowTail (#265)', () => {
+    // Row 3: A → B (chain), Row 4: X (isolated), new node at Row 4 lane 1
+    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }, { id: 'r3' }, { id: 'r4' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      A: { lid: 'l0', rid: 'r3' },
+      B: { lid: 'l1', rid: 'r3' },
+      X: { lid: 'l0', rid: 'r4' },
+    }
+    const arrows = [{ id: 'a1', from: 'A', to: 'B', comment: '' }]
+    // New node at row4(r4), lane1(l1) — X is same-row isolated tail, B is flowTail at row3
+    const result = findClosestUpstream(tasks, rows, lanes, 4, 1, arrows)
+    expect(result).toBe('X')
+  })
+
+  it('should prefer same-row closest tail when multiple same-row tails exist', () => {
+    // Row 0: A → B (B is flowTail at l1), C is isolated at l2, new node at l3
+    const rows = [{ id: 'r0' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }, { id: 'l2' }, { id: 'l3' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      A: { lid: 'l0', rid: 'r0' },
+      B: { lid: 'l1', rid: 'r0' },
+      C: { lid: 'l2', rid: 'r0' },
+    }
+    const arrows = [{ id: 'a1', from: 'A', to: 'B', comment: '' }]
+    const result = findClosestUpstream(tasks, rows, lanes, 0, 3, arrows)
+    // C is closer (l2 vs l1), both are same-row tails
+    expect(result).toBe('C')
+  })
 })
 
 describe('findCrossingArrows', () => {

--- a/src/features/editor/auto-connect.ts
+++ b/src/features/editor/auto-connect.ts
@@ -51,10 +51,22 @@ export function findClosestUpstream(
     return bestKey
   }
 
-  // Try flow-connected tails first, fall back to all tails
+  // 1. Same-row tails: strongest signal (fixes #265)
+  const sameRowTails = tails.filter((k) => {
+    const task = tasks[k]
+    const tRi = rows.findIndex((r) => r.id === task.rid)
+    return tRi === newRi
+  })
+  if (sameRowTails.length > 0) {
+    const sameRowResult = findBest(sameRowTails)
+    if (sameRowResult) return sameRowResult
+  }
+
+  // 2. Flow-connected tails from previous rows
   const result = flowTails.length > 0 ? findBest(flowTails) : null
   if (result) return result
 
+  // 3. Fall back to all tails
   return findBest(tails)
 }
 


### PR DESCRIPTION
## Summary
- `findClosestUpstream()` の探索優先順位を変更し、同行tailを最優先に
- 変更前: flowTails → tails の2段階
- 変更後: **同行tails** → flowTails → tails の3段階
- テスト2件追加（バグ再現 + 同行複数tail回帰）

## Bug
同行に孤立ノード（incoming arrowなし）があっても、前行のflowTail（チェーン末端）に接続されていた。

## Fix
```
Row 4: [A] → [B]  ← flowTail
Row 5: [X]        ← isolated tail (same row as new node)
Row 5: [NEW]      ← 新規ノード
```
修正前: NEW → B（前行flowTail）
修正後: NEW → X（同行tail）

Closes #265

## Test plan
- [x] バグ再現テスト: 同行isolated tail vs 前行flowTail → 同行を選択
- [x] 回帰テスト: 同行に複数tail → 最も近いtailを選択
- [x] 既存テスト12件パス（回帰なし）
- [x] 全テスト1222件パス
- [ ] CI全チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)