### PR TITLE
feat(#304): enable registration via invitation code

### DIFF
--- a/api/lib/invitation.ts
+++ b/api/lib/invitation.ts
@@ -15,10 +15,7 @@ export function generateInvitationCode(): string {
   return out
 }
 
-export async function validateInvitationCode(
-  db: D1Database,
-  code: string,
-): Promise<boolean> {
+export async function validateInvitationCode(db: D1Database, code: string): Promise<boolean> {
   const normalized = normalizeInvitationCode(code)
   if (!normalized) return false
   const row = await db

--- a/api/lib/invitation.ts
+++ b/api/lib/invitation.ts
@@ -1,0 +1,34 @@
+export const CODE_CHARSET = '23456789ABCDEFGHJKMNPQRSTUVWXYZ'
+export const CODE_LENGTH = 8
+
+export function normalizeInvitationCode(input: string): string {
+  return input.toUpperCase().replace(/\s/g, '')
+}
+
+export function generateInvitationCode(): string {
+  const bytes = new Uint8Array(CODE_LENGTH)
+  crypto.getRandomValues(bytes)
+  let out = ''
+  for (let i = 0; i < CODE_LENGTH; i++) {
+    out += CODE_CHARSET[bytes[i] % CODE_CHARSET.length]
+  }
+  return out
+}
+
+export async function validateInvitationCode(
+  db: D1Database,
+  code: string,
+): Promise<boolean> {
+  const normalized = normalizeInvitationCode(code)
+  if (!normalized) return false
+  const row = await db
+    .prepare(
+      `SELECT id FROM invitation_codes
+       WHERE code = ?
+         AND revoked_at IS NULL
+         AND datetime(expires_at) > datetime('now')`,
+    )
+    .bind(normalized)
+    .first<{ id: number }>()
+  return row != null
+}

--- a/api/routes/admin.ts
+++ b/api/routes/admin.ts
@@ -199,4 +199,44 @@ admin.post('/invitations', async (c) => {
   )
 })
 
+// =============================================
+// GET /invitations - List invitation codes (admin only)
+// =============================================
+
+admin.get('/invitations', async (c) => {
+  const db = c.env.FLOWLINE_DB
+  const result = await db
+    .prepare(
+      `SELECT id, code, expires_at, revoked_at, created_at, created_by
+       FROM invitation_codes ORDER BY created_at DESC`,
+    )
+    .all<{
+      id: number
+      code: string
+      expires_at: string
+      revoked_at: string | null
+      created_at: string
+      created_by: string
+    }>()
+
+  const now = Date.now()
+  const invitations = (result.results ?? []).map((r) => {
+    let status: 'active' | 'expired' | 'revoked'
+    if (r.revoked_at) status = 'revoked'
+    else if (new Date(r.expires_at).getTime() <= now) status = 'expired'
+    else status = 'active'
+    return {
+      id: r.id,
+      code: r.code,
+      expiresAt: r.expires_at,
+      revokedAt: r.revoked_at,
+      createdAt: r.created_at,
+      createdBy: r.created_by,
+      status,
+    }
+  })
+
+  return c.json({ invitations })
+})
+
 export { admin }

--- a/api/routes/admin.ts
+++ b/api/routes/admin.ts
@@ -239,4 +239,31 @@ admin.get('/invitations', async (c) => {
   return c.json({ invitations })
 })
 
+// =============================================
+// POST /invitations/:id/revoke - Revoke invitation code (admin only)
+// =============================================
+
+admin.post('/invitations/:id/revoke', async (c) => {
+  const db = c.env.FLOWLINE_DB
+  const id = Number(c.req.param('id'))
+  if (!Number.isInteger(id) || id <= 0) {
+    return c.json({ error: '無効な id です' }, 400)
+  }
+
+  const row = await db
+    .prepare('SELECT id, revoked_at FROM invitation_codes WHERE id = ?')
+    .bind(id)
+    .first<{ id: number; revoked_at: string | null }>()
+  if (!row) return c.json({ error: '招待コードが見つかりません' }, 404)
+  if (row.revoked_at) return c.json({ error: '既に無効化されています' }, 409)
+
+  const revokedAt = new Date().toISOString()
+  await db
+    .prepare('UPDATE invitation_codes SET revoked_at = ? WHERE id = ?')
+    .bind(revokedAt, id)
+    .run()
+
+  return c.json({ id, revokedAt })
+})
+
 export { admin }

--- a/api/routes/admin.ts
+++ b/api/routes/admin.ts
@@ -129,7 +129,6 @@ admin.put('/users/:id', async (c) => {
 admin.post('/invitations', async (c) => {
   const db = c.env.FLOWLINE_DB
   const adminId = c.get('userId')
-  if (!adminId) return c.json({ error: '認証が必要です' }, 401)
 
   let body: { expiresInDays?: number }
   try {
@@ -158,7 +157,12 @@ admin.post('/invitations', async (c) => {
         .run()
       inserted = true
       break
-    } catch {
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (!/UNIQUE/i.test(msg)) {
+        console.error('[invitations] insert failed', err)
+        return c.json({ error: '招待コードの生成に失敗しました' }, 500)
+      }
       // UNIQUE collision — retry
     }
   }

--- a/api/routes/admin.ts
+++ b/api/routes/admin.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import type { AuthEnv } from '../app'
 import { authMiddleware } from '../middleware/auth'
 import { adminMiddleware } from '../middleware/admin'
+import { generateInvitationCode } from '../lib/invitation'
 
 const ALLOWED_ROLES = ['user', 'admin']
 
@@ -119,6 +120,79 @@ admin.put('/users/:id', async (c) => {
       aiEnabled: updated.ai_enabled === 1,
     },
   })
+})
+
+// =============================================
+// POST /invitations - Create invitation code (admin only)
+// =============================================
+
+admin.post('/invitations', async (c) => {
+  const db = c.env.FLOWLINE_DB
+  const adminId = c.get('userId')
+  if (!adminId) return c.json({ error: '認証が必要です' }, 401)
+
+  let body: { expiresInDays?: number }
+  try {
+    body = await c.req.json()
+  } catch {
+    return c.json({ error: 'リクエストの形式が正しくありません' }, 400)
+  }
+  const days = body.expiresInDays
+  if (days === undefined || !Number.isInteger(days) || days < 1 || days > 365) {
+    return c.json({ error: 'expiresInDays は 1〜365 の整数で指定してください' }, 400)
+  }
+
+  const expiresAt = new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString()
+
+  let code = ''
+  let inserted = false
+  for (let attempt = 0; attempt < 3; attempt++) {
+    code = generateInvitationCode()
+    try {
+      await db
+        .prepare(
+          `INSERT INTO invitation_codes (code, expires_at, created_by)
+           VALUES (?, ?, ?)`,
+        )
+        .bind(code, expiresAt, adminId)
+        .run()
+      inserted = true
+      break
+    } catch {
+      // UNIQUE collision — retry
+    }
+  }
+  if (!inserted) {
+    return c.json({ error: '招待コードの生成に失敗しました' }, 500)
+  }
+
+  const row = await db
+    .prepare(
+      `SELECT id, code, expires_at, revoked_at, created_at, created_by
+       FROM invitation_codes WHERE code = ?`,
+    )
+    .bind(code)
+    .first<{
+      id: number
+      code: string
+      expires_at: string
+      revoked_at: string | null
+      created_at: string
+      created_by: string
+    }>()
+  if (!row) return c.json({ error: '招待コードの取得に失敗しました' }, 500)
+
+  return c.json(
+    {
+      id: row.id,
+      code: row.code,
+      expiresAt: row.expires_at,
+      revokedAt: row.revoked_at,
+      createdAt: row.created_at,
+      createdBy: row.created_by,
+    },
+    201,
+  )
 })
 
 export { admin }

--- a/api/routes/auth.ts
+++ b/api/routes/auth.ts
@@ -31,15 +31,22 @@ auth.post('/register', async (c) => {
   }
 
   // 招待コード必須チェック（フィールド検証より先に実行し、情報漏洩を防ぐ）
-  if (!body.invitationCode || !body.invitationCode.trim()) {
+  if (typeof body.invitationCode !== 'string' || !body.invitationCode.trim()) {
     return c.json({ error: '招待コードを入力してください', code: 'INVITATION_REQUIRED' }, 400)
   }
 
-  if (!body.email || !body.password || !body.name) {
+  if (
+    typeof body.email !== 'string' ||
+    typeof body.password !== 'string' ||
+    typeof body.name !== 'string' ||
+    !body.email ||
+    !body.password ||
+    !body.name
+  ) {
     return c.json({ error: '入力が不足しています' }, 400)
   }
-  if (body.password.length < 8) {
-    return c.json({ error: 'パスワードは 8 文字以上で入力してください' }, 400)
+  if (body.password.length < 8 || body.password.length > 72) {
+    return c.json({ error: 'パスワードは 8〜72 文字で入力してください' }, 400)
   }
 
   const db = c.env.FLOWLINE_DB

--- a/api/routes/auth.ts
+++ b/api/routes/auth.ts
@@ -32,10 +32,7 @@ auth.post('/register', async (c) => {
 
   // 招待コード必須チェック（フィールド検証より先に実行し、情報漏洩を防ぐ）
   if (!body.invitationCode || !body.invitationCode.trim()) {
-    return c.json(
-      { error: '招待コードを入力してください', code: 'INVITATION_REQUIRED' },
-      400,
-    )
+    return c.json({ error: '招待コードを入力してください', code: 'INVITATION_REQUIRED' }, 400)
   }
 
   if (!body.email || !body.password || !body.name) {
@@ -58,10 +55,7 @@ auth.post('/register', async (c) => {
   }
 
   const email = body.email.toLowerCase().trim()
-  const existing = await db
-    .prepare('SELECT id FROM users WHERE email = ?')
-    .bind(email)
-    .first()
+  const existing = await db.prepare('SELECT id FROM users WHERE email = ?').bind(email).first()
   if (existing) {
     return c.json(
       { error: 'このメールアドレスは既に登録されています', code: 'EMAIL_ALREADY_EXISTS' },

--- a/api/routes/auth.ts
+++ b/api/routes/auth.ts
@@ -1,9 +1,11 @@
 import { Hono } from 'hono'
 import { setCookie, deleteCookie } from 'hono/cookie'
-import { verifyPassword } from '../lib/password'
+import { hashPassword, verifyPassword } from '../lib/password'
 import { createToken, createVerificationToken, verifyVerificationToken } from '../lib/jwt'
 import type { VerificationPayload } from '../lib/jwt'
 import { sendVerificationEmail } from '../lib/email'
+import { generateId } from '../lib/id'
+import { validateInvitationCode } from '../lib/invitation'
 import { authMiddleware } from '../middleware/auth'
 import type { AuthEnv } from '../app'
 
@@ -21,9 +23,76 @@ function getCookieOptions(c: { req: { url: string } }) {
 }
 
 auth.post('/register', async (c) => {
-  // Closed beta: registration is temporarily disabled.
-  // To restore, revert the PR that introduced this change.
-  return c.json({ error: '現在はクローズドβテスト中です' }, 503)
+  let body: { email?: string; password?: string; name?: string; invitationCode?: string }
+  try {
+    body = await c.req.json()
+  } catch {
+    return c.json({ error: 'リクエストの形式が正しくありません' }, 400)
+  }
+
+  // 招待コード必須チェック（フィールド検証より先に実行し、情報漏洩を防ぐ）
+  if (!body.invitationCode || !body.invitationCode.trim()) {
+    return c.json(
+      { error: '招待コードを入力してください', code: 'INVITATION_REQUIRED' },
+      400,
+    )
+  }
+
+  if (!body.email || !body.password || !body.name) {
+    return c.json({ error: '入力が不足しています' }, 400)
+  }
+  if (body.password.length < 8) {
+    return c.json({ error: 'パスワードは 8 文字以上で入力してください' }, 400)
+  }
+
+  const db = c.env.FLOWLINE_DB
+  const isValidInvite = await validateInvitationCode(db, body.invitationCode)
+  if (!isValidInvite) {
+    return c.json(
+      {
+        error: '招待コードが無効です。期限切れまたは誤ったコードです。',
+        code: 'INVITATION_INVALID',
+      },
+      400,
+    )
+  }
+
+  const email = body.email.toLowerCase().trim()
+  const existing = await db
+    .prepare('SELECT id FROM users WHERE email = ?')
+    .bind(email)
+    .first()
+  if (existing) {
+    return c.json(
+      { error: 'このメールアドレスは既に登録されています', code: 'EMAIL_ALREADY_EXISTS' },
+      400,
+    )
+  }
+
+  const userId = generateId()
+  const passwordHash = await hashPassword(body.password)
+  const verificationToken = await createVerificationToken(userId, c.env.JWT_SECRET)
+  const verificationSentAt = new Date().toISOString()
+
+  await db
+    .prepare(
+      `INSERT INTO users (id, email, password_hash, name, email_verified, verification_token, verification_sent_at)
+       VALUES (?, ?, ?, ?, 0, ?, ?)`,
+    )
+    .bind(userId, email, passwordHash, body.name.trim(), verificationToken, verificationSentAt)
+    .run()
+
+  // メール送信失敗は致命的ではない — ユーザー作成は成功扱い、再送可能
+  const baseUrl = new URL(c.req.url).origin
+  try {
+    if (c.env.RESEND_API_KEY) {
+      await sendVerificationEmail(email, verificationToken, c.env.RESEND_API_KEY, baseUrl)
+    }
+  } catch (err) {
+    console.error('[register] failed to send verification email', err)
+  }
+
+  return c.json({ message: '確認メールを送信しました', needsVerification: true })
 })
 
 auth.post('/login', async (c) => {

--- a/migrations/0009_invitation_codes.sql
+++ b/migrations/0009_invitation_codes.sql
@@ -1,0 +1,10 @@
+CREATE TABLE invitation_codes (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  code        TEXT NOT NULL UNIQUE,
+  expires_at  TEXT NOT NULL,
+  revoked_at  TEXT,
+  created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+  created_by  TEXT NOT NULL REFERENCES users(id)
+);
+
+CREATE INDEX idx_invitation_codes_code ON invitation_codes(code);

--- a/src/features/admin/AdminPage.test.tsx
+++ b/src/features/admin/AdminPage.test.tsx
@@ -76,6 +76,19 @@ const mockUsers = [
   },
 ]
 
+// Helper: applies a path-routed mockImplementation on top of any queued
+// mockResolvedValueOnce/mockRejectedValueOnce calls. Queued "once" responses
+// still fire first (vitest behavior); this impl handles the un-queued calls
+// so e.g. InvitationsSection's /admin/invitations GET on mount doesn't break
+// user-focused tests.
+function routeApiFetch(extra?: Record<string, unknown>) {
+  mockApiFetch.mockImplementation(async (path: string) => {
+    if (path === '/admin/invitations') return { invitations: [] }
+    if (extra && path in extra) return extra[path]
+    return { users: [] }
+  })
+}
+
 describe('AdminPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -86,6 +99,7 @@ describe('AdminPage', () => {
       role: 'admin',
       aiEnabled: true,
     }
+    routeApiFetch()
   })
 
   afterEach(() => {
@@ -141,7 +155,7 @@ describe('AdminPage', () => {
   // User List Rendering
   // ========================================
   it('should render user list for admin user', async () => {
-    mockApiFetch.mockResolvedValueOnce({ users: mockUsers })
+    routeApiFetch({ '/admin/users': { users: mockUsers } })
 
     render(<AdminPage />)
 
@@ -157,7 +171,7 @@ describe('AdminPage', () => {
   })
 
   it('should display role badges correctly', async () => {
-    mockApiFetch.mockResolvedValueOnce({ users: mockUsers })
+    routeApiFetch({ '/admin/users': { users: mockUsers } })
 
     render(<AdminPage />)
 
@@ -173,7 +187,7 @@ describe('AdminPage', () => {
   })
 
   it('should show empty state when no users', async () => {
-    mockApiFetch.mockResolvedValueOnce({ users: [] })
+    routeApiFetch({ '/admin/users': { users: [] } })
 
     render(<AdminPage />)
 
@@ -189,7 +203,7 @@ describe('AdminPage', () => {
   // ========================================
   it('should toggle AI enabled when clicking toggle button', async () => {
     const user = userEvent.setup()
-    mockApiFetch.mockResolvedValueOnce({ users: mockUsers })
+    routeApiFetch({ '/admin/users': { users: mockUsers } })
 
     render(<AdminPage />)
 
@@ -214,7 +228,7 @@ describe('AdminPage', () => {
 
   it('should disable toggle button while API call is in progress', async () => {
     const user = userEvent.setup()
-    mockApiFetch.mockResolvedValueOnce({ users: mockUsers })
+    routeApiFetch({ '/admin/users': { users: mockUsers } })
 
     render(<AdminPage />)
 
@@ -232,7 +246,7 @@ describe('AdminPage', () => {
 
   it('should show error when toggle API call fails', async () => {
     const user = userEvent.setup()
-    mockApiFetch.mockResolvedValueOnce({ users: mockUsers })
+    routeApiFetch({ '/admin/users': { users: mockUsers } })
 
     render(<AdminPage />)
 
@@ -255,7 +269,10 @@ describe('AdminPage', () => {
   // Error Handling
   // ========================================
   it('should show error when user list fetch fails', async () => {
-    mockApiFetch.mockRejectedValueOnce(new Error('Server error'))
+    mockApiFetch.mockImplementation(async (path: string) => {
+      if (path === '/admin/invitations') return { invitations: [] }
+      throw new Error('Server error')
+    })
 
     render(<AdminPage />)
 
@@ -270,7 +287,7 @@ describe('AdminPage', () => {
   // Top Bar
   // ========================================
   it('should render top bar with logo link and avatar', async () => {
-    mockApiFetch.mockResolvedValueOnce({ users: mockUsers })
+    routeApiFetch({ '/admin/users': { users: mockUsers } })
 
     render(<AdminPage />)
 
@@ -284,12 +301,26 @@ describe('AdminPage', () => {
   })
 
   it('should call GET /admin/users on mount for admin', async () => {
-    mockApiFetch.mockResolvedValueOnce({ users: [] })
+    routeApiFetch({ '/admin/users': { users: [] } })
 
     render(<AdminPage />)
 
     await waitFor(() => {
       expect(mockApiFetch).toHaveBeenCalledWith('/admin/users')
     })
+  })
+
+  // ========================================
+  // Invitations Section integration
+  // ========================================
+  it('should render InvitationsSection for admin user', async () => {
+    routeApiFetch({ '/admin/users': { users: mockUsers } })
+
+    render(<AdminPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invitations-section')).toBeInTheDocument()
+    })
+    expect(mockApiFetch).toHaveBeenCalledWith('/admin/invitations')
   })
 })

--- a/src/features/admin/AdminPage.tsx
+++ b/src/features/admin/AdminPage.tsx
@@ -4,6 +4,7 @@ import { apiFetch } from '../../lib/api'
 import { useAuth } from '../../hooks/useAuth'
 import { UserMenuPanel } from '../../components/UserMenuPanel'
 import { LoadingSpinner } from '../../components/LoadingSpinner'
+import { InvitationsSection } from './InvitationsSection'
 import styles from './AdminPage.module.css'
 
 interface AdminUser {
@@ -167,6 +168,8 @@ export function AdminPage() {
             )}
           </div>
         )}
+
+        <InvitationsSection />
       </div>
     </div>
   )

--- a/src/features/admin/InvitationsSection.module.css
+++ b/src/features/admin/InvitationsSection.module.css
@@ -1,0 +1,162 @@
+.section {
+  margin-top: 48px;
+  padding-top: 24px;
+  border-top: 1px solid var(--color-border, #e5e7eb);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.title {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.primaryBtn,
+.secondaryBtn,
+.dangerBtn,
+.presetBtn {
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  border: 1px solid transparent;
+}
+
+.primaryBtn {
+  background: var(--color-accent, #7c5cfc);
+  color: white;
+}
+.primaryBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.secondaryBtn {
+  background: white;
+  border-color: var(--color-border, #d1d5db);
+  color: #374151;
+}
+
+.dangerBtn {
+  background: #dc2626;
+  color: white;
+}
+.dangerBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.presetBtn {
+  background: white;
+  border-color: #d1d5db;
+  color: #374151;
+}
+.presetActive {
+  background: #ede9fe;
+  border-color: #7c5cfc;
+  color: #5b21b6;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.table th,
+.table td {
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid #f3f4f6;
+}
+.codeCell {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+}
+.active {
+  background: #d1fae5;
+  color: #065f46;
+}
+.expired {
+  background: #e5e7eb;
+  color: #4b5563;
+}
+.revoked {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.empty {
+  color: #6b7280;
+  padding: 16px 0;
+}
+.error {
+  color: #dc2626;
+  margin-bottom: 12px;
+}
+
+.modalBackdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.modal {
+  background: white;
+  padding: 28px 32px;
+  border-radius: 12px;
+  min-width: 360px;
+  max-width: 480px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+}
+.modalTitle {
+  font-size: 18px;
+  margin: 0 0 16px;
+}
+.modalActions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 16px;
+}
+.presets {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.customInput {
+  padding: 8px 10px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  width: 90px;
+  font-size: 14px;
+}
+.issuedCode {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 28px;
+  font-weight: 700;
+  text-align: center;
+  padding: 16px;
+  background: #f3f4f6;
+  border-radius: 8px;
+  margin: 16px 0;
+  letter-spacing: 4px;
+}

--- a/src/features/admin/InvitationsSection.test.tsx
+++ b/src/features/admin/InvitationsSection.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import { InvitationsSection } from './InvitationsSection'
+import '../../i18n'
+
+const mockApiFetch = vi.fn()
+vi.mock('../../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/api')>('../../lib/api')
+  return { ...actual, apiFetch: (...args: unknown[]) => mockApiFetch(...args) }
+})
+
+describe('InvitationsSection', () => {
+  beforeEach(() => {
+    mockApiFetch.mockReset()
+  })
+  afterEach(cleanup)
+
+  it('renders empty state when no invitations', async () => {
+    mockApiFetch.mockResolvedValueOnce({ invitations: [] })
+    render(<InvitationsSection />)
+    await waitFor(() => expect(screen.getByTestId('invitations-empty')).toBeInTheDocument())
+  })
+
+  it('renders invitations with status badges', async () => {
+    mockApiFetch.mockResolvedValueOnce({
+      invitations: [
+        {
+          id: 1,
+          code: 'ACTIVE01',
+          expiresAt: '2099-01-01T00:00:00Z',
+          revokedAt: null,
+          createdAt: '2026-04-23T00:00:00Z',
+          createdBy: 'admin-1',
+          status: 'active',
+        },
+        {
+          id: 2,
+          code: 'EXPIRED1',
+          expiresAt: '2000-01-01T00:00:00Z',
+          revokedAt: null,
+          createdAt: '2026-04-22T00:00:00Z',
+          createdBy: 'admin-1',
+          status: 'expired',
+        },
+        {
+          id: 3,
+          code: 'REVOKED1',
+          expiresAt: '2099-01-01T00:00:00Z',
+          revokedAt: '2026-04-21T00:00:00Z',
+          createdAt: '2026-04-20T00:00:00Z',
+          createdBy: 'admin-1',
+          status: 'revoked',
+        },
+      ],
+    })
+    render(<InvitationsSection />)
+    await waitFor(() => expect(screen.getByText('ACTIVE01')).toBeInTheDocument())
+    expect(screen.getByText('EXPIRED1')).toBeInTheDocument()
+    expect(screen.getByText('REVOKED1')).toBeInTheDocument()
+    // revoke button only on active
+    expect(screen.getByTestId('revoke-btn-1')).toBeInTheDocument()
+    expect(screen.queryByTestId('revoke-btn-2')).toBeNull()
+    expect(screen.queryByTestId('revoke-btn-3')).toBeNull()
+  })
+
+  it('issues a code via modal and displays it after success', async () => {
+    mockApiFetch
+      .mockResolvedValueOnce({ invitations: [] }) // initial load
+      .mockResolvedValueOnce({
+        // POST /admin/invitations
+        id: 3,
+        code: 'NEWCOD01',
+        expiresAt: '2099-01-01T00:00:00Z',
+        revokedAt: null,
+        createdAt: '2026-04-23T00:00:00Z',
+        createdBy: 'admin-1',
+      })
+      .mockResolvedValueOnce({ invitations: [] }) // re-fetch after issue
+
+    render(<InvitationsSection />)
+    await waitFor(() => screen.getByTestId('invitations-create-btn'))
+    fireEvent.click(screen.getByTestId('invitations-create-btn'))
+    fireEvent.click(screen.getByTestId('preset-7'))
+    fireEvent.click(screen.getByTestId('invitations-issue-btn'))
+
+    await waitFor(() => expect(screen.getByTestId('issued-code')).toHaveTextContent('NEWCOD01'))
+
+    // POST body check
+    const postCall = mockApiFetch.mock.calls.find(
+      ([path, init]) => path === '/admin/invitations' && (init as RequestInit)?.method === 'POST',
+    )
+    expect(postCall).toBeTruthy()
+    const body = JSON.parse((postCall![1] as RequestInit).body as string)
+    expect(body).toEqual({ expiresInDays: 7 })
+  })
+
+  it('revokes an active code after confirm', async () => {
+    mockApiFetch
+      .mockResolvedValueOnce({
+        invitations: [
+          {
+            id: 1,
+            code: 'ACTIVE01',
+            expiresAt: '2099-01-01T00:00:00Z',
+            revokedAt: null,
+            createdAt: '2026-04-23T00:00:00Z',
+            createdBy: 'admin-1',
+            status: 'active',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ id: 1, revokedAt: '2026-04-23T01:00:00Z' }) // POST revoke
+      .mockResolvedValueOnce({ invitations: [] }) // re-fetch
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    render(<InvitationsSection />)
+    await waitFor(() => screen.getByTestId('revoke-btn-1'))
+    fireEvent.click(screen.getByTestId('revoke-btn-1'))
+
+    await waitFor(() => {
+      const revokeCall = mockApiFetch.mock.calls.find(
+        ([path, init]) =>
+          path === '/admin/invitations/1/revoke' && (init as RequestInit)?.method === 'POST',
+      )
+      expect(revokeCall).toBeTruthy()
+    })
+    confirmSpy.mockRestore()
+  })
+
+  it('shows load error when GET fails', async () => {
+    mockApiFetch.mockRejectedValueOnce(new Error('boom'))
+    render(<InvitationsSection />)
+    await waitFor(() => expect(screen.getByTestId('invitations-error')).toBeInTheDocument())
+  })
+})

--- a/src/features/admin/InvitationsSection.tsx
+++ b/src/features/admin/InvitationsSection.tsx
@@ -1,0 +1,250 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { apiFetch } from '../../lib/api'
+import styles from './InvitationsSection.module.css'
+
+interface Invitation {
+  id: number
+  code: string
+  expiresAt: string
+  revokedAt: string | null
+  createdAt: string
+  createdBy: string
+  status: 'active' | 'expired' | 'revoked'
+}
+
+export function InvitationsSection() {
+  const { t, i18n } = useTranslation(['admin'])
+  const [list, setList] = useState<Invitation[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [modalOpen, setModalOpen] = useState(false)
+  const [issuedCode, setIssuedCode] = useState<string | null>(null)
+  const [days, setDays] = useState(7)
+  const [submitting, setSubmitting] = useState(false)
+  const [revokingId, setRevokingId] = useState<number | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await apiFetch<{ invitations: Invitation[] }>('/admin/invitations')
+      setList(data.invitations)
+    } catch {
+      setError(t('admin:invitations.loadError'))
+    } finally {
+      setLoading(false)
+    }
+  }, [t])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const handleIssue = async () => {
+    setError(null)
+    try {
+      setSubmitting(true)
+      const res = await apiFetch<{ code: string }>('/admin/invitations', {
+        method: 'POST',
+        body: JSON.stringify({ expiresInDays: days }),
+      })
+      setIssuedCode(res.code)
+      await load()
+    } catch {
+      setError(t('admin:invitations.createError'))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleRevoke = async (id: number) => {
+    if (!window.confirm(t('admin:invitations.revokeConfirm'))) return
+    setError(null)
+    try {
+      setRevokingId(id)
+      await apiFetch(`/admin/invitations/${id}/revoke`, { method: 'POST' })
+      await load()
+    } catch {
+      setError(t('admin:invitations.revokeError'))
+    } finally {
+      setRevokingId(null)
+    }
+  }
+
+  const handleCopy = async (code: string) => {
+    try {
+      await navigator.clipboard.writeText(code)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // clipboard might be unavailable — ignore
+    }
+  }
+
+  const formatDate = (iso: string) => new Date(iso).toLocaleDateString(i18n.language)
+
+  return (
+    <section className={styles.section} data-testid="invitations-section">
+      <div className={styles.header}>
+        <h2 className={styles.title}>{t('admin:invitations.title')}</h2>
+        <button
+          type="button"
+          className={styles.primaryBtn}
+          onClick={() => {
+            setIssuedCode(null)
+            setDays(7)
+            setModalOpen(true)
+          }}
+          data-testid="invitations-create-btn"
+        >
+          {t('admin:invitations.create')}
+        </button>
+      </div>
+
+      {error && (
+        <div className={styles.error} data-testid="invitations-error">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <p data-testid="invitations-loading">...</p>
+      ) : list.length === 0 ? (
+        <p className={styles.empty} data-testid="invitations-empty">
+          {t('admin:invitations.empty')}
+        </p>
+      ) : (
+        <table className={styles.table} data-testid="invitations-table">
+          <thead>
+            <tr>
+              <th>{t('admin:invitations.columns.code')}</th>
+              <th>{t('admin:invitations.columns.expiresAt')}</th>
+              <th>{t('admin:invitations.columns.status')}</th>
+              <th>{t('admin:invitations.columns.actions')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {list.map((inv) => (
+              <tr key={inv.id} data-testid={`invitation-row-${inv.id}`}>
+                <td className={styles.codeCell}>{inv.code}</td>
+                <td>{formatDate(inv.expiresAt)}</td>
+                <td>
+                  <span className={`${styles.badge} ${styles[inv.status]}`}>
+                    {t(`admin:invitations.status.${inv.status}`)}
+                  </span>
+                </td>
+                <td>
+                  {inv.status === 'active' && (
+                    <button
+                      type="button"
+                      className={styles.dangerBtn}
+                      disabled={revokingId === inv.id}
+                      onClick={() => void handleRevoke(inv.id)}
+                      data-testid={`revoke-btn-${inv.id}`}
+                    >
+                      {t('admin:invitations.revoke')}
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {modalOpen && (
+        <div
+          className={styles.modalBackdrop}
+          onClick={() => setModalOpen(false)}
+          role="presentation"
+        >
+          <div
+            className={styles.modal}
+            onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            data-testid="invitations-modal"
+          >
+            {issuedCode ? (
+              <>
+                <h3 className={styles.modalTitle}>{t('admin:invitations.modal.title')}</h3>
+                <p>{t('admin:invitations.codeDisplayHint')}</p>
+                <div className={styles.issuedCode} data-testid="issued-code">
+                  {issuedCode}
+                </div>
+                <div className={styles.modalActions}>
+                  <button
+                    type="button"
+                    className={styles.primaryBtn}
+                    onClick={() => void handleCopy(issuedCode)}
+                    data-testid="issued-copy-btn"
+                  >
+                    {copied ? t('admin:invitations.copySuccess') : t('admin:invitations.copy')}
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.secondaryBtn}
+                    onClick={() => {
+                      setModalOpen(false)
+                      setIssuedCode(null)
+                    }}
+                  >
+                    {t('admin:invitations.modal.cancel')}
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <h3 className={styles.modalTitle}>{t('admin:invitations.modal.title')}</h3>
+                <p>{t('admin:invitations.modal.expiresInDays')}</p>
+                <div className={styles.presets}>
+                  {[7, 14, 30].map((d) => (
+                    <button
+                      key={d}
+                      type="button"
+                      className={`${styles.presetBtn} ${days === d ? styles.presetActive : ''}`}
+                      onClick={() => setDays(d)}
+                      data-testid={`preset-${d}`}
+                    >
+                      {t(`admin:invitations.modal.presets.${d}`)}
+                    </button>
+                  ))}
+                  <input
+                    type="number"
+                    min={1}
+                    max={365}
+                    value={days}
+                    onChange={(e) => setDays(Number(e.target.value))}
+                    className={styles.customInput}
+                    data-testid="custom-days-input"
+                    aria-label={t('admin:invitations.modal.custom')}
+                  />
+                </div>
+                <div className={styles.modalActions}>
+                  <button
+                    type="button"
+                    className={styles.primaryBtn}
+                    disabled={submitting}
+                    onClick={() => void handleIssue()}
+                    data-testid="invitations-issue-btn"
+                  >
+                    {t('admin:invitations.modal.issue')}
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.secondaryBtn}
+                    onClick={() => setModalOpen(false)}
+                  >
+                    {t('admin:invitations.modal.cancel')}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/features/editor/pages/DemoEditorPage.test.tsx
+++ b/src/features/editor/pages/DemoEditorPage.test.tsx
@@ -78,12 +78,13 @@ describe('DemoEditorPage', () => {
     expect(screen.queryByTestId('share-button')).toBeNull()
   })
 
-  it('should open auth modal (closed-beta notice) when CTA button is clicked', async () => {
+  it('should open auth modal with register form when CTA button is clicked', async () => {
     const user = userEvent.setup()
     render(<DemoEditorPage />)
     const ctaButton = screen.getByTestId('save-cta-button')
     await user.click(ctaButton)
-    // CTA opens modal in register mode, which now shows the closed-beta notice
-    expect(screen.getByTestId('closed-beta-notice')).toBeTruthy()
+    // CTA opens modal in register mode with invitation code + name fields
+    expect(screen.getByTestId('invitation-code-input')).toBeTruthy()
+    expect(screen.getByTestId('register-name-input')).toBeTruthy()
   })
 })

--- a/src/features/landing/LandingPage.test.tsx
+++ b/src/features/landing/LandingPage.test.tsx
@@ -59,11 +59,11 @@ describe('LandingPage', () => {
     expect(screen.getByTestId('auth-modal')).toBeInTheDocument()
   })
 
-  it('無料で始めるボタンクリックでAuthModalが新規登録モード（β案内）で表示される', async () => {
+  it('無料で始めるボタンクリックでAuthModalが新規登録モードで表示される', async () => {
     renderPage()
     fireEvent.click(screen.getAllByText(/brand\.ctaButton/)[0])
     expect(screen.getByTestId('auth-modal')).toBeInTheDocument()
-    expect(screen.getByTestId('closed-beta-notice')).toBeInTheDocument()
-    expect(screen.queryByPlaceholderText('form.name')).not.toBeInTheDocument()
+    expect(screen.getByTestId('invitation-code-input')).toBeInTheDocument()
+    expect(screen.getByTestId('register-name-input')).toBeInTheDocument()
   })
 })

--- a/src/features/landing/components/AuthModal.module.css
+++ b/src/features/landing/components/AuthModal.module.css
@@ -286,21 +286,8 @@
   font-family: inherit;
 }
 
-.closedBetaContainer {
-  text-align: center;
-  padding: 12px 0;
-}
-
-.closedBetaTitle {
-  font-size: 20px;
-  font-weight: 700;
-  color: #1a1a2e;
-  margin: 0 0 16px;
-}
-
-.closedBetaDescription {
-  font-size: 14px;
-  color: #64648c;
-  line-height: 1.6;
-  margin: 0 0 24px;
+.fieldHint {
+  font-size: 12px;
+  color: var(--color-text-secondary, #6b7280);
+  margin: 4px 0 0;
 }

--- a/src/features/landing/components/AuthModal.test.tsx
+++ b/src/features/landing/components/AuthModal.test.tsx
@@ -58,56 +58,7 @@ describe('AuthModal', () => {
     expect(screen.getByPlaceholderText('form.email')).toBeInTheDocument()
     expect(screen.getByPlaceholderText('form.password')).toBeInTheDocument()
     expect(screen.queryByPlaceholderText('form.name')).not.toBeInTheDocument()
-  })
-
-  it('registerモードではβ案内を表示しフォームは出さない', () => {
-    render(
-      <MemoryRouter>
-        <AuthModal isOpen={true} onClose={vi.fn()} initialMode="register" />
-      </MemoryRouter>,
-    )
-    expect(screen.getByTestId('closed-beta-notice')).toBeInTheDocument()
-    expect(screen.queryByPlaceholderText('form.name')).not.toBeInTheDocument()
-    expect(screen.queryByPlaceholderText('form.email')).not.toBeInTheDocument()
-    expect(screen.queryByPlaceholderText('form.password')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('auth-submit')).not.toBeInTheDocument()
-  })
-
-  it('β案内の「ログインへ」ボタン押下でloginモードに戻る', () => {
-    render(
-      <MemoryRouter>
-        <AuthModal isOpen={true} onClose={vi.fn()} initialMode="register" />
-      </MemoryRouter>,
-    )
-    fireEvent.click(screen.getByText('closedBeta.backToLogin'))
-    expect(screen.queryByTestId('closed-beta-notice')).not.toBeInTheDocument()
-    expect(screen.getByPlaceholderText('form.email')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('form.password')).toBeInTheDocument()
-  })
-
-  it('タブを register→login→register と切替えてもβ案内が復帰する', () => {
-    render(
-      <MemoryRouter>
-        <AuthModal isOpen={true} onClose={vi.fn()} initialMode="register" />
-      </MemoryRouter>,
-    )
-    expect(screen.getByTestId('closed-beta-notice')).toBeInTheDocument()
-    fireEvent.click(screen.getByText('login'))
-    expect(screen.queryByTestId('closed-beta-notice')).not.toBeInTheDocument()
-    fireEvent.click(screen.getByText('register'))
-    expect(screen.getByTestId('closed-beta-notice')).toBeInTheDocument()
-  })
-
-  it('タブクリックでregisterタブに切替えるとβ案内が表示される', () => {
-    render(
-      <MemoryRouter>
-        <AuthModal isOpen={true} onClose={vi.fn()} initialMode="login" />
-      </MemoryRouter>,
-    )
-    expect(screen.queryByTestId('closed-beta-notice')).not.toBeInTheDocument()
-    fireEvent.click(screen.getByText('register'))
-    expect(screen.getByTestId('closed-beta-notice')).toBeInTheDocument()
-    expect(screen.queryByPlaceholderText('form.name')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('invitation-code-input')).not.toBeInTheDocument()
   })
 
   it('ログイン成功時にonCloseが呼ばれ /flows に遷移する', async () => {
@@ -334,6 +285,134 @@ describe('AuthModal', () => {
 
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith('/flows')
+      })
+    })
+  })
+
+  describe('register mode with invitation code', () => {
+    it('shows invitation code and name fields in register tab', () => {
+      render(
+        <MemoryRouter>
+          <AuthModal isOpen={true} onClose={() => {}} initialMode="register" />
+        </MemoryRouter>,
+      )
+      expect(screen.getByTestId('invitation-code-input')).toBeInTheDocument()
+      expect(screen.getByTestId('register-name-input')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('form.email')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('form.password')).toBeInTheDocument()
+    })
+
+    it('hides Google button and divider in register mode', () => {
+      render(
+        <MemoryRouter>
+          <AuthModal isOpen={true} onClose={() => {}} initialMode="register" />
+        </MemoryRouter>,
+      )
+      expect(screen.queryByText(/Google/)).not.toBeInTheDocument()
+    })
+
+    it('normalizes invitation code on change (uppercase + strip spaces)', () => {
+      render(
+        <MemoryRouter>
+          <AuthModal isOpen={true} onClose={() => {}} initialMode="register" />
+        </MemoryRouter>,
+      )
+      const input = screen.getByTestId('invitation-code-input') as HTMLInputElement
+      fireEvent.change(input, { target: { value: ' abc 123 ' } })
+      expect(input.value).toBe('ABC123')
+    })
+
+    it('calls register with invitationCode and transitions to verify on success', async () => {
+      mockRegister.mockResolvedValueOnce({ needsVerification: true, email: 'new@x.com' })
+      render(
+        <MemoryRouter>
+          <AuthModal isOpen={true} onClose={() => {}} initialMode="register" />
+        </MemoryRouter>,
+      )
+      fireEvent.change(screen.getByTestId('invitation-code-input'), {
+        target: { value: 'VALID01' },
+      })
+      fireEvent.change(screen.getByTestId('register-name-input'), {
+        target: { value: 'New User' },
+      })
+      fireEvent.change(screen.getByPlaceholderText('form.email'), {
+        target: { value: 'new@x.com' },
+      })
+      fireEvent.change(screen.getByPlaceholderText('form.password'), {
+        target: { value: 'password123' },
+      })
+      fireEvent.click(screen.getByTestId('auth-submit'))
+      await waitFor(() =>
+        expect(mockRegister).toHaveBeenCalledWith(
+          'new@x.com',
+          'password123',
+          'New User',
+          'VALID01',
+        ),
+      )
+      await waitFor(() => {
+        expect(screen.getByText('verifyEmail.title')).toBeInTheDocument()
+        expect(screen.getByText('new@x.com')).toBeInTheDocument()
+      })
+    })
+
+    it('shows invalid code error inline when server returns INVITATION_INVALID', async () => {
+      mockRegister.mockRejectedValueOnce(
+        new ApiError(
+          400,
+          '招待コードが無効です。期限切れまたは誤ったコードです。',
+          'INVITATION_INVALID',
+        ),
+      )
+      render(
+        <MemoryRouter>
+          <AuthModal isOpen={true} onClose={() => {}} initialMode="register" />
+        </MemoryRouter>,
+      )
+      fireEvent.change(screen.getByTestId('invitation-code-input'), {
+        target: { value: 'BADCODE0' },
+      })
+      fireEvent.change(screen.getByTestId('register-name-input'), { target: { value: 'U' } })
+      fireEvent.change(screen.getByPlaceholderText('form.email'), {
+        target: { value: 'x@x.com' },
+      })
+      fireEvent.change(screen.getByPlaceholderText('form.password'), {
+        target: { value: 'password123' },
+      })
+      fireEvent.click(screen.getByTestId('auth-submit'))
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(
+          /invitationCode\.errors\.invalid|招待コードが無効/,
+        )
+      })
+    })
+
+    it('shows required error inline when server returns INVITATION_REQUIRED', async () => {
+      mockRegister.mockRejectedValueOnce(
+        new ApiError(400, '招待コードを入力してください', 'INVITATION_REQUIRED'),
+      )
+      render(
+        <MemoryRouter>
+          <AuthModal isOpen={true} onClose={() => {}} initialMode="register" />
+        </MemoryRouter>,
+      )
+      // Use spaces to hit server-side required check (client require is satisfied visually but
+      // we trust the mock to simulate the server rejection regardless)
+      fireEvent.change(screen.getByTestId('invitation-code-input'), {
+        target: { value: 'SOMECODE' },
+      })
+      fireEvent.change(screen.getByTestId('register-name-input'), { target: { value: 'U' } })
+      fireEvent.change(screen.getByPlaceholderText('form.email'), {
+        target: { value: 'x@x.com' },
+      })
+      fireEvent.change(screen.getByPlaceholderText('form.password'), {
+        target: { value: 'password123' },
+      })
+      fireEvent.click(screen.getByTestId('auth-submit'))
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(
+          /invitationCode\.errors\.required|招待コードを入力/,
+        )
       })
     })
   })

--- a/src/features/landing/components/AuthModal.test.tsx
+++ b/src/features/landing/components/AuthModal.test.tsx
@@ -387,6 +387,31 @@ describe('AuthModal', () => {
       })
     })
 
+    it('shows emailAlreadyExists error inline when server returns EMAIL_ALREADY_EXISTS', async () => {
+      mockRegister.mockRejectedValueOnce(
+        new ApiError(400, 'このメールアドレスは既に登録されています', 'EMAIL_ALREADY_EXISTS'),
+      )
+      render(
+        <MemoryRouter>
+          <AuthModal isOpen={true} onClose={() => {}} initialMode="register" />
+        </MemoryRouter>,
+      )
+      fireEvent.change(screen.getByTestId('invitation-code-input'), {
+        target: { value: 'VALID01' },
+      })
+      fireEvent.change(screen.getByTestId('register-name-input'), { target: { value: 'U' } })
+      fireEvent.change(screen.getByPlaceholderText('form.email'), {
+        target: { value: 'dup@x.com' },
+      })
+      fireEvent.change(screen.getByPlaceholderText('form.password'), {
+        target: { value: 'password123' },
+      })
+      fireEvent.click(screen.getByTestId('auth-submit'))
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(/emailAlreadyExists|既に登録/)
+      })
+    })
+
     it('shows required error inline when server returns INVITATION_REQUIRED', async () => {
       mockRegister.mockRejectedValueOnce(
         new ApiError(400, '招待コードを入力してください', 'INVITATION_REQUIRED'),

--- a/src/features/landing/components/AuthModal.tsx
+++ b/src/features/landing/components/AuthModal.tsx
@@ -17,12 +17,15 @@ interface AuthModalProps {
 export function AuthModal({ isOpen, onClose, initialMode, onSuccess }: AuthModalProps) {
   const navigate = useNavigate()
   const { t } = useTranslation(['auth', 'common'])
-  const { login, resendVerification } = useAuth()
+  const { login, register, resendVerification } = useAuth()
 
   const [mode, setMode] = useState<AuthMode>(initialMode)
+  const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [invitationCode, setInvitationCode] = useState('')
   const [verifyEmail, setVerifyEmail] = useState('')
+  const [verifySource, setVerifySource] = useState<'login' | 'register'>('login')
   const [error, setError] = useState<string | null>(null)
   const [info, setInfo] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
@@ -31,8 +34,10 @@ export function AuthModal({ isOpen, onClose, initialMode, onSuccess }: AuthModal
     setMode(newMode)
     setError(null)
     setInfo(null)
+    setName('')
     setEmail('')
     setPassword('')
+    setInvitationCode('')
   }, [])
 
   const [prevInitialMode, setPrevInitialMode] = useState(initialMode)
@@ -48,21 +53,44 @@ export function AuthModal({ isOpen, onClose, initialMode, onSuccess }: AuthModal
       setSubmitting(true)
 
       try {
-        await login(email, password)
-        onClose()
-        if (onSuccess) {
-          onSuccess()
+        if (mode === 'login') {
+          await login(email, password)
+          onClose()
+          if (onSuccess) {
+            onSuccess()
+          } else {
+            navigate('/flows')
+          }
         } else {
-          navigate('/flows')
+          const result = await register(email, password, name, invitationCode)
+          if (result.needsVerification) {
+            setVerifyEmail(result.email)
+            setVerifySource('register')
+            setMode('verify')
+            return
+          }
+          onClose()
+          if (onSuccess) {
+            onSuccess()
+          } else {
+            navigate('/flows')
+          }
         }
       } catch (err: unknown) {
-        if (err instanceof ApiError && err.status === 403) {
+        if (err instanceof ApiError && err.status === 403 && mode === 'login') {
           setVerifyEmail(email)
+          setVerifySource('login')
           setMode('verify')
           return
         }
         if (err instanceof ApiError) {
-          setError(err.message)
+          if (err.code === 'INVITATION_REQUIRED') {
+            setError(t('auth:invitationCode.errors.required'))
+          } else if (err.code === 'INVITATION_INVALID') {
+            setError(t('auth:invitationCode.errors.invalid'))
+          } else {
+            setError(err.message)
+          }
         } else if (err instanceof Error) {
           setError(err.message)
         } else {
@@ -72,7 +100,7 @@ export function AuthModal({ isOpen, onClose, initialMode, onSuccess }: AuthModal
         setSubmitting(false)
       }
     },
-    [email, password, login, onClose, navigate, onSuccess, t],
+    [mode, email, password, name, invitationCode, login, register, onClose, navigate, onSuccess, t],
   )
 
   const handleResend = useCallback(async () => {
@@ -162,21 +190,51 @@ export function AuthModal({ isOpen, onClose, initialMode, onSuccess }: AuthModal
             >
               {submitting ? t('auth:verifyEmail.resending') : t('auth:verifyEmail.resend')}
             </button>
-            <button type="button" className={styles.backLink} onClick={() => switchMode('login')}>
-              {t('auth:verifyEmail.backToLogin')}
-            </button>
-          </div>
-        ) : mode === 'register' ? (
-          <div className={styles.closedBetaContainer} data-testid="closed-beta-notice">
-            <h2 className={styles.closedBetaTitle}>{t('auth:closedBeta.title')}</h2>
-            <p className={styles.closedBetaDescription}>{t('auth:closedBeta.description')}</p>
-            <button type="button" className={styles.submitBtn} onClick={() => switchMode('login')}>
-              {t('auth:closedBeta.backToLogin')}
+            <button
+              type="button"
+              className={styles.backLink}
+              onClick={() => switchMode(verifySource)}
+            >
+              {verifySource === 'login'
+                ? t('auth:verifyEmail.backToLogin')
+                : t('auth:verifyEmail.changeEmail')}
             </button>
           </div>
         ) : (
           <>
             <form onSubmit={handleSubmit}>
+              {mode === 'register' && (
+                <>
+                  <div className={styles.field}>
+                    <input
+                      className={styles.input}
+                      type="text"
+                      placeholder={t('auth:invitationCode.placeholder')}
+                      value={invitationCode}
+                      onChange={(e) =>
+                        setInvitationCode(e.target.value.toUpperCase().replace(/\s/g, ''))
+                      }
+                      required
+                      data-testid="invitation-code-input"
+                      maxLength={32}
+                      autoComplete="off"
+                    />
+                    <p className={styles.fieldHint}>{t('auth:invitationCode.hint')}</p>
+                  </div>
+                  <div className={styles.field}>
+                    <input
+                      className={styles.input}
+                      type="text"
+                      placeholder={t('auth:form.name')}
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                      required
+                      data-testid="register-name-input"
+                    />
+                  </div>
+                </>
+              )}
+
               <div className={styles.field}>
                 <input
                   className={styles.input}
@@ -200,9 +258,11 @@ export function AuthModal({ isOpen, onClose, initialMode, onSuccess }: AuthModal
                 />
               </div>
 
-              <button type="button" className={styles.forgotLink} onClick={handleForgotClick}>
-                {t('auth:form.forgotPassword')}
-              </button>
+              {mode === 'login' && (
+                <button type="button" className={styles.forgotLink} onClick={handleForgotClick}>
+                  {t('auth:form.forgotPassword')}
+                </button>
+              )}
 
               <button
                 type="submit"
@@ -210,19 +270,26 @@ export function AuthModal({ isOpen, onClose, initialMode, onSuccess }: AuthModal
                 disabled={submitting}
                 data-testid="auth-submit"
               >
-                {submitting ? t('auth:form.processing') : t('auth:form.loginButton')}
+                {submitting
+                  ? t('auth:form.processing')
+                  : mode === 'login'
+                    ? t('auth:form.loginButton')
+                    : t('auth:form.registerButton')}
               </button>
             </form>
 
-            <div className={styles.divider}>
-              <span className={styles.dividerLine} />
-              <span>{t('common:or')}</span>
-              <span className={styles.dividerLine} />
-            </div>
-
-            <button className={styles.googleBtn} onClick={handleGoogleClick}>
-              {t('auth:form.continueWithGoogle')}
-            </button>
+            {mode === 'login' && (
+              <>
+                <div className={styles.divider}>
+                  <span className={styles.dividerLine} />
+                  <span>{t('common:or')}</span>
+                  <span className={styles.dividerLine} />
+                </div>
+                <button className={styles.googleBtn} onClick={handleGoogleClick}>
+                  {t('auth:form.continueWithGoogle')}
+                </button>
+              </>
+            )}
           </>
         )}
       </div>

--- a/src/features/landing/components/AuthModal.tsx
+++ b/src/features/landing/components/AuthModal.tsx
@@ -88,6 +88,8 @@ export function AuthModal({ isOpen, onClose, initialMode, onSuccess }: AuthModal
             setError(t('auth:invitationCode.errors.required'))
           } else if (err.code === 'INVITATION_INVALID') {
             setError(t('auth:invitationCode.errors.invalid'))
+          } else if (err.code === 'EMAIL_ALREADY_EXISTS') {
+            setError(t('auth:emailAlreadyExists'))
           } else {
             setError(err.message)
           }

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -248,4 +248,40 @@ describe('useAuth', () => {
 
     expect(result.current.user).toBeNull()
   })
+
+  describe('register', () => {
+    it('sends invitationCode in request body and returns needsVerification', async () => {
+      // Initial /auth/me call resolves with null user (not logged in)
+      mockApiFetch.mockResolvedValueOnce({ user: null })
+      // register call response
+      mockApiFetch.mockResolvedValueOnce({ message: 'ok' })
+
+      const { result } = renderHook(() => useAuth(), { wrapper })
+      await waitFor(() => expect(result.current.loading).toBe(false))
+
+      let res: { needsVerification: boolean; email: string } | undefined
+      await act(async () => {
+        res = await result.current.register(
+          'new@example.com',
+          'password123',
+          'New User',
+          'VALIDC01',
+        )
+      })
+
+      expect(res).toEqual({ needsVerification: true, email: 'new@example.com' })
+
+      const registerCall = mockApiFetch.mock.calls.find(
+        ([path]) => path === '/auth/register',
+      )
+      expect(registerCall).toBeTruthy()
+      const body = JSON.parse((registerCall![1] as RequestInit).body as string)
+      expect(body).toEqual({
+        email: 'new@example.com',
+        password: 'password123',
+        name: 'New User',
+        invitationCode: 'VALIDC01',
+      })
+    })
+  })
 })

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -133,6 +133,7 @@ describe('useAuth', () => {
         'test@example.com',
         'password123',
         'New User',
+        'INVITE42',
       )
       expect(registerResult).toEqual({ needsVerification: true, email: 'test@example.com' })
     })
@@ -145,6 +146,7 @@ describe('useAuth', () => {
         email: 'test@example.com',
         password: 'password123',
         name: 'New User',
+        invitationCode: 'INVITE42',
       }),
     })
   })

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -273,9 +273,7 @@ describe('useAuth', () => {
 
       expect(res).toEqual({ needsVerification: true, email: 'new@example.com' })
 
-      const registerCall = mockApiFetch.mock.calls.find(
-        ([path]) => path === '/auth/register',
-      )
+      const registerCall = mockApiFetch.mock.calls.find(([path]) => path === '/auth/register')
       expect(registerCall).toBeTruthy()
       const body = JSON.parse((registerCall![1] as RequestInit).body as string)
       expect(body).toEqual({

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -18,7 +18,12 @@ interface AuthContextValue {
   user: User | null
   loading: boolean
   login: (email: string, password: string) => Promise<User>
-  register: (email: string, password: string, name: string) => Promise<RegisterResult>
+  register: (
+    email: string,
+    password: string,
+    name: string,
+    invitationCode: string,
+  ) => Promise<RegisterResult>
   resendVerification: (email: string) => Promise<void>
   logout: () => Promise<void>
   refreshAuth: () => Promise<void>
@@ -60,10 +65,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     email: string,
     password: string,
     name: string,
+    invitationCode: string,
   ): Promise<RegisterResult> => {
     await apiFetch<{ message: string }>('/auth/register', {
       method: 'POST',
-      body: JSON.stringify({ email, password, name }),
+      body: JSON.stringify({ email, password, name, invitationCode }),
     })
     return { needsVerification: true, email }
   }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -9,6 +9,7 @@ import jaEditor from './locales/ja/editor.json'
 import jaSettings from './locales/ja/settings.json'
 import jaAuth from './locales/ja/auth.json'
 import jaShared from './locales/ja/shared.json'
+import jaAdmin from './locales/ja/admin.json'
 
 import enCommon from './locales/en/common.json'
 import enLanding from './locales/en/landing.json'
@@ -17,6 +18,7 @@ import enEditor from './locales/en/editor.json'
 import enSettings from './locales/en/settings.json'
 import enAuth from './locales/en/auth.json'
 import enShared from './locales/en/shared.json'
+import enAdmin from './locales/en/admin.json'
 
 i18n
   .use(LanguageDetector)
@@ -31,6 +33,7 @@ i18n
         settings: jaSettings,
         auth: jaAuth,
         shared: jaShared,
+        admin: jaAdmin,
       },
       en: {
         common: enCommon,
@@ -40,6 +43,7 @@ i18n
         settings: enSettings,
         auth: enAuth,
         shared: enShared,
+        admin: enAdmin,
       },
     },
     fallbackLng: 'ja',

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,10 +4,12 @@ const API_BASE = '/api'
 
 export class ApiError extends Error {
   status: number
+  code?: string
 
-  constructor(status: number, message: string) {
+  constructor(status: number, message: string, code?: string) {
     super(message)
     this.status = status
+    this.code = code
   }
 }
 
@@ -21,7 +23,8 @@ export async function apiFetch<T>(path: string, options?: RequestInit): Promise<
   })
   const data = await res.json()
   if (!res.ok) {
-    throw new ApiError(res.status, data.error ?? 'エラーが発生しました')
+    const body = data as { error?: string; code?: string }
+    throw new ApiError(res.status, body.error ?? 'エラーが発生しました', body.code)
   }
   return data as T
 }

--- a/src/locales/en/admin.json
+++ b/src/locales/en/admin.json
@@ -1,0 +1,30 @@
+{
+  "invitations": {
+    "title": "Invitation codes",
+    "create": "+ New",
+    "modal": {
+      "title": "Issue invitation code",
+      "expiresInDays": "Valid for (days)",
+      "presets": { "7": "7 days", "14": "14 days", "30": "30 days" },
+      "custom": "Custom",
+      "issue": "Issue",
+      "cancel": "Cancel"
+    },
+    "columns": {
+      "code": "Code",
+      "expiresAt": "Expires",
+      "status": "Status",
+      "actions": "Actions"
+    },
+    "status": { "active": "Active", "expired": "Expired", "revoked": "Revoked" },
+    "revoke": "Revoke",
+    "revokeConfirm": "Revoke this code?",
+    "copy": "Copy",
+    "copySuccess": "Copied",
+    "codeDisplayHint": "Distribute this code. It remains viewable in the list after closing.",
+    "empty": "No invitation codes yet",
+    "loadError": "Failed to load invitation codes",
+    "createError": "Failed to issue invitation code",
+    "revokeError": "Failed to revoke invitation code"
+  }
+}

--- a/src/locales/en/auth.json
+++ b/src/locales/en/auth.json
@@ -5,6 +5,7 @@
   "error": "An error occurred",
   "emailResent": "Verification email resent",
   "emailResendFailed": "Failed to resend",
+  "emailAlreadyExists": "This email address is already registered",
   "googleLoginPending": "Google login is coming soon",
   "passwordResetPending": "Password reset is coming soon",
   "invitationCode": {

--- a/src/locales/en/auth.json
+++ b/src/locales/en/auth.json
@@ -7,10 +7,14 @@
   "emailResendFailed": "Failed to resend",
   "googleLoginPending": "Google login is coming soon",
   "passwordResetPending": "Password reset is coming soon",
-  "closedBeta": {
-    "title": "Currently in closed beta",
-    "description": "New registration is not currently available. If you already have an account, please log in.",
-    "backToLogin": "Go to login"
+  "invitationCode": {
+    "label": "Invitation code",
+    "placeholder": "Enter your invitation code",
+    "hint": "* An invitation code is required",
+    "errors": {
+      "required": "Please enter an invitation code",
+      "invalid": "Invalid invitation code. It may be expired or incorrect."
+    }
   },
   "verifyEmail": {
     "title": "Check your email",
@@ -28,6 +32,7 @@
     "forgotPassword": "Forgot your password?",
     "processing": "Processing...",
     "loginButton": "Log in",
+    "registerButton": "Register",
     "createAccount": "Create account",
     "continueWithGoogle": "Continue with Google"
   },

--- a/src/locales/ja/admin.json
+++ b/src/locales/ja/admin.json
@@ -1,0 +1,30 @@
+{
+  "invitations": {
+    "title": "招待コード",
+    "create": "+ 新規発行",
+    "modal": {
+      "title": "招待コードを発行",
+      "expiresInDays": "有効日数",
+      "presets": { "7": "7日", "14": "14日", "30": "30日" },
+      "custom": "カスタム",
+      "issue": "発行",
+      "cancel": "キャンセル"
+    },
+    "columns": {
+      "code": "コード",
+      "expiresAt": "期限",
+      "status": "状態",
+      "actions": "操作"
+    },
+    "status": { "active": "有効", "expired": "期限切れ", "revoked": "無効化" },
+    "revoke": "無効化",
+    "revokeConfirm": "このコードを無効化しますか？",
+    "copy": "コピー",
+    "copySuccess": "コピーしました",
+    "codeDisplayHint": "このコードを配布してください。閉じた後も一覧から確認できます。",
+    "empty": "まだ招待コードが発行されていません",
+    "loadError": "招待コード一覧の取得に失敗しました",
+    "createError": "招待コードの発行に失敗しました",
+    "revokeError": "無効化に失敗しました"
+  }
+}

--- a/src/locales/ja/auth.json
+++ b/src/locales/ja/auth.json
@@ -7,10 +7,14 @@
   "emailResendFailed": "再送に失敗しました",
   "googleLoginPending": "Googleログインは準備中です",
   "passwordResetPending": "パスワードリセットは準備中です",
-  "closedBeta": {
-    "title": "現在はクローズドβテスト中です",
-    "description": "新規登録は現在受け付けておりません。既にアカウントをお持ちの方はログインしてください。",
-    "backToLogin": "ログイン画面へ"
+  "invitationCode": {
+    "label": "招待コード",
+    "placeholder": "招待コードを入力",
+    "hint": "※ 招待コードが必要です",
+    "errors": {
+      "required": "招待コードを入力してください",
+      "invalid": "招待コードが無効です。期限切れまたは誤ったコードです。"
+    }
   },
   "verifyEmail": {
     "title": "メールを確認してください",
@@ -28,6 +32,7 @@
     "forgotPassword": "パスワードをお忘れですか？",
     "processing": "処理中...",
     "loginButton": "ログイン",
+    "registerButton": "登録する",
     "createAccount": "アカウント作成",
     "continueWithGoogle": "Googleで続ける"
   },

--- a/src/locales/ja/auth.json
+++ b/src/locales/ja/auth.json
@@ -5,6 +5,7 @@
   "error": "エラーが発生しました",
   "emailResent": "確認メールを再送しました",
   "emailResendFailed": "再送に失敗しました",
+  "emailAlreadyExists": "このメールアドレスは既に登録されています",
   "googleLoginPending": "Googleログインは準備中です",
   "passwordResetPending": "パスワードリセットは準備中です",
   "invitationCode": {

--- a/tests/api/lib/invitation.test.ts
+++ b/tests/api/lib/invitation.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { createTestDb, createMockD1 } from '../../helpers/mock-d1'
+import {
+  normalizeInvitationCode,
+  validateInvitationCode,
+  generateInvitationCode,
+  CODE_CHARSET,
+} from '../../../api/lib/invitation'
+
+describe('normalizeInvitationCode', () => {
+  it('uppercases lowercase characters', () => {
+    expect(normalizeInvitationCode('abc123')).toBe('ABC123')
+  })
+  it('removes all whitespace', () => {
+    expect(normalizeInvitationCode(' a b c\t1\n2 3 ')).toBe('ABC123')
+  })
+  it('returns empty string for all-whitespace input', () => {
+    expect(normalizeInvitationCode('   ')).toBe('')
+  })
+  it('returns empty string for empty input', () => {
+    expect(normalizeInvitationCode('')).toBe('')
+  })
+})
+
+describe('generateInvitationCode', () => {
+  it('returns an 8-character string', () => {
+    expect(generateInvitationCode()).toHaveLength(8)
+  })
+  it('uses only characters from CODE_CHARSET', () => {
+    for (let i = 0; i < 100; i++) {
+      const code = generateInvitationCode()
+      for (const ch of code) {
+        expect(CODE_CHARSET).toContain(ch)
+      }
+    }
+  })
+  it('does not include confusing characters (0, O, 1, I, L)', () => {
+    for (let i = 0; i < 100; i++) {
+      expect(generateInvitationCode()).not.toMatch(/[0O1IL]/)
+    }
+  })
+  it('produces different codes on successive calls', () => {
+    const codes = new Set<string>()
+    for (let i = 0; i < 20; i++) codes.add(generateInvitationCode())
+    expect(codes.size).toBeGreaterThan(18)
+  })
+})
+
+describe('validateInvitationCode', () => {
+  let db: ReturnType<typeof Database>
+  let d1: ReturnType<typeof createMockD1>
+
+  beforeEach(() => {
+    db = createTestDb()
+    d1 = createMockD1(db)
+    db.prepare(
+      `INSERT INTO users (id, email, password_hash, name, role)
+       VALUES ('admin-1', 'admin@example.com', 'hash', 'Admin', 'admin')`,
+    ).run()
+  })
+  afterEach(() => db.close())
+
+  function insertCode(
+    code: string,
+    opts: { expiresAt?: string; revokedAt?: string | null } = {},
+  ) {
+    const expiresAt = opts.expiresAt ?? '2099-01-01T00:00:00Z'
+    const revokedAt = opts.revokedAt ?? null
+    db.prepare(
+      `INSERT INTO invitation_codes (code, expires_at, revoked_at, created_by)
+       VALUES (?, ?, ?, 'admin-1')`,
+    ).run(code, expiresAt, revokedAt)
+  }
+
+  it('returns true for active, not-revoked, not-expired code', async () => {
+    insertCode('ABCDEFGH')
+    expect(await validateInvitationCode(d1, 'ABCDEFGH')).toBe(true)
+  })
+  it('returns false for expired code', async () => {
+    insertCode('EXPIRED1', { expiresAt: '2000-01-01T00:00:00Z' })
+    expect(await validateInvitationCode(d1, 'EXPIRED1')).toBe(false)
+  })
+  it('returns false for revoked code', async () => {
+    insertCode('REVOKED1', { revokedAt: '2026-01-01T00:00:00Z' })
+    expect(await validateInvitationCode(d1, 'REVOKED1')).toBe(false)
+  })
+  it('returns false for non-existent code', async () => {
+    expect(await validateInvitationCode(d1, 'NOSUCH99')).toBe(false)
+  })
+  it('returns true after normalizing mixed-case + whitespace input', async () => {
+    insertCode('ABCDEFGH')
+    expect(await validateInvitationCode(d1, ' abc defgh ')).toBe(true)
+  })
+  it('returns false for empty input', async () => {
+    expect(await validateInvitationCode(d1, '')).toBe(false)
+  })
+  it('returns false for whitespace-only input', async () => {
+    expect(await validateInvitationCode(d1, '   ')).toBe(false)
+  })
+})

--- a/tests/api/lib/invitation.test.ts
+++ b/tests/api/lib/invitation.test.ts
@@ -61,10 +61,7 @@ describe('validateInvitationCode', () => {
   })
   afterEach(() => db.close())
 
-  function insertCode(
-    code: string,
-    opts: { expiresAt?: string; revokedAt?: string | null } = {},
-  ) {
+  function insertCode(code: string, opts: { expiresAt?: string; revokedAt?: string | null } = {}) {
     const expiresAt = opts.expiresAt ?? '2099-01-01T00:00:00Z'
     const revokedAt = opts.revokedAt ?? null
     db.prepare(

--- a/tests/api/routes/admin.test.ts
+++ b/tests/api/routes/admin.test.ts
@@ -255,4 +255,79 @@ describe('Admin API', () => {
       expect(res2.status).toBe(200)
     })
   })
+
+  // ========================================
+  // POST /api/admin/invitations
+  // ========================================
+  describe('POST /api/admin/invitations', () => {
+    function postJson(path: string, body: unknown, env: object, cookie?: string) {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (cookie) headers['Cookie'] = cookie
+      return app.request(
+        path,
+        { method: 'POST', headers, body: JSON.stringify(body) },
+        env,
+      )
+    }
+
+    it('returns 401 when no auth cookie', async () => {
+      const res = await postJson('/api/admin/invitations', { expiresInDays: 7 }, env)
+      expect(res.status).toBe(401)
+    })
+    it('returns 403 when non-admin', async () => {
+      const res = await postJson(
+        '/api/admin/invitations',
+        { expiresInDays: 7 },
+        env,
+        userCookie,
+      )
+      expect(res.status).toBe(403)
+    })
+    it('returns 400 when expiresInDays missing', async () => {
+      const res = await postJson('/api/admin/invitations', {}, env, adminCookie)
+      expect(res.status).toBe(400)
+    })
+    it('returns 400 when expiresInDays is 0', async () => {
+      const res = await postJson(
+        '/api/admin/invitations',
+        { expiresInDays: 0 },
+        env,
+        adminCookie,
+      )
+      expect(res.status).toBe(400)
+    })
+    it('returns 400 when expiresInDays > 365', async () => {
+      const res = await postJson(
+        '/api/admin/invitations',
+        { expiresInDays: 366 },
+        env,
+        adminCookie,
+      )
+      expect(res.status).toBe(400)
+    })
+    it('creates a code and returns 201 with code data', async () => {
+      const res = await postJson(
+        '/api/admin/invitations',
+        { expiresInDays: 30 },
+        env,
+        adminCookie,
+      )
+      expect(res.status).toBe(201)
+      const body = (await res.json()) as {
+        id: number
+        code: string
+        expiresAt: string
+        revokedAt: string | null
+        createdAt: string
+        createdBy: string
+      }
+      expect(body.code).toMatch(/^[23456789ABCDEFGHJKMNPQRSTUVWXYZ]{8}$/)
+      expect(body.revokedAt).toBeNull()
+      expect(body.createdBy).toBe(ADMIN_ID)
+      const row = db
+        .prepare('SELECT code FROM invitation_codes WHERE id = ?')
+        .get(body.id) as { code: string }
+      expect(row.code).toBe(body.code)
+    })
+  })
 })

--- a/tests/api/routes/admin.test.ts
+++ b/tests/api/routes/admin.test.ts
@@ -263,11 +263,7 @@ describe('Admin API', () => {
     function postJson(path: string, body: unknown, env: object, cookie?: string) {
       const headers: Record<string, string> = { 'Content-Type': 'application/json' }
       if (cookie) headers['Cookie'] = cookie
-      return app.request(
-        path,
-        { method: 'POST', headers, body: JSON.stringify(body) },
-        env,
-      )
+      return app.request(path, { method: 'POST', headers, body: JSON.stringify(body) }, env)
     }
 
     it('returns 401 when no auth cookie', async () => {
@@ -275,12 +271,7 @@ describe('Admin API', () => {
       expect(res.status).toBe(401)
     })
     it('returns 403 when non-admin', async () => {
-      const res = await postJson(
-        '/api/admin/invitations',
-        { expiresInDays: 7 },
-        env,
-        userCookie,
-      )
+      const res = await postJson('/api/admin/invitations', { expiresInDays: 7 }, env, userCookie)
       expect(res.status).toBe(403)
     })
     it('returns 400 when expiresInDays missing', async () => {
@@ -288,30 +279,15 @@ describe('Admin API', () => {
       expect(res.status).toBe(400)
     })
     it('returns 400 when expiresInDays is 0', async () => {
-      const res = await postJson(
-        '/api/admin/invitations',
-        { expiresInDays: 0 },
-        env,
-        adminCookie,
-      )
+      const res = await postJson('/api/admin/invitations', { expiresInDays: 0 }, env, adminCookie)
       expect(res.status).toBe(400)
     })
     it('returns 400 when expiresInDays > 365', async () => {
-      const res = await postJson(
-        '/api/admin/invitations',
-        { expiresInDays: 366 },
-        env,
-        adminCookie,
-      )
+      const res = await postJson('/api/admin/invitations', { expiresInDays: 366 }, env, adminCookie)
       expect(res.status).toBe(400)
     })
     it('creates a code and returns 201 with code data', async () => {
-      const res = await postJson(
-        '/api/admin/invitations',
-        { expiresInDays: 30 },
-        env,
-        adminCookie,
-      )
+      const res = await postJson('/api/admin/invitations', { expiresInDays: 30 }, env, adminCookie)
       expect(res.status).toBe(201)
       const body = (await res.json()) as {
         id: number
@@ -324,9 +300,9 @@ describe('Admin API', () => {
       expect(body.code).toMatch(/^[23456789ABCDEFGHJKMNPQRSTUVWXYZ]{8}$/)
       expect(body.revokedAt).toBeNull()
       expect(body.createdBy).toBe(ADMIN_ID)
-      const row = db
-        .prepare('SELECT code FROM invitation_codes WHERE id = ?')
-        .get(body.id) as { code: string }
+      const row = db.prepare('SELECT code FROM invitation_codes WHERE id = ?').get(body.id) as {
+        code: string
+      }
       expect(row.code).toBe(body.code)
     })
   })
@@ -378,11 +354,7 @@ describe('Admin API', () => {
     function postJson(path: string, body: unknown, env: object, cookie?: string) {
       const headers: Record<string, string> = { 'Content-Type': 'application/json' }
       if (cookie) headers['Cookie'] = cookie
-      return app.request(
-        path,
-        { method: 'POST', headers, body: JSON.stringify(body) },
-        env,
-      )
+      return app.request(path, { method: 'POST', headers, body: JSON.stringify(body) }, env)
     }
 
     it('returns 403 for non-admin', async () => {
@@ -390,12 +362,7 @@ describe('Admin API', () => {
       expect(res.status).toBe(403)
     })
     it('returns 404 for non-existent id', async () => {
-      const res = await postJson(
-        '/api/admin/invitations/9999/revoke',
-        {},
-        env,
-        adminCookie,
-      )
+      const res = await postJson('/api/admin/invitations/9999/revoke', {}, env, adminCookie)
       expect(res.status).toBe(404)
     })
     it('revokes an active code and returns 200 with revokedAt', async () => {
@@ -403,16 +370,11 @@ describe('Admin API', () => {
         `INSERT INTO invitation_codes (code, expires_at, created_by)
          VALUES (?, ?, ?)`,
       ).run('ACTIVE02', '2099-01-01T00:00:00Z', ADMIN_ID)
-      const row = db.prepare('SELECT id FROM invitation_codes WHERE code = ?').get(
-        'ACTIVE02',
-      ) as { id: number }
+      const row = db.prepare('SELECT id FROM invitation_codes WHERE code = ?').get('ACTIVE02') as {
+        id: number
+      }
 
-      const res = await postJson(
-        `/api/admin/invitations/${row.id}/revoke`,
-        {},
-        env,
-        adminCookie,
-      )
+      const res = await postJson(`/api/admin/invitations/${row.id}/revoke`, {}, env, adminCookie)
       expect(res.status).toBe(200)
       const body = (await res.json()) as { id: number; revokedAt: string }
       expect(body.id).toBe(row.id)
@@ -427,16 +389,11 @@ describe('Admin API', () => {
         `INSERT INTO invitation_codes (code, expires_at, revoked_at, created_by)
          VALUES (?, ?, ?, ?)`,
       ).run('REVOKED2', '2099-01-01T00:00:00Z', '2026-01-01T00:00:00Z', ADMIN_ID)
-      const row = db.prepare('SELECT id FROM invitation_codes WHERE code = ?').get(
-        'REVOKED2',
-      ) as { id: number }
+      const row = db.prepare('SELECT id FROM invitation_codes WHERE code = ?').get('REVOKED2') as {
+        id: number
+      }
 
-      const res = await postJson(
-        `/api/admin/invitations/${row.id}/revoke`,
-        {},
-        env,
-        adminCookie,
-      )
+      const res = await postJson(`/api/admin/invitations/${row.id}/revoke`, {}, env, adminCookie)
       expect(res.status).toBe(409)
     })
   })

--- a/tests/api/routes/admin.test.ts
+++ b/tests/api/routes/admin.test.ts
@@ -370,4 +370,74 @@ describe('Admin API', () => {
       expect(byCode.REVOKED1).toBe('revoked')
     })
   })
+
+  // ========================================
+  // POST /api/admin/invitations/:id/revoke
+  // ========================================
+  describe('POST /api/admin/invitations/:id/revoke', () => {
+    function postJson(path: string, body: unknown, env: object, cookie?: string) {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (cookie) headers['Cookie'] = cookie
+      return app.request(
+        path,
+        { method: 'POST', headers, body: JSON.stringify(body) },
+        env,
+      )
+    }
+
+    it('returns 403 for non-admin', async () => {
+      const res = await postJson('/api/admin/invitations/1/revoke', {}, env, userCookie)
+      expect(res.status).toBe(403)
+    })
+    it('returns 404 for non-existent id', async () => {
+      const res = await postJson(
+        '/api/admin/invitations/9999/revoke',
+        {},
+        env,
+        adminCookie,
+      )
+      expect(res.status).toBe(404)
+    })
+    it('revokes an active code and returns 200 with revokedAt', async () => {
+      db.prepare(
+        `INSERT INTO invitation_codes (code, expires_at, created_by)
+         VALUES (?, ?, ?)`,
+      ).run('ACTIVE02', '2099-01-01T00:00:00Z', ADMIN_ID)
+      const row = db.prepare('SELECT id FROM invitation_codes WHERE code = ?').get(
+        'ACTIVE02',
+      ) as { id: number }
+
+      const res = await postJson(
+        `/api/admin/invitations/${row.id}/revoke`,
+        {},
+        env,
+        adminCookie,
+      )
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { id: number; revokedAt: string }
+      expect(body.id).toBe(row.id)
+      expect(body.revokedAt).toBeTruthy()
+      const after = db
+        .prepare('SELECT revoked_at FROM invitation_codes WHERE id = ?')
+        .get(row.id) as { revoked_at: string }
+      expect(after.revoked_at).toBeTruthy()
+    })
+    it('returns 409 when already revoked', async () => {
+      db.prepare(
+        `INSERT INTO invitation_codes (code, expires_at, revoked_at, created_by)
+         VALUES (?, ?, ?, ?)`,
+      ).run('REVOKED2', '2099-01-01T00:00:00Z', '2026-01-01T00:00:00Z', ADMIN_ID)
+      const row = db.prepare('SELECT id FROM invitation_codes WHERE code = ?').get(
+        'REVOKED2',
+      ) as { id: number }
+
+      const res = await postJson(
+        `/api/admin/invitations/${row.id}/revoke`,
+        {},
+        env,
+        adminCookie,
+      )
+      expect(res.status).toBe(409)
+    })
+  })
 })

--- a/tests/api/routes/admin.test.ts
+++ b/tests/api/routes/admin.test.ts
@@ -330,4 +330,44 @@ describe('Admin API', () => {
       expect(row.code).toBe(body.code)
     })
   })
+
+  // ========================================
+  // GET /api/admin/invitations
+  // ========================================
+  describe('GET /api/admin/invitations', () => {
+    it('returns 403 for non-admin', async () => {
+      const res = await getWithCookie('/api/admin/invitations', env, userCookie)
+      expect(res.status).toBe(403)
+    })
+    it('returns empty list when no codes', async () => {
+      const res = await getWithCookie('/api/admin/invitations', env, adminCookie)
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { invitations: unknown[] }
+      expect(body.invitations).toEqual([])
+    })
+    it('returns codes with computed status (active/expired/revoked)', async () => {
+      db.prepare(
+        `INSERT INTO invitation_codes (code, expires_at, revoked_at, created_by)
+         VALUES (?, ?, ?, ?)`,
+      ).run('ACTIVE01', '2099-01-01T00:00:00Z', null, ADMIN_ID)
+      db.prepare(
+        `INSERT INTO invitation_codes (code, expires_at, revoked_at, created_by)
+         VALUES (?, ?, ?, ?)`,
+      ).run('EXPIRED1', '2000-01-01T00:00:00Z', null, ADMIN_ID)
+      db.prepare(
+        `INSERT INTO invitation_codes (code, expires_at, revoked_at, created_by)
+         VALUES (?, ?, ?, ?)`,
+      ).run('REVOKED1', '2099-01-01T00:00:00Z', '2026-01-01T00:00:00Z', ADMIN_ID)
+
+      const res = await getWithCookie('/api/admin/invitations', env, adminCookie)
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as {
+        invitations: Array<{ code: string; status: string }>
+      }
+      const byCode = Object.fromEntries(body.invitations.map((i) => [i.code, i.status]))
+      expect(byCode.ACTIVE01).toBe('active')
+      expect(byCode.EXPIRED1).toBe('expired')
+      expect(byCode.REVOKED1).toBe('revoked')
+    })
+  })
 })

--- a/tests/api/routes/admin.test.ts
+++ b/tests/api/routes/admin.test.ts
@@ -47,6 +47,12 @@ function putJson(path: string, body: unknown, env: object, cookie?: string) {
   )
 }
 
+function postJson(path: string, body: unknown, env: object, cookie?: string) {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (cookie) headers['Cookie'] = cookie
+  return app.request(path, { method: 'POST', headers, body: JSON.stringify(body) }, env)
+}
+
 describe('Admin API', () => {
   let db: ReturnType<typeof Database>
   let env: ReturnType<typeof createEnv>
@@ -260,12 +266,6 @@ describe('Admin API', () => {
   // POST /api/admin/invitations
   // ========================================
   describe('POST /api/admin/invitations', () => {
-    function postJson(path: string, body: unknown, env: object, cookie?: string) {
-      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-      if (cookie) headers['Cookie'] = cookie
-      return app.request(path, { method: 'POST', headers, body: JSON.stringify(body) }, env)
-    }
-
     it('returns 401 when no auth cookie', async () => {
       const res = await postJson('/api/admin/invitations', { expiresInDays: 7 }, env)
       expect(res.status).toBe(401)
@@ -351,12 +351,6 @@ describe('Admin API', () => {
   // POST /api/admin/invitations/:id/revoke
   // ========================================
   describe('POST /api/admin/invitations/:id/revoke', () => {
-    function postJson(path: string, body: unknown, env: object, cookie?: string) {
-      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-      if (cookie) headers['Cookie'] = cookie
-      return app.request(path, { method: 'POST', headers, body: JSON.stringify(body) }, env)
-    }
-
     it('returns 403 for non-admin', async () => {
       const res = await postJson('/api/admin/invitations/1/revoke', {}, env, userCookie)
       expect(res.status).toBe(403)

--- a/tests/api/routes/auth.test.ts
+++ b/tests/api/routes/auth.test.ts
@@ -53,56 +53,124 @@ describe('Auth API', () => {
     db.close()
   })
 
-  // === Registration (Closed Beta: disabled, returns 503) ===
-  describe('POST /api/auth/register', () => {
-    it('should return 503 with closed-beta message', async () => {
-      const res = await postJson(
-        '/api/auth/register',
-        { email: 'test@example.com', password: 'password123', name: 'Test' },
-        env,
-      )
-      expect(res.status).toBe(503)
-      const body = await res.json()
-      expect(body.error).toBe('現在はクローズドβテスト中です')
-    })
+  // === Registration (with invitation code) ===
+  describe('POST /api/auth/register (with invitation code)', () => {
+    function insertValidInvite(code: string = 'VALIDC01', inviterId: string = 'inviter-admin-1') {
+      db.prepare(
+        `INSERT OR IGNORE INTO users (id, email, password_hash, name, role)
+         VALUES (?, ?, 'hash', 'Inviter', 'admin')`,
+      ).run(inviterId, `${inviterId}@example.com`)
+      db.prepare(
+        `INSERT INTO invitation_codes (code, expires_at, created_by)
+         VALUES (?, ?, ?)`,
+      ).run(code, '2099-01-01T00:00:00Z', inviterId)
+      return code
+    }
 
-    it('should return 503 even with empty body', async () => {
-      const res = await postJson('/api/auth/register', {}, env)
-      expect(res.status).toBe(503)
-      const body = await res.json()
-      expect(body.error).toBe('現在はクローズドβテスト中です')
-    })
-
-    it('should return 503 for malformed JSON body', async () => {
-      const res = await app.request(
+    async function registerRequest(body: Record<string, unknown>) {
+      return app.request(
         '/api/auth/register',
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: 'not-json',
+          body: JSON.stringify(body),
         },
         env,
       )
-      expect(res.status).toBe(503)
+    }
+
+    it('returns 400 INVITATION_REQUIRED when code missing', async () => {
+      const res = await registerRequest({
+        email: 'new@example.com',
+        password: 'password123',
+        name: 'New',
+      })
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { code?: string }
+      expect(body.code).toBe('INVITATION_REQUIRED')
     })
 
-    it('should NOT create a user in DB when register is called', async () => {
-      await postJson(
-        '/api/auth/register',
-        { email: 'never@example.com', password: 'password123', name: 'Never' },
-        env,
-      )
-      const user = db.prepare('SELECT id FROM users WHERE email = ?').get('never@example.com')
-      expect(user).toBeUndefined()
+    it('returns 400 INVITATION_INVALID when code does not exist', async () => {
+      const res = await registerRequest({
+        email: 'new@example.com',
+        password: 'password123',
+        name: 'New',
+        invitationCode: 'NOSUCH99',
+      })
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { code?: string }
+      expect(body.code).toBe('INVITATION_INVALID')
     })
 
-    it('should NOT set auth_token cookie', async () => {
-      const res = await postJson(
-        '/api/auth/register',
-        { email: 'test@example.com', password: 'password123', name: 'Test' },
-        env,
-      )
-      expect(res.headers.get('set-cookie')).toBeNull()
+    it('returns 400 INVITATION_INVALID for expired code', async () => {
+      db.prepare(
+        `INSERT OR IGNORE INTO users (id, email, password_hash, name, role)
+         VALUES ('exp-admin', 'exp@example.com', 'hash', 'Exp', 'admin')`,
+      ).run()
+      db.prepare(
+        `INSERT INTO invitation_codes (code, expires_at, created_by)
+         VALUES ('EXPIRED2', '2000-01-01T00:00:00Z', 'exp-admin')`,
+      ).run()
+      const res = await registerRequest({
+        email: 'new@example.com',
+        password: 'password123',
+        name: 'New',
+        invitationCode: 'EXPIRED2',
+      })
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { code?: string }
+      expect(body.code).toBe('INVITATION_INVALID')
+    })
+
+    it('returns 400 INVITATION_INVALID for revoked code', async () => {
+      db.prepare(
+        `INSERT OR IGNORE INTO users (id, email, password_hash, name, role)
+         VALUES ('rev-admin', 'rev@example.com', 'hash', 'Rev', 'admin')`,
+      ).run()
+      db.prepare(
+        `INSERT INTO invitation_codes (code, expires_at, revoked_at, created_by)
+         VALUES ('REVOKED3', '2099-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 'rev-admin')`,
+      ).run()
+      const res = await registerRequest({
+        email: 'new@example.com',
+        password: 'password123',
+        name: 'New',
+        invitationCode: 'REVOKED3',
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 200 and creates user when code valid', async () => {
+      insertValidInvite('VALIDC01')
+      const res = await registerRequest({
+        email: 'new@example.com',
+        password: 'password123',
+        name: 'New User',
+        invitationCode: 'VALIDC01',
+      })
+      expect(res.status).toBe(200)
+      const row = db
+        .prepare('SELECT email, email_verified FROM users WHERE email = ?')
+        .get('new@example.com') as { email: string; email_verified: number }
+      expect(row.email).toBe('new@example.com')
+      expect(row.email_verified).toBe(0)
+    })
+
+    it('allows multiple users to register with the same valid code (unlimited uses)', async () => {
+      insertValidInvite('SHARED01')
+      for (const [i, email] of [
+        [0, 'a@example.com'],
+        [1, 'b@example.com'],
+        [2, 'c@example.com'],
+      ] as const) {
+        const res = await registerRequest({
+          email,
+          password: 'password123',
+          name: `U${i}`,
+          invitationCode: 'SHARED01',
+        })
+        expect(res.status).toBe(200)
+      }
     })
   })
 

--- a/tests/api/routes/auth.test.ts
+++ b/tests/api/routes/auth.test.ts
@@ -90,6 +90,37 @@ describe('Auth API', () => {
       expect(body.code).toBe('INVITATION_REQUIRED')
     })
 
+    it('returns 400 INVITATION_REQUIRED when invitationCode is non-string (type guard)', async () => {
+      // ランタイム型チェックが無いと、オブジェクトを渡した時 .trim() で 500 になる
+      const res = await registerRequest({
+        email: 'new@example.com',
+        password: 'password123',
+        name: 'New',
+        invitationCode: {},
+      })
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { code?: string }
+      expect(body.code).toBe('INVITATION_REQUIRED')
+    })
+
+    it('returns 400 when password exceeds 72 bytes (bcrypt limit)', async () => {
+      db.prepare(
+        `INSERT OR IGNORE INTO users (id, email, password_hash, name, role)
+         VALUES ('inviter-bcrypt', 'bcrypt@example.com', 'hash', 'BC', 'admin')`,
+      ).run()
+      db.prepare(
+        `INSERT INTO invitation_codes (code, expires_at, created_by)
+         VALUES ('BCRYPT01', '2099-01-01T00:00:00Z', 'inviter-bcrypt')`,
+      ).run()
+      const res = await registerRequest({
+        email: 'new@example.com',
+        password: 'a'.repeat(73),
+        name: 'New',
+        invitationCode: 'BCRYPT01',
+      })
+      expect(res.status).toBe(400)
+    })
+
     it('returns 400 INVITATION_INVALID when code does not exist', async () => {
       const res = await registerRequest({
         email: 'new@example.com',

--- a/tests/db/migration.test.ts
+++ b/tests/db/migration.test.ts
@@ -132,6 +132,41 @@ describe('D1 Migration', () => {
     expect(flows).toHaveLength(2)
   })
 
+  it('should create invitation_codes table (0009)', () => {
+    const db = new Database(':memory:')
+    db.pragma('foreign_keys = ON')
+    const files = [
+      '0001_initial.sql',
+      '0002_node_arrow_styles.sql',
+      '0003_user_settings.sql',
+      '0004_email_verification.sql',
+      '0005_soft_delete.sql',
+      '0006_ai_admin.sql',
+      '0007_node_shape.sql',
+      '0008_projects.sql',
+      '0009_invitation_codes.sql',
+    ]
+    for (const f of files) {
+      const sql = readFileSync(resolve(__dirname, '../../migrations/', f), 'utf-8')
+      for (const stmt of sql.split(';').filter((s) => s.trim())) {
+        db.exec(stmt + ';')
+      }
+    }
+    const cols = db
+      .prepare("PRAGMA table_info(invitation_codes)")
+      .all() as Array<{ name: string; type: string }>
+    const names = cols.map((c) => c.name).sort()
+    expect(names).toEqual([
+      'code',
+      'created_at',
+      'created_by',
+      'expires_at',
+      'id',
+      'revoked_at',
+    ])
+    db.close()
+  })
+
   it('should have created_at and updated_at on all tables', () => {
     db.prepare(
       "INSERT INTO users (id, email, password_hash, name) VALUES ('u1', 'ts@test.com', 'hash', 'Test')",

--- a/tests/db/migration.test.ts
+++ b/tests/db/migration.test.ts
@@ -152,18 +152,12 @@ describe('D1 Migration', () => {
         db.exec(stmt + ';')
       }
     }
-    const cols = db
-      .prepare("PRAGMA table_info(invitation_codes)")
-      .all() as Array<{ name: string; type: string }>
+    const cols = db.prepare('PRAGMA table_info(invitation_codes)').all() as Array<{
+      name: string
+      type: string
+    }>
     const names = cols.map((c) => c.name).sort()
-    expect(names).toEqual([
-      'code',
-      'created_at',
-      'created_by',
-      'expires_at',
-      'id',
-      'revoked_at',
-    ])
+    expect(names).toEqual(['code', 'created_at', 'created_by', 'expires_at', 'id', 'revoked_at'])
     db.close()
   })
 

--- a/tests/helpers/mock-d1.ts
+++ b/tests/helpers/mock-d1.ts
@@ -13,6 +13,8 @@ export function createTestDb(): ReturnType<typeof Database> {
     '0005_soft_delete.sql',
     '0006_ai_admin.sql',
     '0007_node_shape.sql',
+    '0008_projects.sql',
+    '0009_invitation_codes.sql',
   ]
   for (const file of migrationFiles) {
     const sql = readFileSync(resolve(__dirname, '../../migrations/', file), 'utf-8')


### PR DESCRIPTION
## Summary

招待コード制で新規登録を再開する。管理者が `/admin` から招待コードを発行し、ユーザーは `AuthModal` の register タブにコードを入力して登録できる。クローズドβの 503 レスポンスと closedBeta notice UI を撤去。

Closes #304

## Changes

### Backend (D1 + Hono)
- `migrations/0009_invitation_codes.sql` — `invitation_codes` テーブル追加（`code` UNIQUE / `expires_at` / `revoked_at` / `created_by` → users.id TEXT）
- `api/lib/invitation.ts` — `normalizeInvitationCode`, `generateInvitationCode`（8文字ランダム、紛らわしい0OIL1除外）, `validateInvitationCode`
- `api/routes/admin.ts` — `/admin/invitations` 3 エンドポイント:
  - POST: 発行（1〜365日、UNIQUE 衝突時リトライ3回）
  - GET: 一覧（status 計算: active / expired / revoked）
  - POST `/:id/revoke`: 無効化（404 / 409 対応）
- `api/routes/auth.ts` — `POST /register` の 503 ショートサーキット撤去、`invitationCode` 検証追加。エラーコード `INVITATION_REQUIRED` / `INVITATION_INVALID` / `EMAIL_ALREADY_EXISTS`（`INVITATION_INVALID` は期限切れ/無効化/不存在を区別せず列挙攻撃対策）

### Frontend (React)
- `src/hooks/useAuth.tsx` — `register()` に `invitationCode: string` 引数追加
- `src/features/landing/components/AuthModal.tsx` — closedBeta notice 撤去、register フォーム復活、招待コード入力欄追加（入力時 uppercase + strip whitespace）、サーバーエラーコードをインライン表示にマップ
- `src/features/admin/InvitationsSection.tsx` 新設 — 一覧、発行モーダル（7/14/30日プリセット + カスタム）、無効化、コードコピー
- `src/features/admin/AdminPage.tsx` — InvitationsSection を埋め込み
- `src/lib/api.ts` — `ApiError` に `code` フィールド追加（レスポンス body から populate）

### i18n
- `src/locales/{ja,en}/auth.json` — closedBeta.* 撤去、`invitationCode.*` 追加、`form.registerButton` 追加
- `src/locales/{ja,en}/admin.json` 新設 — InvitationsSection 用
- `src/i18n.ts` — admin namespace 登録

### テスト
- 新規テスト: 15（invitation lib）+ 10（admin invitations API）+ 6（register with invite）+ 5（InvitationsSection）+ 6（AuthModal register flow）+ 1（AdminPage integration）
- 撤去: 5（503 assertion）+ 6（closedBeta notice）
- **全テスト 1323 pass / 1 skip**

## Deferred

- **Rate limit** `/auth/register`: 既存の IP ベースレート制限基盤が無いためスキップ（招待コード検証自体が攻撃面を絞るため β 期間中は許容）
- **TOCTOU**: コード検証と INSERT の間で revoke されるウィンドウは極小（β スケールでは非問題）
- **管理画面のブラウザ目視確認**: E2E 用資格情報が未設定のためスキップ。統合テストで代替

## Test plan

- [x] `npm test` 全通過（1323/1324）
- [x] `tsc --noEmit` clean
- [ ] CI 全 pass
- [ ] 本番プレビュービルドで管理画面 → 発行 → 登録 → 無効化 → 弾くフローを実機確認
- [ ] LCP < 1秒（landing / admin）

🤖 Generated with [Claude Code](https://claude.com/claude-code)