### PR TITLE
refactor(#291): remove unused exports and fix knip config

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,20 @@
 {
   "$schema": "https://unpkg.com/knip/schema.json",
-  "entry": ["src/main.tsx", "vite.config.ts", "functions/**/*.ts", "workers/**/*.ts"],
-  "project": ["src/**/*.{ts,tsx}", "functions/**/*.ts", "workers/**/*.ts"],
-  "ignore": ["tests/helpers/**", "**/*.d.ts"]
+  "entry": [
+    "src/main.tsx",
+    "vite.config.ts",
+    "api/**/*.ts",
+    "functions/**/*.ts",
+    "workers/**/*.ts",
+    "scripts/*.mjs"
+  ],
+  "project": [
+    "src/**/*.{ts,tsx}",
+    "api/**/*.ts",
+    "functions/**/*.ts",
+    "workers/**/*.ts",
+    "scripts/*.mjs"
+  ],
+  "ignore": ["tests/helpers/**", "**/*.d.ts"],
+  "ignoreDependencies": ["@resvg/resvg-js", "@types/bcryptjs"]
 }

--- a/src/features/dashboard/constants.ts
+++ b/src/features/dashboard/constants.ts
@@ -5,13 +5,13 @@ export const DEFAULT_FLOW_TITLE = '無題のフロー'
 
 export const DEFAULT_FLOW_THEME_ID = 'cloud'
 
-export interface DefaultLane {
+interface DefaultLane {
   name: string
   colorIndex: number
   position: number
 }
 
-export const DEFAULT_LANES: DefaultLane[] = [
+const DEFAULT_LANES: DefaultLane[] = [
   { name: 'lane1', colorIndex: 0, position: 0 },
   { name: 'lane2', colorIndex: 1, position: 1 },
   { name: 'lane3', colorIndex: 2, position: 2 },

--- a/src/features/editor/components/RightPanel.tsx
+++ b/src/features/editor/components/RightPanel.tsx
@@ -22,7 +22,7 @@ import {
   STROKE_STYLES,
 } from '../theme-constants'
 
-export interface RightPanelProps {
+interface RightPanelProps {
   // Selection
   multiSel: Set<string>
   setMultiSel: React.Dispatch<React.SetStateAction<Set<string>>>

--- a/src/features/editor/components/Toolbar.tsx
+++ b/src/features/editor/components/Toolbar.tsx
@@ -13,7 +13,7 @@ interface ToolbarTheme {
   toolbarShadow: string
 }
 
-export interface ToolbarProps {
+interface ToolbarProps {
   x: number
   y: number
   items: ToolbarItem[]

--- a/src/features/editor/theme-constants.ts
+++ b/src/features/editor/theme-constants.ts
@@ -173,7 +173,7 @@ export const THEMES: Record<ThemeId, Theme> = {
 // Node background color palettes
 // =============================================
 
-export interface NodeColor {
+interface NodeColor {
   id: string
   fill: string | null
   label: string
@@ -209,7 +209,7 @@ export const NODE_COLORS_DARK: NodeColor[] = [
 // Line color & stroke style palettes
 // =============================================
 
-export interface LineColor {
+interface LineColor {
   id: string
   color: string | null
   label: string
@@ -228,7 +228,7 @@ export const LINE_COLORS: LineColor[] = [
   { id: 'pink', color: '#C06088', label: 'ピンク' },
 ]
 
-export interface StrokeStyle {
+interface StrokeStyle {
   id: string
   label: string
   dash: string

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -56,4 +56,4 @@ i18n.on('languageChanged', (lng: string) => {
   document.documentElement.lang = lng
 })
 
-export default i18n
+// side-effect only — imported as `import './i18n'`

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -3,7 +3,7 @@ export interface Point {
   y: number
 }
 
-export interface ArrowPath {
+interface ArrowPath {
   d: string
   mx: number
   my: number

--- a/src/lib/flow-engine.ts
+++ b/src/lib/flow-engine.ts
@@ -7,12 +7,12 @@ import type { Point } from './arrow-routing'
 /* calcArrowPath types                                       */
 /* --------------------------------------------------------- */
 
-export interface NodePos {
+interface NodePos {
   x: number
   y: number
 }
 
-export interface ArrowConfig {
+interface ArrowConfig {
   hw: number
   hh: number
   rh: number
@@ -231,7 +231,7 @@ export interface CrossLaneRewire {
 /* swapKeys — 2ノードの位置交換                               */
 /* --------------------------------------------------------- */
 
-export interface SwapResult {
+interface SwapResult {
   tasks: Record<string, TaskData>
   arrows: InternalArrow[]
   order: string[]

--- a/src/test-i18n.ts
+++ b/src/test-i18n.ts
@@ -13,4 +13,4 @@ i18n.use(initReactI18next).init({
   },
 })
 
-export default i18n
+// side-effect only — imported as `import './test-i18n'`


### PR DESCRIPTION
## Summary
- 未使用の `export` を11件削除（`NodePos`, `ArrowConfig`, `SwapResult`, `ArrowPath`, `NodeColor`, `LineColor`, `StrokeStyle`, `ToolbarProps`, `RightPanelProps`, `DefaultLane`, `DEFAULT_LANES`）
- `i18n.ts` / `test-i18n.ts` の不要な `export default` を削除
- `knip.json` に `api/` と `scripts/` ディレクトリを追加し、誤検知を解消
- knip issues: ~15 → 0

## Test plan
- [x] `npm test` — 81ファイル 1262テスト全通過
- [x] `npm run lint` — エラー0（既存warning 2件のみ）
- [x] `npx knip` — issues 0件

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)