### PR TITLE
fix: 自動接続で同レーン直上ノードを優先し、既存矢印を新ノード経由に自動分割

### DIFF
--- a/src/features/editor/FlowEditor.test.tsx
+++ b/src/features/editor/FlowEditor.test.tsx
@@ -1836,8 +1836,10 @@ describe('auto-connect by flow position (#182)', () => {
 })
 
 describe('arrow reorganization toast (#182)', () => {
-  it('should show confirm toast when node added to inserted row with crossing arrows', async () => {
-    // A(row0) → B(row1) connected, insert row between them
+  it('should auto-split A→B into A→new→B when inserting node between linked same-lane nodes', async () => {
+    // A(row0) → B(row1) same lane. Insert row between.
+    // autoConnectOnCreate picks A as same-lane upstream and auto-splits A→B,
+    // so no toast is needed — the new node is wired up end-to-end.
     const flow: Flow = {
       ...createMinimalFlow(),
       nodes: [
@@ -1848,104 +1850,153 @@ describe('arrow reorganization toast (#182)', () => {
     }
     const { container } = render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
 
-    // Insert row at index 1 (between row0 and row1) — 2 clicks
     const rowGapHit = container.querySelector('[data-testid="rowgap-hit-1"]')
     expect(rowGapHit).toBeTruthy()
-    fireEvent.click(rowGapHit!) // ghost
-    fireEvent.click(rowGapHit!) // confirm
+    fireEvent.click(rowGapHit!)
+    fireEvent.click(rowGapHit!)
 
-    // After insertion, rows: [row0(A), newRow(empty), row1(B)]
-    // The new empty cell at ri=1 will have y = 24 + 46 + 1*84 = 154
     const allRects = container.querySelectorAll('rect[fill="transparent"]')
     const emptyCellRects = Array.from(allRects).filter(
       (r) => (r as SVGRectElement).style.cursor === 'crosshair',
     )
     const targetRect = emptyCellRects.find((r) => r.getAttribute('y') === '154')
     expect(targetRect).toBeTruthy()
-    fireEvent.click(targetRect!) // ghost
-    fireEvent.click(targetRect!) // confirm
+    fireEvent.click(targetRect!)
+    fireEvent.click(targetRect!)
 
-    // Confirm toast should appear
+    // No toast — auto-split handled the crossing proactively.
+    await new Promise((r) => setTimeout(r, 20))
+    expect(container.querySelector('[data-testid="toast-confirm"]')).toBeNull()
+  })
+
+  it('should show confirm toast when a crossing arrow is not covered by auto-split', async () => {
+    // Two unrelated flows crossing the inserted row:
+    //   lane-1: A(row0) → B(row1)            ← auto-split by autoConnectOnCreate
+    //   lane-2: X(row0) → Y(row1)            ← not auto-split (user adds node in lane-1)
+    // Toast should still appear for X→Y.
+    const flow: Flow = {
+      ...createMinimalFlow(),
+      lanes: [
+        { id: 'lane-1', name: 'レーン1', colorIndex: 0, position: 0 },
+        { id: 'lane-2', name: 'レーン2', colorIndex: 1, position: 1 },
+      ],
+      nodes: [
+        { id: 'n1', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+        { id: 'n2', laneId: 'lane-1', rowIndex: 1, label: 'B', note: null, orderIndex: 1 },
+        { id: 'n3', laneId: 'lane-2', rowIndex: 0, label: 'X', note: null, orderIndex: 2 },
+        { id: 'n4', laneId: 'lane-2', rowIndex: 1, label: 'Y', note: null, orderIndex: 3 },
+      ],
+      arrows: [
+        { id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: null },
+        { id: 'a2', fromNodeId: 'n3', toNodeId: 'n4', comment: null },
+      ],
+    }
+    const { container } = render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+
+    const rowGapHit = container.querySelector('[data-testid="rowgap-hit-1"]')
+    fireEvent.click(rowGapHit!)
+    fireEvent.click(rowGapHit!)
+
+    const allRects = container.querySelectorAll('rect[fill="transparent"]')
+    const emptyCellRects = Array.from(allRects).filter(
+      (r) => (r as SVGRectElement).style.cursor === 'crosshair',
+    )
+    // Add node in lane-1 (x = 16 + 180 * 0.5 ~ 16 + lane offset, easier: pick first empty at y=154)
+    const targetRect = emptyCellRects.find((r) => r.getAttribute('y') === '154')
+    expect(targetRect).toBeTruthy()
+    fireEvent.click(targetRect!)
+    fireEvent.click(targetRect!)
+
     await waitFor(() => {
       expect(container.querySelector('[data-testid="toast-confirm"]')).toBeTruthy()
     })
-    // Should have skip and organize buttons
     expect(container.querySelector('[data-testid="toast-skip-btn"]')).toBeTruthy()
     expect(container.querySelector('[data-testid="toast-organize-btn"]')).toBeTruthy()
   })
 
-  it('should reorganize arrows when "整理する" button is clicked', async () => {
+  it('should reorganize remaining crossings when "整理する" button is clicked', async () => {
     const flow: Flow = {
       ...createMinimalFlow(),
+      lanes: [
+        { id: 'lane-1', name: 'レーン1', colorIndex: 0, position: 0 },
+        { id: 'lane-2', name: 'レーン2', colorIndex: 1, position: 1 },
+      ],
       nodes: [
         { id: 'n1', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
         { id: 'n2', laneId: 'lane-1', rowIndex: 1, label: 'B', note: null, orderIndex: 1 },
+        { id: 'n3', laneId: 'lane-2', rowIndex: 0, label: 'X', note: null, orderIndex: 2 },
+        { id: 'n4', laneId: 'lane-2', rowIndex: 1, label: 'Y', note: null, orderIndex: 3 },
       ],
-      arrows: [{ id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: null }],
+      arrows: [
+        { id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: null },
+        { id: 'a2', fromNodeId: 'n3', toNodeId: 'n4', comment: null },
+      ],
     }
     const { container } = render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
 
-    // Insert row and click cell — both need 2 clicks
     const rowGapHit = container.querySelector('[data-testid="rowgap-hit-1"]')
-    fireEvent.click(rowGapHit!) // ghost
-    fireEvent.click(rowGapHit!) // confirm
+    fireEvent.click(rowGapHit!)
+    fireEvent.click(rowGapHit!)
     const allRects = container.querySelectorAll('rect[fill="transparent"]')
     const emptyCellRects = Array.from(allRects).filter(
       (r) => (r as SVGRectElement).style.cursor === 'crosshair',
     )
     const targetRect = emptyCellRects.find((r) => r.getAttribute('y') === '154')
-    fireEvent.click(targetRect!) // ghost
-    fireEvent.click(targetRect!) // confirm
+    fireEvent.click(targetRect!)
+    fireEvent.click(targetRect!)
 
     await waitFor(() => {
       expect(container.querySelector('[data-testid="toast-confirm"]')).toBeTruthy()
     })
 
-    // Click "整理する"
     const organizeBtn = container.querySelector('[data-testid="toast-organize-btn"]')
     expect(organizeBtn).toBeTruthy()
     fireEvent.click(organizeBtn!)
 
-    // Success toast should appear
     await waitFor(() => {
       expect(container.querySelector('[data-testid="toast-success"]')).toBeTruthy()
     })
-    // Confirm toast should be dismissed
     expect(container.querySelector('[data-testid="toast-confirm"]')).toBeNull()
   })
 
   it('should dismiss toast when "スキップ" button is clicked', async () => {
     const flow: Flow = {
       ...createMinimalFlow(),
+      lanes: [
+        { id: 'lane-1', name: 'レーン1', colorIndex: 0, position: 0 },
+        { id: 'lane-2', name: 'レーン2', colorIndex: 1, position: 1 },
+      ],
       nodes: [
         { id: 'n1', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
         { id: 'n2', laneId: 'lane-1', rowIndex: 1, label: 'B', note: null, orderIndex: 1 },
+        { id: 'n3', laneId: 'lane-2', rowIndex: 0, label: 'X', note: null, orderIndex: 2 },
+        { id: 'n4', laneId: 'lane-2', rowIndex: 1, label: 'Y', note: null, orderIndex: 3 },
       ],
-      arrows: [{ id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: null }],
+      arrows: [
+        { id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: null },
+        { id: 'a2', fromNodeId: 'n3', toNodeId: 'n4', comment: null },
+      ],
     }
     const { container } = render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
 
-    // Insert row and click cell — both need 2 clicks
     const rowGapHit = container.querySelector('[data-testid="rowgap-hit-1"]')
-    fireEvent.click(rowGapHit!) // ghost
-    fireEvent.click(rowGapHit!) // confirm
+    fireEvent.click(rowGapHit!)
+    fireEvent.click(rowGapHit!)
     const allRects = container.querySelectorAll('rect[fill="transparent"]')
     const emptyCellRects = Array.from(allRects).filter(
       (r) => (r as SVGRectElement).style.cursor === 'crosshair',
     )
     const targetRect = emptyCellRects.find((r) => r.getAttribute('y') === '154')
-    fireEvent.click(targetRect!) // ghost
-    fireEvent.click(targetRect!) // confirm
+    fireEvent.click(targetRect!)
+    fireEvent.click(targetRect!)
 
     await waitFor(() => {
       expect(container.querySelector('[data-testid="toast-confirm"]')).toBeTruthy()
     })
 
-    // Click "スキップ"
     const skipBtn = container.querySelector('[data-testid="toast-skip-btn"]')
     fireEvent.click(skipBtn!)
 
-    // Toast should be dismissed
     expect(container.querySelector('[data-testid="toast-confirm"]')).toBeNull()
     expect(container.querySelector('[data-testid="toast-success"]')).toBeNull()
   })

--- a/src/features/editor/auto-connect.test.ts
+++ b/src/features/editor/auto-connect.test.ts
@@ -225,6 +225,67 @@ describe('findClosestUpstream', () => {
     // C is closer (l2 vs l1), both are same-row tails
     expect(result).toBe('C')
   })
+
+  it('should prefer same-lane upstream non-tail over other-lane tail when inserted between linked nodes', () => {
+    // User reported scenario:
+    // Row 2: worker_r2 (outgoing → worker_r3), teams_r2 (no outgoing = tail)
+    // Row 3: worker_r3 (outgoing → worker_r5, non-tail)
+    // Row 4: (empty) ← new node inserted here in worker lane
+    // Row 5: worker_r5
+    // Expected: worker_r3 (same-lane direct upstream), NOT teams_r2 (closer tail)
+    const rows = [
+      { id: 'r0' },
+      { id: 'r1' },
+      { id: 'r2' },
+      { id: 'r3' },
+      { id: 'r4' },
+      { id: 'r5' },
+    ]
+    const lanes = [
+      { id: 'L_customer' },
+      { id: 'L_sales' },
+      { id: 'L_worker' },
+      { id: 'L_worker2' },
+      { id: 'L_teams' },
+    ]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      worker_r2: { lid: 'L_worker', rid: 'r2' },
+      teams_r2: { lid: 'L_teams', rid: 'r2' },
+      worker_r3: { lid: 'L_worker', rid: 'r3' },
+      worker_r5: { lid: 'L_worker', rid: 'r5' },
+    }
+    const arrows = [
+      { id: 'a1', from: 'worker_r2', to: 'teams_r2', comment: '' },
+      { id: 'a2', from: 'worker_r2', to: 'worker_r3', comment: '' },
+      { id: 'a3', from: 'worker_r3', to: 'worker_r5', comment: '' },
+    ]
+    const result = findClosestUpstream(tasks, rows, lanes, 4, 2, arrows)
+    expect(result).toBe('worker_r3')
+  })
+
+  it('should still return same-row node when same-lane upstream and same-row both exist', () => {
+    // Verify same-row priority is preserved (Step 1 takes precedence over Step 2)
+    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      sameLaneUpstream: { lid: 'l0', rid: 'r1' },
+      sameRow: { lid: 'l1', rid: 'r2' },
+    }
+    const arrows = [{ id: 'a1', from: 'sameLaneUpstream', to: 'other', comment: '' }]
+    const result = findClosestUpstream(tasks, rows, lanes, 2, 0, arrows)
+    expect(result).toBe('sameRow')
+  })
+
+  it('should fall through to tail-based search when no same-lane upstream exists', () => {
+    // Only upstream is in a different lane as a tail — should still be found
+    const rows = [{ id: 'r0' }, { id: 'r1' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      otherLaneTail: { lid: 'l0', rid: 'r0' },
+    }
+    const result = findClosestUpstream(tasks, rows, lanes, 1, 1, [])
+    expect(result).toBe('otherLaneTail')
+  })
 })
 
 describe('findCrossingArrows', () => {

--- a/src/features/editor/auto-connect.ts
+++ b/src/features/editor/auto-connect.ts
@@ -4,7 +4,9 @@
  * Priority:
  * 1. Same-row nodes: closest by lane distance (bidirectional),
  *    with tail nodes preferred over non-tails at equal distance.
- * 2. Upstream tails (previous rows): closest by row index,
+ * 2. Same-lane upstream: closest row in the same lane (tail or non-tail).
+ *    Handles insertions between already-linked nodes within the same lane.
+ * 3. Upstream tails (previous rows): closest by row index,
  *    with flow-connected tails preferred over isolated at same row.
  *
  * @returns The task key of the closest upstream node, or null if none found.
@@ -45,7 +47,27 @@ export function findClosestUpstream(
     if (bestKey) return bestKey
   }
 
-  // 2. Upstream tails: closest by row, flow-connected as tiebreaker
+  // 2. Same-lane upstream: pick the closest (largest tRi < newRi) node in the same lane.
+  //    A same-lane predecessor is the natural upstream even when it already has outgoing
+  //    arrows, because the user is inserting a new step into an existing chain.
+  {
+    let bestKey: string | null = null
+    let bestRi = -1
+    for (const key of allKeys) {
+      const task = tasks[key]
+      const tLi = lanes.findIndex((l) => l.id === task.lid)
+      if (tLi !== newLi) continue
+      const tRi = rows.findIndex((r) => r.id === task.rid)
+      if (tRi < 0 || tRi >= newRi) continue
+      if (tRi > bestRi) {
+        bestKey = key
+        bestRi = tRi
+      }
+    }
+    if (bestKey) return bestKey
+  }
+
+  // 3. Upstream tails: closest by row, flow-connected as tiebreaker
   {
     let bestKey: string | null = null
     let bestRi = -1

--- a/src/features/editor/hooks/useArrows.test.ts
+++ b/src/features/editor/hooks/useArrows.test.ts
@@ -331,6 +331,85 @@ describe('useArrows', () => {
       expect(toastArg.detail).toContain('新ノード')
     })
 
+    it('should not offer toast for arrows already split by autoConnectOnCreate', () => {
+      // Regression: autoConnectOnCreate auto-splits A→C via new node B.
+      // detectCrossing runs right after in the same event — it must NOT re-offer
+      // to split A→C, otherwise confirming the toast creates duplicate arrows.
+      const addConfirmToast = vi.fn()
+      const tasks: Record<string, TaskData> = {
+        l0_r0: { label: 'A', lid: 'l0', rid: 'r0', nodeId: 'n1' },
+        l0_r1: { label: 'B', lid: 'l0', rid: 'r1', nodeId: 'n2' },
+        l0_r2: { label: 'C', lid: 'l0', rid: 'r2', nodeId: 'n3' },
+      }
+      const rows: RowData[] = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+      const arrows: InternalArrow[] = [{ id: 'a1', from: 'l0_r0', to: 'l0_r2', comment: '' }]
+      const { result } = renderHook(() =>
+        useArrows({
+          ...defaultOptions(),
+          tasks,
+          rows,
+          initialArrows: arrows,
+        }),
+      )
+      act(() => {
+        result.current.setRecentInsertedRow({ rowId: 'r1' })
+      })
+      // Critical: autoConnectOnCreate and detectCrossing must be in the same
+      // act() block to simulate a single event handler (React batches setState).
+      act(() => {
+        result.current.autoConnectOnCreate('l0_r1', 1, 0)
+        result.current.detectCrossing('r1', 'l0_r1', 'B', addConfirmToast)
+      })
+      // auto-split already handled the crossing; toast should not fire
+      expect(addConfirmToast).not.toHaveBeenCalled()
+      // Only 2 arrows expected: A→B and B→C — no duplicates
+      expect(result.current.arrows).toHaveLength(2)
+      const pairs = result.current.arrows.map((a) => `${a.from}->${a.to}`).sort()
+      expect(pairs).toEqual(['l0_r0->l0_r1', 'l0_r1->l0_r2'])
+    })
+
+    it('should still offer toast for remaining crossings not handled by auto-split', () => {
+      // A→C is auto-split by autoConnectOnCreate (same-lane upstream),
+      // but X→Y still crosses the inserted row and was NOT touched.
+      // detectCrossing should still offer a toast for X→Y.
+      const addConfirmToast = vi.fn()
+      const tasks: Record<string, TaskData> = {
+        l0_r0: { label: 'A', lid: 'l0', rid: 'r0', nodeId: 'n1' },
+        l0_r1: { label: 'B', lid: 'l0', rid: 'r1', nodeId: 'n2' },
+        l0_r2: { label: 'C', lid: 'l0', rid: 'r2', nodeId: 'n3' },
+        l1_r0: { label: 'X', lid: 'l1', rid: 'r0', nodeId: 'n4' },
+        l1_r2: { label: 'Y', lid: 'l1', rid: 'r2', nodeId: 'n5' },
+      }
+      const rows: RowData[] = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+      const lanes: InternalLane[] = [
+        { id: 'l0', name: 'L0', ci: 0 },
+        { id: 'l1', name: 'L1', ci: 1 },
+      ]
+      const arrows: InternalArrow[] = [
+        { id: 'a1', from: 'l0_r0', to: 'l0_r2', comment: '' },
+        { id: 'a2', from: 'l1_r0', to: 'l1_r2', comment: '' },
+      ]
+      const { result } = renderHook(() =>
+        useArrows({
+          ...defaultOptions(),
+          tasks,
+          rows,
+          lanes,
+          initialArrows: arrows,
+        }),
+      )
+      act(() => {
+        result.current.setRecentInsertedRow({ rowId: 'r1' })
+      })
+      act(() => {
+        result.current.autoConnectOnCreate('l0_r1', 1, 0)
+        result.current.detectCrossing('r1', 'l0_r1', 'B', addConfirmToast)
+      })
+      expect(addConfirmToast).toHaveBeenCalledOnce()
+      // Only X→Y should be offered, not A→C (already split)
+      expect(addConfirmToast.mock.calls[0][0].crossingCount).toBe(1)
+    })
+
     it('should clear recentInsertedRow even when no crossing found', () => {
       const addConfirmToast = vi.fn()
       const { result } = renderHook(() => useArrows(defaultOptions()))

--- a/src/features/editor/hooks/useArrows.test.ts
+++ b/src/features/editor/hooks/useArrows.test.ts
@@ -95,6 +95,102 @@ describe('useArrows', () => {
       expect(result.current.arrows[0].id).toBeTruthy()
       expect(result.current.arrows[0].comment).toBe('')
     })
+
+    it('should auto-split existing arrow when inserting between linked nodes in same lane', () => {
+      // A(l0,r0) → C(l0,r2), insert B at (l0,r1)
+      // Expected: A→B, B→C (A→C is removed)
+      const tasks: Record<string, TaskData> = {
+        l0_r0: { label: 'A', lid: 'l0', rid: 'r0', nodeId: 'n1' },
+        l0_r1: { label: 'B', lid: 'l0', rid: 'r1', nodeId: 'n2' },
+        l0_r2: { label: 'C', lid: 'l0', rid: 'r2', nodeId: 'n3' },
+      }
+      const rows: RowData[] = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+      const arrows: InternalArrow[] = [{ id: 'a1', from: 'l0_r0', to: 'l0_r2', comment: 'c1' }]
+      const { result } = renderHook(() =>
+        useArrows({
+          ...defaultOptions(),
+          tasks,
+          rows,
+          initialArrows: arrows,
+        }),
+      )
+      act(() => {
+        result.current.autoConnectOnCreate('l0_r1', 1, 0)
+      })
+      expect(result.current.arrows).toHaveLength(2)
+      const pairs = result.current.arrows.map((a) => `${a.from}->${a.to}`).sort()
+      expect(pairs).toEqual(['l0_r0->l0_r1', 'l0_r1->l0_r2'])
+      expect(result.current.arrows.find((a) => a.id === 'a1')).toBeUndefined()
+      const downstream = result.current.arrows.find(
+        (a) => a.from === 'l0_r1' && a.to === 'l0_r2',
+      )
+      expect(downstream?.comment).toBe('c1')
+    })
+
+    it('should not auto-split when bestKey is in same row as new node', () => {
+      // A(l0,r0) → B(l1,r0), insert C at (r0, l2)
+      // bestKey should be B (same-row). No split.
+      const tasks: Record<string, TaskData> = {
+        l0_r0: { label: 'A', lid: 'l0', rid: 'r0', nodeId: 'n1' },
+        l1_r0: { label: 'B', lid: 'l1', rid: 'r0', nodeId: 'n2' },
+      }
+      const rows: RowData[] = [{ id: 'r0' }]
+      const lanes: InternalLane[] = [
+        { id: 'l0', name: 'L0', ci: 0 },
+        { id: 'l1', name: 'L1', ci: 1 },
+        { id: 'l2', name: 'L2', ci: 2 },
+      ]
+      const arrows: InternalArrow[] = [{ id: 'a1', from: 'l0_r0', to: 'l1_r0', comment: '' }]
+      const { result } = renderHook(() =>
+        useArrows({
+          ...defaultOptions(),
+          tasks,
+          rows,
+          lanes,
+          initialArrows: arrows,
+        }),
+      )
+      act(() => {
+        result.current.autoConnectOnCreate('l2_r0', 0, 2)
+      })
+      expect(result.current.arrows).toHaveLength(2)
+      expect(result.current.arrows.find((a) => a.id === 'a1')).toBeDefined()
+    })
+
+    it('should auto-split multiple downstream arrows when upstream has several', () => {
+      // A(l0,r0) → C(l0,r2), A → D(l1,r2), insert B at (l0,r1)
+      // Expected: A→B, B→C, B→D
+      const tasks: Record<string, TaskData> = {
+        l0_r0: { label: 'A', lid: 'l0', rid: 'r0', nodeId: 'n1' },
+        l0_r1: { label: 'B', lid: 'l0', rid: 'r1', nodeId: 'n2' },
+        l0_r2: { label: 'C', lid: 'l0', rid: 'r2', nodeId: 'n3' },
+        l1_r2: { label: 'D', lid: 'l1', rid: 'r2', nodeId: 'n4' },
+      }
+      const rows: RowData[] = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+      const lanes: InternalLane[] = [
+        { id: 'l0', name: 'L0', ci: 0 },
+        { id: 'l1', name: 'L1', ci: 1 },
+      ]
+      const arrows: InternalArrow[] = [
+        { id: 'a1', from: 'l0_r0', to: 'l0_r2', comment: '' },
+        { id: 'a2', from: 'l0_r0', to: 'l1_r2', comment: '' },
+      ]
+      const { result } = renderHook(() =>
+        useArrows({
+          ...defaultOptions(),
+          tasks,
+          rows,
+          lanes,
+          initialArrows: arrows,
+        }),
+      )
+      act(() => {
+        result.current.autoConnectOnCreate('l0_r1', 1, 0)
+      })
+      expect(result.current.arrows).toHaveLength(3)
+      const pairs = result.current.arrows.map((a) => `${a.from}->${a.to}`).sort()
+      expect(pairs).toEqual(['l0_r0->l0_r1', 'l0_r1->l0_r2', 'l0_r1->l1_r2'])
+    })
   })
 
   describe('detectCrossing', () => {

--- a/src/features/editor/hooks/useArrows.test.ts
+++ b/src/features/editor/hooks/useArrows.test.ts
@@ -121,9 +121,7 @@ describe('useArrows', () => {
       const pairs = result.current.arrows.map((a) => `${a.from}->${a.to}`).sort()
       expect(pairs).toEqual(['l0_r0->l0_r1', 'l0_r1->l0_r2'])
       expect(result.current.arrows.find((a) => a.id === 'a1')).toBeUndefined()
-      const downstream = result.current.arrows.find(
-        (a) => a.from === 'l0_r1' && a.to === 'l0_r2',
-      )
+      const downstream = result.current.arrows.find((a) => a.from === 'l0_r1' && a.to === 'l0_r2')
       expect(downstream?.comment).toBe('c1')
     })
 

--- a/src/features/editor/hooks/useArrows.ts
+++ b/src/features/editor/hooks/useArrows.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import type { InternalArrow, TaskData, RowData, InternalLane } from '../types'
 import { findClosestUpstream, findCrossingArrows } from '../auto-connect'
 import { uid } from '../../../lib/uid'
@@ -14,6 +14,10 @@ interface UseArrowsOptions {
 export function useArrows({ initialArrows, tasks, rows, lanes, autoConnect }: UseArrowsOptions) {
   const [arrows, setArrows] = useState<InternalArrow[]>(initialArrows)
   const [recentInsertedRow, setRecentInsertedRow] = useState<{ rowId: string } | null>(null)
+  // Arrow IDs auto-split by autoConnectOnCreate within the current event.
+  // detectCrossing (called right after in the same handler) excludes them so
+  // the user isn't offered a toast to re-split an arrow that was already rewired.
+  const autoSplitHandledRef = useRef<Set<string>>(new Set())
 
   const autoConnectOnCreate = (taskKey: string, ri: number, li: number): void => {
     if (!autoConnect || Object.keys(tasks).length < 1) return
@@ -36,8 +40,9 @@ export function useArrows({ initialArrows, tasks, rows, lanes, autoConnect }: Us
           })
         : []
 
+    const splitIds = new Set(splitArrows.map((a) => a.id))
+    autoSplitHandledRef.current = splitIds
     setArrows((prev) => {
-      const splitIds = new Set(splitArrows.map((a) => a.id))
       const filtered = prev.filter((a) => !splitIds.has(a.id))
       const additions: InternalArrow[] = [{ id: uid(), from: bestKey, to: taskKey, comment: '' }]
       for (const s of splitArrows) {
@@ -58,10 +63,16 @@ export function useArrows({ initialArrows, tasks, rows, lanes, autoConnect }: Us
       crossingCount?: number
     }) => void,
   ): void => {
-    if (!recentInsertedRow || rid !== recentInsertedRow.rowId) return
+    if (!recentInsertedRow || rid !== recentInsertedRow.rowId) {
+      autoSplitHandledRef.current = new Set()
+      return
+    }
     const insertedIndex = rows.findIndex((r) => r.id === recentInsertedRow.rowId)
     if (insertedIndex >= 0) {
-      const crossing = findCrossingArrows(arrows, tasks, rows, insertedIndex)
+      const handled = autoSplitHandledRef.current
+      const crossing = findCrossingArrows(arrows, tasks, rows, insertedIndex).filter(
+        (a) => !handled.has(a.id),
+      )
       if (crossing.length > 0) {
         const newNodeKey = taskKey
         const crossingCount = crossing.length
@@ -91,6 +102,7 @@ export function useArrows({ initialArrows, tasks, rows, lanes, autoConnect }: Us
       }
     }
     setRecentInsertedRow(null)
+    autoSplitHandledRef.current = new Set()
   }
 
   return {

--- a/src/features/editor/hooks/useArrows.ts
+++ b/src/features/editor/hooks/useArrows.ts
@@ -18,9 +18,33 @@ export function useArrows({ initialArrows, tasks, rows, lanes, autoConnect }: Us
   const autoConnectOnCreate = (taskKey: string, ri: number, li: number): void => {
     if (!autoConnect || Object.keys(tasks).length < 1) return
     const bestKey = findClosestUpstream(tasks, rows, lanes, ri, li, arrows)
-    if (bestKey) {
-      setArrows((p) => [...p, { id: uid(), from: bestKey, to: taskKey, comment: '' }])
-    }
+    if (!bestKey) return
+
+    // If the chosen upstream lives in a row above the new node, re-route any arrow
+    // from it to a downstream node (row > ri) through the new node, splitting
+    // `bestKey → downstream` into `bestKey → new → downstream`.
+    const bestTask = tasks[bestKey]
+    const bestRi = bestTask ? rows.findIndex((r) => r.id === bestTask.rid) : -1
+    const splitArrows =
+      bestRi >= 0 && bestRi < ri
+        ? arrows.filter((a) => {
+            if (a.from !== bestKey) return false
+            const toTask = tasks[a.to]
+            if (!toTask) return false
+            const toRi = rows.findIndex((r) => r.id === toTask.rid)
+            return toRi > ri
+          })
+        : []
+
+    setArrows((prev) => {
+      const splitIds = new Set(splitArrows.map((a) => a.id))
+      const filtered = prev.filter((a) => !splitIds.has(a.id))
+      const additions: InternalArrow[] = [{ id: uid(), from: bestKey, to: taskKey, comment: '' }]
+      for (const s of splitArrows) {
+        additions.push({ id: uid(), from: taskKey, to: s.to, comment: s.comment })
+      }
+      return [...filtered, ...additions]
+    })
   }
 
   const detectCrossing = (


### PR DESCRIPTION
## Summary
- `findClosestUpstream` で、Step 1 (同一行) と tail ベース fallback の間に「同レーン直上優先」パスを追加。outgoing を持つ中間ノードでも同レーン直上なら候補にする
- `useArrows.autoConnectOnCreate` で、選ばれた upstream が上方行にある場合に既存の下流矢印を検出し、`upstream → 新ノード → 下流` に自動分割するロジックを追加 (案B)

## 背景 (再現シナリオ)
ユーザーから報告のあったフロー: 作業担当レーンで `新規案件(row3) → 既存or新規◇(row5)` という矢印が張られている状態で、その間の `row4` に新ノード「作業」を追加。

- **Before**: Step 2 が tail のみを候補にしていたため `新規案件` (outgoing あり = 非tail) がスキップされ、別レーンの `Teams_定期確認(row2)` が upstream として選ばれた
- **After**: 同レーン直上 (`新規案件`) を upstream として採用し、さらに既存の `新規案件 → ◇` を `新規案件 → 作業 → ◇` に自動分割

## Test plan
- [x] `src/features/editor/auto-connect.test.ts` にユーザー報告シナリオそのままの再現テスト + 回帰テストを追加
- [x] `src/features/editor/hooks/useArrows.test.ts` に自動分割のテスト (同レーン挿入 / 同一行の場合は非分割 / 複数下流の一括分割) を追加
- [x] 全1398テストpass

🤖 Generated with [Claude Code](https://claude.com/claude-code)