### PR TITLE
fix(#275): レーングループ親ヘッダーがサブレーンボディに覆われる問題を修正

### DIFF
--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -1694,10 +1694,10 @@ export default function FlowEditor({
                 >
                   <rect
                     x={x}
-                    y={TM}
+                    y={isSub ? TM + HH : TM}
                     width={LW}
-                    height={fullH}
-                    rx={10}
+                    height={isSub ? fullH - HH : fullH}
+                    rx={isSub ? 0 : 10}
                     fill={T.laneBg}
                     stroke={T.laneBorder}
                     strokeWidth={0.5}
@@ -1705,10 +1705,10 @@ export default function FlowEditor({
                   {isSel && (
                     <rect
                       x={x + 1}
-                      y={TM + 1}
+                      y={isSub ? TM + HH + 1 : TM + 1}
                       width={LW - 2}
-                      height={fullH - 2}
-                      rx={9}
+                      height={isSub ? fullH - HH - 2 : fullH - 2}
+                      rx={isSub ? 0 : 9}
                       fill="none"
                       stroke={T.accent}
                       strokeWidth={1.5}

--- a/src/features/shared/SharedFlowViewer.tsx
+++ b/src/features/shared/SharedFlowViewer.tsx
@@ -208,10 +208,10 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
               <g key={`lane-${lane.id}`}>
                 <rect
                   x={x}
-                  y={TM}
+                  y={isSub ? TM + HH : TM}
                   width={LW}
-                  height={fullH}
-                  rx={10}
+                  height={isSub ? fullH - HH : fullH}
+                  rx={isSub ? 0 : 10}
                   fill={T.laneBg}
                   stroke={T.laneBorder}
                   strokeWidth={0.5}


### PR DESCRIPTION
## Summary
Closes #275

レーングループで親レーンのヘッダーがサブレーンのボディrectに覆い隠されるZ-order問題を修正。

サブレーンのボディrectからヘッダー領域（高さHH）を除外し、`y=TM+HH`、`height=fullH-HH` にすることで、親ヘッダーと重ならないようにした。

- `FlowEditor.tsx`: サブレーンのボディrectと選択ボーダーの両方を修正
- `SharedFlowViewer.tsx`: サブレーンのボディrectを修正

## Test plan
- [x] 全1239テスト通過
- [x] ブラウザ検証: ダイヤモンドノード→レーン分割→親ヘッダーがグループ全幅で正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)