### PR TITLE
fix(#288): 言語切替が反映されないバグを修正

### DIFF
--- a/src/features/settings/SettingsPage.test.tsx
+++ b/src/features/settings/SettingsPage.test.tsx
@@ -446,6 +446,41 @@ describe('SettingsPage', () => {
     expect(screen.getByTestId('settings-avatar')).toHaveAttribute('aria-label', 'status.menu')
   })
 
+  // === 言語切替: APIリフェッチしない ===
+  it('should not re-fetch settings from API when language is changed', async () => {
+    const user = userEvent.setup()
+    mockApiFetch.mockResolvedValueOnce(mockSettingsResponse)
+    renderSettingsPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('settings-content')).toBeInTheDocument()
+    })
+
+    // Record initial API call count (1 for loadSettings)
+    const initialCallCount = mockApiFetch.mock.calls.filter(
+      (call) => call[0] === '/settings' && (!call[1] || !call[1].method),
+    ).length
+    expect(initialCallCount).toBe(1)
+
+    // Navigate to display section
+    await user.click(screen.getByTestId('nav-display'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('language-select')).toBeInTheDocument()
+    })
+
+    // Change language to English
+    await user.selectOptions(screen.getByTestId('language-select'), 'en')
+
+    // Wait a bit and verify no additional GET /settings call was made
+    await new Promise((r) => setTimeout(r, 500))
+
+    const getSettingsCalls = mockApiFetch.mock.calls.filter(
+      (call) => call[0] === '/settings' && (!call[1] || !call[1].method),
+    )
+    expect(getSettingsCalls.length).toBe(initialCallCount)
+  })
+
   // === アバターの頭文字表示 ===
   it('should display first character of user name in avatar', async () => {
     mockApiFetch.mockResolvedValueOnce(mockSettingsResponse)

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -95,6 +95,9 @@ export function SettingsPage() {
   const isInitialLoadRef = useRef(true)
   const userNameRef = useRef(user?.name)
 
+  const tRef = useRef(t)
+  tRef.current = t
+
   const loadSettings = useCallback(async () => {
     try {
       setLoading(true)
@@ -113,7 +116,7 @@ export function SettingsPage() {
         isInitialLoadRef.current = false
       }, 0)
     } catch {
-      setError(t('status.loadError'))
+      setError(tRef.current('status.loadError'))
       setLoadFailed(true)
       // Use user info as fallback
       if (user) {
@@ -128,7 +131,7 @@ export function SettingsPage() {
     } finally {
       setLoading(false)
     }
-  }, [user, t])
+  }, [user])
 
   useEffect(() => {
     loadSettings()
@@ -178,7 +181,7 @@ export function SettingsPage() {
         setTimeout(() => setSaveStatus('idle'), 2000)
       } catch {
         setSaveStatus('error')
-        setError(t('status.saveError'))
+        setError(tRef.current('status.saveError'))
         setTimeout(() => setSaveStatus('idle'), 3000)
       }
     }, 800)
@@ -186,7 +189,7 @@ export function SettingsPage() {
     return () => {
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
     }
-  }, [settings, profileName, t])
+  }, [settings, profileName])
 
   const handlePasswordChange = async (
     currentPassword: string,


### PR DESCRIPTION
## Summary

- 設定画面で言語を切り替えても、UIが日本語のまま変わらないバグを修正
- 原因: `loadSettings` の依存配列に `t`（useTranslation）が含まれていたため、言語変更 → `t` 参照更新 → `loadSettings` 再実行 → DBから旧設定（`language: 'ja'`）をロード → 言語が日本語に戻る、というサイクルが発生していた
- 修正: `t` を `useRef` 経由で参照し、`loadSettings` と auto-save の依存配列から `t` を除去

## Test plan

- [x] 言語変更時にAPIリフェッチが発生しないことを検証するテストを追加
- [x] 既存テスト全1296件通過
- [ ] ブラウザで設定画面の言語切替が即座に反映されることを確認

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)