### PR TITLE
fix(#314): 同一行で間にノードがある矢印を迂回させる

### DIFF
--- a/docs/plans/2026-04-29-arrow-detour-design.md
+++ b/docs/plans/2026-04-29-arrow-detour-design.md
@@ -1,0 +1,325 @@
+# 同一行で間にノードがある矢印の迂回（Arrow Detour）設計
+
+- Issue: [#314](https://github.com/tomohirof/flowline/issues/314)
+- 作成日: 2026-04-29
+- ステータス: Design 承認済 → Plan 作成へ
+
+## 背景・目的
+
+同一行（同じ `rid`）で複数レーンをまたぐ矢印（例: A→C）が、経路上にあるノード（B）を貫通してしまう。Issue #314 の画像 1 → 画像 2 のように、間にあるノードを回避して下（または上）に迂回する経路を生成する。
+
+## スコープ
+
+### 対象
+- 同一行で `from` から `to` の間のレーンに 1 つ以上ノードが存在する場合の水平直線パスの迂回
+- エディタ (`FlowEditor`) と共有ビュー (`SharedFlowViewer`) の両方
+
+### 対象外
+- 縦方向（同一レーンで `from` と `to` の間にノードがある）の貫通対応 — 発生頻度が低いため今回は据え置き
+- 既存の Z 字 / L 字パス（縦横混合の出入口）に対する障害回避
+
+## 受け入れ基準（Issue #314 より）
+
+- [ ] 同一行で A→B、A→C があるとき、A→C が B を避けて下に迂回する
+- [ ] 同一行で A→C 単独（B あり）の場合も同様に迂回する
+- [ ] 同一行で A→B 単独（隣接レーン、間にノードなし）は従来どおり直線
+- [ ] 直下にノードがある場合は上へ迂回
+- [ ] 縦方向（同一レーン）の貫通は対象外で従来挙動のまま
+- [ ] エディタと共有ビューアの両方で同じ挙動
+- [ ] LCP 1 秒以内 / 全テスト pass / Playwright 目視確認
+
+## アーキテクチャ概要
+
+```
+[呼び出し側]
+  FlowEditor.aPath / SharedFlowViewer.computeArrowPath
+    ↓ tasks/nodes から「同一行・直上行・直下行のノード bbox 配列」を組み立て
+    ↓
+[flow-engine.ts: calcArrowPath(from, to, config, obstacles?)]
+    ↓ パススルー
+    ↓
+[arrow-routing.ts: buildArrowPath(s, e, fc, tc, obstacles?)]
+    ├── detectDetour(s, e, obstacles)  — 内部関数
+    │     ・経路上の障害ノード検出
+    │     ・障害ノードの直下/直上塞がり判定
+    │     ・戻り値: { detourY: number } | null
+    └── detourY が得られたら迂回パス、null なら既存パス
+```
+
+### 責務分担
+
+| レイヤ | 責務 |
+|--------|------|
+| 呼び出し側 (`aPath` / `computeArrowPath`) | 同一行・直上行・直下行のノードを bbox 配列に変換して渡す。`from`/`to` 自身は除外 |
+| `arrow-routing.ts` | 与えられた bbox 群から経路上の障害を抽出し、上下塞がり判定・迂回方向決定・パス生成を完結 |
+
+## 型定義と API
+
+### 新規型 (`arrow-routing.ts`)
+
+```ts
+export interface Bbox {
+  x: number  // 中心 X
+  y: number  // 中心 Y
+  w: number  // 幅
+  h: number  // 高さ
+}
+```
+
+### `buildArrowPath` シグネチャ拡張
+
+```ts
+export const buildArrowPath = (
+  s: Point,
+  e: Point,
+  fc: Point,
+  tc: Point,
+  obstacles?: Bbox[],   // ← 新規。同一行＋直上行＋直下行の候補ノード
+): ArrowPath
+```
+
+### `calcArrowPath` シグネチャ拡張 (`flow-engine.ts`)
+
+```ts
+export function calcArrowPath(
+  from: NodePos,
+  to: NodePos,
+  config: ArrowConfig,
+  obstacles?: Bbox[],   // ← 新規
+): ArrowPathResult
+```
+
+### 内部定数・ヘルパー
+
+```ts
+const DETOUR_MARGIN = 14  // 行間 28px の中央
+
+function detectDetour(
+  s: Point,
+  e: Point,
+  obstacles: Bbox[],
+): { detourY: number } | null
+```
+
+### 後方互換性
+
+- `obstacles` は省略可能。既存呼び出し（テスト含む）は変更不要
+- `obstacles` が `undefined` または `[]` のとき、既存挙動と完全一致
+
+## 検出アルゴリズム (`detectDetour`)
+
+```ts
+const DETOUR_MARGIN = 14
+
+function detectDetour(
+  s: Point,
+  e: Point,
+  obstacles: Bbox[],
+): { detourY: number } | null {
+  // ① 水平直線でなければ迂回しない
+  if (Math.abs(e.y - s.y) >= 2) return null
+
+  const xLow = Math.min(s.x, e.x)
+  const xHigh = Math.max(s.x, e.x)
+  const rowY = s.y
+
+  // ② 経路上の障害ノード = 同一行（rowY と Y が重なる）かつ X が始終点の間
+  const inRow = obstacles.filter(
+    (b) =>
+      Math.abs(b.y - rowY) < b.h / 2 + 2 &&
+      b.x - b.w / 2 < xHigh - 1 &&
+      b.x + b.w / 2 > xLow + 1,
+  )
+  if (inRow.length === 0) return null
+
+  // ③ 上下塞がり判定（X 重なりするノードが直上/直下に存在するか）
+  const xOverlap = (a: Bbox, b: Bbox) => Math.abs(a.x - b.x) < (a.w + b.w) / 2
+  const downBlocked = inRow.some((obs) =>
+    obstacles.some((b) => b.y > obs.y + 1 && xOverlap(obs, b)),
+  )
+  const upBlocked = inRow.some((obs) =>
+    obstacles.some((b) => b.y < obs.y - 1 && xOverlap(obs, b)),
+  )
+
+  // ④ 方向決定: 下空きなら下、下塞がり＆上空きなら上、両塞がりは下優先
+  const goDown = !downBlocked || upBlocked
+
+  // ⑤ detourY: 障害ノード群の最下端＋マージン or 最上端－マージン
+  const detourY = goDown
+    ? Math.max(...inRow.map((o) => o.y + o.h / 2)) + DETOUR_MARGIN
+    : Math.min(...inRow.map((o) => o.y - o.h / 2)) - DETOUR_MARGIN
+
+  return { detourY }
+}
+```
+
+## 迂回パス生成 (`buildArrowPath` 内)
+
+```ts
+const detour = obstacles && obstacles.length > 0 ? detectDetour(s, e, obstacles) : null
+if (detour) {
+  const { detourY } = detour
+  const d = `M${s.x},${s.y} L${s.x},${detourY} L${e.x},${detourY} L${e.x},${e.y}`
+  return { d, mx: (s.x + e.x) / 2, my: detourY }  // ラベルは迂回区間の中点
+}
+// ↓ 既存の直線/Z字/L字ロジック（変更なし）
+```
+
+## 呼び出し側の bbox 抽出ロジック
+
+### `FlowEditor.aPath`
+
+```ts
+const aPath = (arrow: InternalArrow): ArrowPathResult | null => {
+  const ft = tasks[arrow.from], tt = tasks[arrow.to]
+  if (!ft || !tt) return null
+  const fli = liMap[ft.lid], fri = riMap[ft.rid]
+  const tli = liMap[tt.lid], tri = riMap[tt.rid]
+  if ([fli, fri, tli, tri].some((v) => v === undefined)) return null
+
+  const from = ct(fli, fri)
+  const to = ct(tli, tri)
+
+  let obstacles: Bbox[] | undefined
+  if (fri === tri) {
+    // タスク → ObstacleNode[] に変換（自身も含めて全部、collectObstacles 側で from/to を除外）
+    const nodes: ObstacleNode[] = []
+    for (const [k, t] of Object.entries(tasks)) {
+      const li = liMap[t.lid], ri = riMap[t.rid]
+      if (li === undefined || ri === undefined) continue
+      const c = ct(li, ri)
+      nodes.push({ key: k, cx: c.x, cy: c.y })
+    }
+    obstacles = collectObstacles({
+      nodes,
+      fromKey: arrow.from,
+      toKey: arrow.to,
+      fromCx: from.x,
+      toCx: to.x,
+      rowY: from.y,
+      rowH: RH,
+      bboxW: TW,
+      bboxH: TH,
+    })
+  }
+
+  return calcArrowPath(
+    from, to,
+    { hw: TW / 2, hh: TH / 2, rh: RH, fromShape: ft.shape ?? undefined, toShape: tt.shape ?? undefined },
+    obstacles,
+  )
+}
+```
+
+### `collectObstacles` ヘルパー（共通化）
+
+`arrow-routing.ts` に薄いユーティリティとして export し、エディタ・ビューア両方から呼ぶ。
+
+```ts
+// arrow-routing.ts
+export interface ObstacleNode {
+  key: string
+  cx: number  // 中心 X
+  cy: number  // 中心 Y
+}
+
+export interface CollectObstaclesArgs {
+  nodes: ObstacleNode[]
+  fromKey: string
+  toKey: string
+  fromCx: number
+  toCx: number
+  rowY: number
+  rowH: number    // 行高さ（直上/直下行判定用）
+  bboxW: number
+  bboxH: number
+}
+
+export function collectObstacles(args: CollectObstaclesArgs): Bbox[] {
+  const { nodes, fromKey, toKey, fromCx, toCx, rowY, rowH, bboxW, bboxH } = args
+  const xLow = Math.min(fromCx, toCx)
+  const xHigh = Math.max(fromCx, toCx)
+  const result: Bbox[] = []
+  for (const n of nodes) {
+    if (n.key === fromKey || n.key === toKey) continue
+    const dy = Math.abs(n.cy - rowY)
+    const onRow = dy < bboxH / 2 + 2
+    // 直上/直下行のみを採用（2行以上離れたノードは無視）
+    const onAdjacentRow = !onRow && dy > rowH - bboxH / 2 && dy < rowH + bboxH / 2
+    if (onRow) {
+      // 同一行: from-to 間レーンに限定
+      if (n.cx > xLow + 1 && n.cx < xHigh - 1) {
+        result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+      }
+    } else if (onAdjacentRow) {
+      // 直上/直下行: 上下塞がり判定用に X 制限なしで含める
+      result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+    }
+  }
+  return result
+}
+```
+
+呼び出し側は `tasks` / `flow.nodes` を `ObstacleNode[]` に1度だけ変換して渡す。
+
+### `SharedFlowViewer.computeArrowPath`
+
+`flow.nodes` を `ObstacleNode[]` にマップして同じヘルパーを呼ぶ。bbox 抽出ロジックを共通化することで、エディタとビューアの挙動差を防ぐ。
+
+## エラー処理・エッジケース
+
+| ケース | 期待挙動 |
+|--------|----------|
+| `obstacles` が `undefined` または `[]` | 既存挙動完全一致 |
+| 同一レーン縦方向矢印 | 既存挙動（スコープ外） |
+| 同一行・隣接レーン、間にノードなし | `inRow` 空 → 既存直線 |
+| `from === to`（自己参照）| `xLow === xHigh` → `inRow` 空 → 既存挙動 |
+| `from`/`to` 自身が bbox に混入 | 呼び出し側で除外 + arrow-routing 側でも X±1 マージンで二重防御 |
+| 最上行で上塞がり判定 | 直上行ノードが存在しない → 上塞がりは false → 仕様通り |
+| 浮きノード（liMap/riMap が undefined）| `collectObstacles` で除外 |
+| 不正 bbox（w=0, h=0）| 起こり得ないが、X 重なり判定が自然に false → 副作用なし |
+
+## テスト戦略
+
+### `src/lib/arrow-routing.test.ts`（新規 or 既存拡張）
+
+| ケース | 期待 |
+|--------|------|
+| `obstacles` 省略 / 空 | 既存パスと完全一致 |
+| 同一行・障害1個・下空き | 下迂回、`detourY = B.y + B.h/2 + 14` |
+| 同一行・障害1個・直下塞がり・上空き | 上迂回、`detourY = B.y - B.h/2 - 14` |
+| 同一行・障害1個・両塞がり | 下迂回（下優先）|
+| 同一行・障害2個・下空き | まとめて下迂回、`detourY = max(B,C の最下端) + 14` |
+| 同一行・障害2個・1つだけ直下塞がり | 上迂回（1つでも塞がっていれば上）|
+| ラベル位置 | 迂回時 `mx = (s.x+e.x)/2`, `my = detourY` |
+| `from`/`to` 自身が bbox に混入 | X±1 マージンで除外、迂回しない |
+
+### `flow-engine.test.ts`（既存拡張）
+- 既存テストは引数省略で通る（後方互換）
+- `obstacles` を渡したときの 1〜2 ケース
+
+### `collectObstacles` ヘルパーテスト
+- 同一行・直上行・直下行のみが集まる
+- `from`/`to` 自身が除外される
+- 浮きノード（座標 undefined）が無視される
+
+### 統合テスト
+- FlowEditor: A→B、A→C 同一行 → A→C が下迂回 / B 直下にもノード → A→C は上迂回 / A→B 単独 → 直線
+- SharedFlowViewer: 同等のシナリオ 1〜2 ケース
+
+### Playwright 目視確認（Workflow Step 6）
+1. A→B、A→C 同一行 → A→C が B を下に迂回
+2. A→C 単独（B あり）→ 同様に下迂回
+3. A→B 単独（隣接、間にノードなし）→ 従来直線
+4. B 直下にもノード → A→C は上に迂回
+5. 縦方向（同一レーン）は従来挙動のまま
+6. LCP 1 秒以内
+
+## 影響範囲（ファイル一覧）
+
+- `src/lib/arrow-routing.ts` — `Bbox` 型, `buildArrowPath` 拡張, `detectDetour`, `collectObstacles`
+- `src/lib/flow-engine.ts` — `calcArrowPath` の `obstacles` パススルー
+- `src/features/editor/FlowEditor.tsx` — `aPath` での bbox 抽出 + 渡し
+- `src/features/shared/SharedFlowViewer.tsx` — `computeArrowPath` での bbox 抽出 + 渡し
+- `src/lib/flow-engine.test.ts` 等 — 既存テスト追加
+- `src/lib/arrow-routing.test.ts` — 新規（または既存拡張）

--- a/docs/plans/2026-04-29-arrow-detour-design.md
+++ b/docs/plans/2026-04-29-arrow-detour-design.md
@@ -11,10 +11,12 @@
 ## スコープ
 
 ### 対象
+
 - 同一行で `from` から `to` の間のレーンに 1 つ以上ノードが存在する場合の水平直線パスの迂回
 - エディタ (`FlowEditor`) と共有ビュー (`SharedFlowViewer`) の両方
 
 ### 対象外
+
 - 縦方向（同一レーンで `from` と `to` の間にノードがある）の貫通対応 — 発生頻度が低いため今回は据え置き
 - 既存の Z 字 / L 字パス（縦横混合の出入口）に対する障害回避
 
@@ -48,10 +50,10 @@
 
 ### 責務分担
 
-| レイヤ | 責務 |
-|--------|------|
-| 呼び出し側 (`aPath` / `computeArrowPath`) | 同一行・直上行・直下行のノードを bbox 配列に変換して渡す。`from`/`to` 自身は除外 |
-| `arrow-routing.ts` | 与えられた bbox 群から経路上の障害を抽出し、上下塞がり判定・迂回方向決定・パス生成を完結 |
+| レイヤ                                    | 責務                                                                                     |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------- |
+| 呼び出し側 (`aPath` / `computeArrowPath`) | 同一行・直上行・直下行のノードを bbox 配列に変換して渡す。`from`/`to` 自身は除外         |
+| `arrow-routing.ts`                        | 与えられた bbox 群から経路上の障害を抽出し、上下塞がり判定・迂回方向決定・パス生成を完結 |
 
 ## 型定義と API
 
@@ -59,10 +61,10 @@
 
 ```ts
 export interface Bbox {
-  x: number  // 中心 X
-  y: number  // 中心 Y
-  w: number  // 幅
-  h: number  // 高さ
+  x: number // 中心 X
+  y: number // 中心 Y
+  w: number // 幅
+  h: number // 高さ
 }
 ```
 
@@ -85,20 +87,16 @@ export function calcArrowPath(
   from: NodePos,
   to: NodePos,
   config: ArrowConfig,
-  obstacles?: Bbox[],   // ← 新規
+  obstacles?: Bbox[], // ← 新規
 ): ArrowPathResult
 ```
 
 ### 内部定数・ヘルパー
 
 ```ts
-const DETOUR_MARGIN = 14  // 行間 28px の中央
+const DETOUR_MARGIN = 14 // 行間 28px の中央
 
-function detectDetour(
-  s: Point,
-  e: Point,
-  obstacles: Bbox[],
-): { detourY: number } | null
+function detectDetour(s: Point, e: Point, obstacles: Bbox[]): { detourY: number } | null
 ```
 
 ### 後方互換性
@@ -111,11 +109,7 @@ function detectDetour(
 ```ts
 const DETOUR_MARGIN = 14
 
-function detectDetour(
-  s: Point,
-  e: Point,
-  obstacles: Bbox[],
-): { detourY: number } | null {
+function detectDetour(s: Point, e: Point, obstacles: Bbox[]): { detourY: number } | null {
   // ① 水平直線でなければ迂回しない
   if (Math.abs(e.y - s.y) >= 2) return null
 
@@ -126,9 +120,7 @@ function detectDetour(
   // ② 経路上の障害ノード = 同一行（rowY と Y が重なる）かつ X が始終点の間
   const inRow = obstacles.filter(
     (b) =>
-      Math.abs(b.y - rowY) < b.h / 2 + 2 &&
-      b.x - b.w / 2 < xHigh - 1 &&
-      b.x + b.w / 2 > xLow + 1,
+      Math.abs(b.y - rowY) < b.h / 2 + 2 && b.x - b.w / 2 < xHigh - 1 && b.x + b.w / 2 > xLow + 1,
   )
   if (inRow.length === 0) return null
 
@@ -137,9 +129,7 @@ function detectDetour(
   const downBlocked = inRow.some((obs) =>
     obstacles.some((b) => b.y > obs.y + 1 && xOverlap(obs, b)),
   )
-  const upBlocked = inRow.some((obs) =>
-    obstacles.some((b) => b.y < obs.y - 1 && xOverlap(obs, b)),
-  )
+  const upBlocked = inRow.some((obs) => obstacles.some((b) => b.y < obs.y - 1 && xOverlap(obs, b)))
 
   // ④ 方向決定: 下空きなら下、下塞がり＆上空きなら上、両塞がりは下優先
   const goDown = !downBlocked || upBlocked
@@ -160,7 +150,7 @@ const detour = obstacles && obstacles.length > 0 ? detectDetour(s, e, obstacles)
 if (detour) {
   const { detourY } = detour
   const d = `M${s.x},${s.y} L${s.x},${detourY} L${e.x},${detourY} L${e.x},${e.y}`
-  return { d, mx: (s.x + e.x) / 2, my: detourY }  // ラベルは迂回区間の中点
+  return { d, mx: (s.x + e.x) / 2, my: detourY } // ラベルは迂回区間の中点
 }
 // ↓ 既存の直線/Z字/L字ロジック（変更なし）
 ```
@@ -171,10 +161,13 @@ if (detour) {
 
 ```ts
 const aPath = (arrow: InternalArrow): ArrowPathResult | null => {
-  const ft = tasks[arrow.from], tt = tasks[arrow.to]
+  const ft = tasks[arrow.from],
+    tt = tasks[arrow.to]
   if (!ft || !tt) return null
-  const fli = liMap[ft.lid], fri = riMap[ft.rid]
-  const tli = liMap[tt.lid], tri = riMap[tt.rid]
+  const fli = liMap[ft.lid],
+    fri = riMap[ft.rid]
+  const tli = liMap[tt.lid],
+    tri = riMap[tt.rid]
   if ([fli, fri, tli, tri].some((v) => v === undefined)) return null
 
   const from = ct(fli, fri)
@@ -185,7 +178,8 @@ const aPath = (arrow: InternalArrow): ArrowPathResult | null => {
     // タスク → ObstacleNode[] に変換（自身も含めて全部、collectObstacles 側で from/to を除外）
     const nodes: ObstacleNode[] = []
     for (const [k, t] of Object.entries(tasks)) {
-      const li = liMap[t.lid], ri = riMap[t.rid]
+      const li = liMap[t.lid],
+        ri = riMap[t.rid]
       if (li === undefined || ri === undefined) continue
       const c = ct(li, ri)
       nodes.push({ key: k, cx: c.x, cy: c.y })
@@ -204,8 +198,15 @@ const aPath = (arrow: InternalArrow): ArrowPathResult | null => {
   }
 
   return calcArrowPath(
-    from, to,
-    { hw: TW / 2, hh: TH / 2, rh: RH, fromShape: ft.shape ?? undefined, toShape: tt.shape ?? undefined },
+    from,
+    to,
+    {
+      hw: TW / 2,
+      hh: TH / 2,
+      rh: RH,
+      fromShape: ft.shape ?? undefined,
+      toShape: tt.shape ?? undefined,
+    },
     obstacles,
   )
 }
@@ -219,8 +220,8 @@ const aPath = (arrow: InternalArrow): ArrowPathResult | null => {
 // arrow-routing.ts
 export interface ObstacleNode {
   key: string
-  cx: number  // 中心 X
-  cy: number  // 中心 Y
+  cx: number // 中心 X
+  cy: number // 中心 Y
 }
 
 export interface CollectObstaclesArgs {
@@ -230,7 +231,7 @@ export interface CollectObstaclesArgs {
   fromCx: number
   toCx: number
   rowY: number
-  rowH: number    // 行高さ（直上/直下行判定用）
+  rowH: number // 行高さ（直上/直下行判定用）
   bboxW: number
   bboxH: number
 }
@@ -268,46 +269,50 @@ export function collectObstacles(args: CollectObstaclesArgs): Bbox[] {
 
 ## エラー処理・エッジケース
 
-| ケース | 期待挙動 |
-|--------|----------|
-| `obstacles` が `undefined` または `[]` | 既存挙動完全一致 |
-| 同一レーン縦方向矢印 | 既存挙動（スコープ外） |
-| 同一行・隣接レーン、間にノードなし | `inRow` 空 → 既存直線 |
-| `from === to`（自己参照）| `xLow === xHigh` → `inRow` 空 → 既存挙動 |
-| `from`/`to` 自身が bbox に混入 | 呼び出し側で除外 + arrow-routing 側でも X±1 マージンで二重防御 |
-| 最上行で上塞がり判定 | 直上行ノードが存在しない → 上塞がりは false → 仕様通り |
-| 浮きノード（liMap/riMap が undefined）| `collectObstacles` で除外 |
-| 不正 bbox（w=0, h=0）| 起こり得ないが、X 重なり判定が自然に false → 副作用なし |
+| ケース                                 | 期待挙動                                                       |
+| -------------------------------------- | -------------------------------------------------------------- |
+| `obstacles` が `undefined` または `[]` | 既存挙動完全一致                                               |
+| 同一レーン縦方向矢印                   | 既存挙動（スコープ外）                                         |
+| 同一行・隣接レーン、間にノードなし     | `inRow` 空 → 既存直線                                          |
+| `from === to`（自己参照）              | `xLow === xHigh` → `inRow` 空 → 既存挙動                       |
+| `from`/`to` 自身が bbox に混入         | 呼び出し側で除外 + arrow-routing 側でも X±1 マージンで二重防御 |
+| 最上行で上塞がり判定                   | 直上行ノードが存在しない → 上塞がりは false → 仕様通り         |
+| 浮きノード（liMap/riMap が undefined） | `collectObstacles` で除外                                      |
+| 不正 bbox（w=0, h=0）                  | 起こり得ないが、X 重なり判定が自然に false → 副作用なし        |
 
 ## テスト戦略
 
 ### `src/lib/arrow-routing.test.ts`（新規 or 既存拡張）
 
-| ケース | 期待 |
-|--------|------|
-| `obstacles` 省略 / 空 | 既存パスと完全一致 |
-| 同一行・障害1個・下空き | 下迂回、`detourY = B.y + B.h/2 + 14` |
-| 同一行・障害1個・直下塞がり・上空き | 上迂回、`detourY = B.y - B.h/2 - 14` |
-| 同一行・障害1個・両塞がり | 下迂回（下優先）|
-| 同一行・障害2個・下空き | まとめて下迂回、`detourY = max(B,C の最下端) + 14` |
-| 同一行・障害2個・1つだけ直下塞がり | 上迂回（1つでも塞がっていれば上）|
-| ラベル位置 | 迂回時 `mx = (s.x+e.x)/2`, `my = detourY` |
-| `from`/`to` 自身が bbox に混入 | X±1 マージンで除外、迂回しない |
+| ケース                              | 期待                                               |
+| ----------------------------------- | -------------------------------------------------- |
+| `obstacles` 省略 / 空               | 既存パスと完全一致                                 |
+| 同一行・障害1個・下空き             | 下迂回、`detourY = B.y + B.h/2 + 14`               |
+| 同一行・障害1個・直下塞がり・上空き | 上迂回、`detourY = B.y - B.h/2 - 14`               |
+| 同一行・障害1個・両塞がり           | 下迂回（下優先）                                   |
+| 同一行・障害2個・下空き             | まとめて下迂回、`detourY = max(B,C の最下端) + 14` |
+| 同一行・障害2個・1つだけ直下塞がり  | 上迂回（1つでも塞がっていれば上）                  |
+| ラベル位置                          | 迂回時 `mx = (s.x+e.x)/2`, `my = detourY`          |
+| `from`/`to` 自身が bbox に混入      | X±1 マージンで除外、迂回しない                     |
 
 ### `flow-engine.test.ts`（既存拡張）
+
 - 既存テストは引数省略で通る（後方互換）
 - `obstacles` を渡したときの 1〜2 ケース
 
 ### `collectObstacles` ヘルパーテスト
+
 - 同一行・直上行・直下行のみが集まる
 - `from`/`to` 自身が除外される
 - 浮きノード（座標 undefined）が無視される
 
 ### 統合テスト
+
 - FlowEditor: A→B、A→C 同一行 → A→C が下迂回 / B 直下にもノード → A→C は上迂回 / A→B 単独 → 直線
 - SharedFlowViewer: 同等のシナリオ 1〜2 ケース
 
 ### Playwright 目視確認（Workflow Step 6）
+
 1. A→B、A→C 同一行 → A→C が B を下に迂回
 2. A→C 単独（B あり）→ 同様に下迂回
 3. A→B 単独（隣接、間にノードなし）→ 従来直線

--- a/docs/plans/2026-04-29-arrow-detour-plan.md
+++ b/docs/plans/2026-04-29-arrow-detour-plan.md
@@ -25,14 +25,17 @@
 - ノード E: 中心 `(400, 116)`（B の直上、`rid-1`）
 
 矢印 A→C:
+
 - `exitPt(A, C)` → 横出口 `s = (276, 200)`（A.x + hw）
 - `entryPt(C, A)` → 横入口 `e = (524, 200)`（C.x - hw）
 
 B の bbox `{ x: 400, y: 200, w: 152, h: 56 }`:
+
 - 最下端 = `200 + 28 = 228`
 - 最上端 = `200 - 28 = 172`
 
 `DETOUR_MARGIN = 14` のとき:
+
 - 下迂回 detourY = `228 + 14 = 242`
 - 上迂回 detourY = `172 - 14 = 158`
 
@@ -40,20 +43,21 @@ B の bbox `{ x: 400, y: 200, w: 152, h: 56 }`:
 
 ## File Structure
 
-| ファイル | 役割 |
-|----------|------|
-| `src/lib/arrow-routing.ts` | `Bbox`/`ObstacleNode`/`CollectObstaclesArgs` 型, `DETOUR_MARGIN`, `detectDetour`（内部）, `buildArrowPath` 拡張, `collectObstacles` |
-| `src/lib/flow-engine.ts` | `calcArrowPath` の `obstacles` パススルー |
-| `src/features/editor/FlowEditor.tsx` | `aPath` で bbox 抽出 + `calcArrowPath` 呼び出し |
-| `src/features/shared/SharedFlowViewer.tsx` | `computeArrowPath` で bbox 抽出 + `buildArrowPath` 呼び出し |
-| `src/lib/arrow-routing.test.ts` | 新規。`Bbox`/`detectDetour`（buildArrowPath 経由）、`collectObstacles` のテスト |
-| `src/lib/flow-engine.test.ts` | `calcArrowPath` の `obstacles` パススルーテスト追加 |
+| ファイル                                   | 役割                                                                                                                                |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `src/lib/arrow-routing.ts`                 | `Bbox`/`ObstacleNode`/`CollectObstaclesArgs` 型, `DETOUR_MARGIN`, `detectDetour`（内部）, `buildArrowPath` 拡張, `collectObstacles` |
+| `src/lib/flow-engine.ts`                   | `calcArrowPath` の `obstacles` パススルー                                                                                           |
+| `src/features/editor/FlowEditor.tsx`       | `aPath` で bbox 抽出 + `calcArrowPath` 呼び出し                                                                                     |
+| `src/features/shared/SharedFlowViewer.tsx` | `computeArrowPath` で bbox 抽出 + `buildArrowPath` 呼び出し                                                                         |
+| `src/lib/arrow-routing.test.ts`            | 新規。`Bbox`/`detectDetour`（buildArrowPath 経由）、`collectObstacles` のテスト                                                     |
+| `src/lib/flow-engine.test.ts`              | `calcArrowPath` の `obstacles` パススルーテスト追加                                                                                 |
 
 ---
 
 ## Task 1: arrow-routing.ts に Bbox 型と buildArrowPath の obstacles 引数を追加（TDD）
 
 **Files:**
+
 - Create: `src/lib/arrow-routing.test.ts`
 - Modify: `src/lib/arrow-routing.ts`
 
@@ -109,8 +113,8 @@ describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
   })
 
   it('同一行・障害2個・下空き → まとめて下迂回（detourY は最下端の最大）', () => {
-    const B: Bbox = { x: 380, y: 200, w: 152, h: 56 }   // 最下端 228
-    const C2: Bbox = { x: 480, y: 200, w: 152, h: 80 }  // 最下端 240
+    const B: Bbox = { x: 380, y: 200, w: 152, h: 56 } // 最下端 228
+    const C2: Bbox = { x: 480, y: 200, w: 152, h: 80 } // 最下端 240
     // 始終点を広げる: A=(200,200) → 終点=(700,200)
     const sExt = { x: 276, y: 200 }
     const eExt = { x: 624, y: 200 }
@@ -123,14 +127,10 @@ describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
   it('同一行・障害2個・1つだけ直下塞がり → 上迂回', () => {
     const B: Bbox = { x: 380, y: 200, w: 152, h: 56 }
     const C2: Bbox = { x: 480, y: 200, w: 152, h: 56 }
-    const Bdown: Bbox = { x: 380, y: 284, w: 152, h: 56 }  // B 直下のみ塞がり
+    const Bdown: Bbox = { x: 380, y: 284, w: 152, h: 56 } // B 直下のみ塞がり
     const sExt = { x: 276, y: 200 }
     const eExt = { x: 624, y: 200 }
-    const r = buildArrowPath(
-      sExt, eExt,
-      { x: 200, y: 200 }, { x: 700, y: 200 },
-      [B, C2, Bdown],
-    )
+    const r = buildArrowPath(sExt, eExt, { x: 200, y: 200 }, { x: 700, y: 200 }, [B, C2, Bdown])
     // 1つでも直下塞がりがあれば上迂回。最上端 min(172, 172) = 172, detourY = 158
     expect(r.my).toBe(158)
   })
@@ -151,14 +151,16 @@ describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
     const r = buildArrowPath(sDiag, eDiag, { x: 200, y: 200 }, { x: 600, y: 300 }, [B])
     // dy=100, dx=248: 縦出口でない（s.y - fc.y = 0, s.x - fc.x = 76 → sV false）
     // 横出口→縦入口（または両横）→ 既存ロジックの結果
-    expect(r.d).not.toContain('L276,242')  // 迂回パスではない
+    expect(r.d).not.toContain('L276,242') // 迂回パスではない
   })
 
   it('始終点が同じ X（自己参照） → inRow 空 → 直線', () => {
     const B: Bbox = { x: 200, y: 200, w: 152, h: 56 }
     const r = buildArrowPath(
-      { x: 200, y: 200 }, { x: 200, y: 200 },
-      { x: 200, y: 200 }, { x: 200, y: 200 },
+      { x: 200, y: 200 },
+      { x: 200, y: 200 },
+      { x: 200, y: 200 },
+      { x: 200, y: 200 },
       [B],
     )
     expect(r.d).toBe('M200,200 L200,200')
@@ -166,8 +168,8 @@ describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
 
   it('from/to 自身の bbox が混入しても X±1 マージンで除外される', () => {
     // start=(276,200) の真上にある bbox（A 自身を表すかのような位置）は inRow 判定で除外される
-    const fromSelfBbox: Bbox = { x: 200, y: 200, w: 152, h: 56 }  // 左端 124, 右端 276
-    const toSelfBbox: Bbox = { x: 600, y: 200, w: 152, h: 56 }    // 左端 524, 右端 676
+    const fromSelfBbox: Bbox = { x: 200, y: 200, w: 152, h: 56 } // 左端 124, 右端 276
+    const toSelfBbox: Bbox = { x: 600, y: 200, w: 152, h: 56 } // 左端 524, 右端 676
     const r = buildArrowPath(s, e, fc, tc, [fromSelfBbox, toSelfBbox])
     // どちらも inRow フィルタの X 判定で除外される（X±1 マージン）
     expect(r.d).toBe('M276,200 L524,200')
@@ -186,19 +188,15 @@ Expected: 全テスト FAIL（`Bbox` 型なし、`buildArrowPath` が 5 引数�
 
 ```ts
 export interface Bbox {
-  x: number  // 中心 X
-  y: number  // 中心 Y
-  w: number  // 幅
-  h: number  // 高さ
+  x: number // 中心 X
+  y: number // 中心 Y
+  w: number // 幅
+  h: number // 高さ
 }
 
 const DETOUR_MARGIN = 14
 
-function detectDetour(
-  s: Point,
-  e: Point,
-  obstacles: Bbox[],
-): { detourY: number } | null {
+function detectDetour(s: Point, e: Point, obstacles: Bbox[]): { detourY: number } | null {
   // 水平直線でなければ迂回しない
   if (Math.abs(e.y - s.y) >= 2) return null
 
@@ -209,9 +207,7 @@ function detectDetour(
   // 経路上の障害ノード = 同一行（rowY と Y が重なる）かつ X が始終点の間
   const inRow = obstacles.filter(
     (b) =>
-      Math.abs(b.y - rowY) < b.h / 2 + 2 &&
-      b.x - b.w / 2 < xHigh - 1 &&
-      b.x + b.w / 2 > xLow + 1,
+      Math.abs(b.y - rowY) < b.h / 2 + 2 && b.x - b.w / 2 < xHigh - 1 && b.x + b.w / 2 > xLow + 1,
   )
   if (inRow.length === 0) return null
 
@@ -220,9 +216,7 @@ function detectDetour(
   const downBlocked = inRow.some((obs) =>
     obstacles.some((b) => b.y > obs.y + 1 && xOverlap(obs, b)),
   )
-  const upBlocked = inRow.some((obs) =>
-    obstacles.some((b) => b.y < obs.y - 1 && xOverlap(obs, b)),
-  )
+  const upBlocked = inRow.some((obs) => obstacles.some((b) => b.y < obs.y - 1 && xOverlap(obs, b)))
 
   // 方向決定: 下空きなら下、下塞がり＆上空きなら上、両塞がりは下優先
   const goDown = !downBlocked || upBlocked
@@ -312,6 +306,7 @@ git commit -m "feat(#314): add Bbox type and obstacle-aware arrow detour to buil
 ## Task 2: flow-engine.ts の calcArrowPath を obstacles パススルーに拡張（TDD）
 
 **Files:**
+
 - Modify: `src/lib/flow-engine.ts`
 - Modify: `src/lib/flow-engine.test.ts`
 
@@ -320,34 +315,34 @@ git commit -m "feat(#314): add Bbox type and obstacle-aware arrow detour to buil
 `src/lib/flow-engine.test.ts` の既存 `describe('calcArrowPath', ...)` ブロックの最後の `it` の後ろに以下を追加:
 
 ```ts
-  it('should pass obstacles through to buildArrowPath and produce detour path', () => {
-    // A=(200,200) → C=(600,200) 同一行、間に B (400,200) 障害
-    const obstacles = [{ x: 400, y: 200, w: 152, h: 56 }]
-    const r = calcArrowPath(
-      { x: 200, y: 200 },
-      { x: 600, y: 200 },
-      { hw: 76, hh: 28, rh: 84 },
-      obstacles,
-    )
-    expect(r).not.toBeNull()
-    // exitPt: dx=400 横出口 {276,200}, entryPt: 横入口 {524,200}
-    // 迂回: detourY = 228 + 14 = 242
-    expect(r.d).toBe('M276,200 L276,242 L524,242 L524,200')
-    expect(r.mx).toBe(400)
-    expect(r.my).toBe(242)
-  })
+it('should pass obstacles through to buildArrowPath and produce detour path', () => {
+  // A=(200,200) → C=(600,200) 同一行、間に B (400,200) 障害
+  const obstacles = [{ x: 400, y: 200, w: 152, h: 56 }]
+  const r = calcArrowPath(
+    { x: 200, y: 200 },
+    { x: 600, y: 200 },
+    { hw: 76, hh: 28, rh: 84 },
+    obstacles,
+  )
+  expect(r).not.toBeNull()
+  // exitPt: dx=400 横出口 {276,200}, entryPt: 横入口 {524,200}
+  // 迂回: detourY = 228 + 14 = 242
+  expect(r.d).toBe('M276,200 L276,242 L524,242 L524,200')
+  expect(r.mx).toBe(400)
+  expect(r.my).toBe(242)
+})
 
-  it('should ignore obstacles when arrow is not horizontal', () => {
-    const obstacles = [{ x: 200, y: 200, w: 152, h: 56 }]
-    const r = calcArrowPath(
-      { x: 100, y: 100 },
-      { x: 100, y: 300 },
-      { hw: 76, hh: 28, rh: 84 },
-      obstacles,
-    )
-    // 縦パスなので obstacles 無視 → 既存の直線
-    expect(r.d).toBe('M100,128 L100,272')
-  })
+it('should ignore obstacles when arrow is not horizontal', () => {
+  const obstacles = [{ x: 200, y: 200, w: 152, h: 56 }]
+  const r = calcArrowPath(
+    { x: 100, y: 100 },
+    { x: 100, y: 300 },
+    { hw: 76, hh: 28, rh: 84 },
+    obstacles,
+  )
+  // 縦パスなので obstacles 無視 → 既存の直線
+  expect(r.d).toBe('M100,128 L100,272')
+})
 ```
 
 - [ ] **Step 2: テスト実行 → FAIL を確認**
@@ -398,6 +393,7 @@ git commit -m "feat(#314): pass obstacles through calcArrowPath to buildArrowPat
 ## Task 3: arrow-routing.ts に collectObstacles ヘルパー追加（TDD）
 
 **Files:**
+
 - Modify: `src/lib/arrow-routing.ts`
 - Modify: `src/lib/arrow-routing.test.ts`
 
@@ -407,12 +403,7 @@ git commit -m "feat(#314): pass obstacles through calcArrowPath to buildArrowPat
 
 ```ts
 import { describe, it, expect } from 'vitest'
-import {
-  buildArrowPath,
-  collectObstacles,
-  type Bbox,
-  type ObstacleNode,
-} from './arrow-routing'
+import { buildArrowPath, collectObstacles, type Bbox, type ObstacleNode } from './arrow-routing'
 ```
 
 ファイル末尾に新規 describe ブロック追加:
@@ -422,7 +413,9 @@ describe('collectObstacles', () => {
   // A=(200,200), B=(400,200), C=(600,200) 同一行 (rowY=200)
   // D=(400,284) B 直下行, E=(400,116) B 直上行
   // F=(400,368) 2行下（除外対象）
-  const TW = 152, TH = 56, RH = 84
+  const TW = 152,
+    TH = 56,
+    RH = 84
 
   const baseNodes: ObstacleNode[] = [
     { key: 'A', cx: 200, cy: 200 },
@@ -517,8 +510,8 @@ Expected: 新規テスト FAIL（`collectObstacles` 未定義）
 ```ts
 export interface ObstacleNode {
   key: string
-  cx: number  // 中心 X
-  cy: number  // 中心 Y
+  cx: number // 中心 X
+  cy: number // 中心 Y
 }
 
 export interface CollectObstaclesArgs {
@@ -528,7 +521,7 @@ export interface CollectObstaclesArgs {
   fromCx: number
   toCx: number
   rowY: number
-  rowH: number    // 行高さ（直上/直下行判定用）
+  rowH: number // 行高さ（直上/直下行判定用）
   bboxW: number
   bboxH: number
 }
@@ -585,6 +578,7 @@ git commit -m "feat(#314): add collectObstacles helper for in-row + adjacent-row
 ## Task 4: FlowEditor.aPath を更新して obstacles を渡す
 
 **Files:**
+
 - Modify: `src/features/editor/FlowEditor.tsx`
 
 - [ ] **Step 1: import に collectObstacles, Bbox, ObstacleNode 型を追加**
@@ -598,12 +592,7 @@ import { DS } from '../../lib/arrow-routing'
 を以下に置き換える:
 
 ```ts
-import {
-  DS,
-  collectObstacles,
-  type Bbox,
-  type ObstacleNode,
-} from '../../lib/arrow-routing'
+import { DS, collectObstacles, type Bbox, type ObstacleNode } from '../../lib/arrow-routing'
 ```
 
 `flow-engine` 由来の `calcArrowPath` import（`src/features/editor/FlowEditor.tsx:50`）は変更不要。
@@ -613,56 +602,56 @@ import {
 `src/features/editor/FlowEditor.tsx` の `aPath` 関数（`src/features/editor/FlowEditor.tsx:1362` 付近）を以下に置き換える:
 
 ```ts
-  const aPath = (arrow: InternalArrow): ArrowPathResult | null => {
-    const ft = tasks[arrow.from],
-      tt = tasks[arrow.to]
-    if (!ft || !tt) return null
-    const fli = liMap[ft.lid],
-      fri = riMap[ft.rid],
-      tli = liMap[tt.lid],
-      tri = riMap[tt.rid]
-    if ([fli, fri, tli, tri].some((v) => v === undefined)) return null
-    const from = ct(fli, fri)
-    const to = ct(tli, tri)
+const aPath = (arrow: InternalArrow): ArrowPathResult | null => {
+  const ft = tasks[arrow.from],
+    tt = tasks[arrow.to]
+  if (!ft || !tt) return null
+  const fli = liMap[ft.lid],
+    fri = riMap[ft.rid],
+    tli = liMap[tt.lid],
+    tri = riMap[tt.rid]
+  if ([fli, fri, tli, tri].some((v) => v === undefined)) return null
+  const from = ct(fli, fri)
+  const to = ct(tli, tri)
 
-    // 同一行のときのみ obstacles を組み立てる
-    let obstacles: Bbox[] | undefined
-    if (fri === tri) {
-      const nodes: ObstacleNode[] = []
-      for (const k of Object.keys(tasks)) {
-        const t = tasks[k]
-        const li = liMap[t.lid]
-        const ri = riMap[t.rid]
-        if (li === undefined || ri === undefined) continue
-        const c = ct(li, ri)
-        nodes.push({ key: k, cx: c.x, cy: c.y })
-      }
-      obstacles = collectObstacles({
-        nodes,
-        fromKey: arrow.from,
-        toKey: arrow.to,
-        fromCx: from.x,
-        toCx: to.x,
-        rowY: from.y,
-        rowH: RH,
-        bboxW: TW,
-        bboxH: TH,
-      })
+  // 同一行のときのみ obstacles を組み立てる
+  let obstacles: Bbox[] | undefined
+  if (fri === tri) {
+    const nodes: ObstacleNode[] = []
+    for (const k of Object.keys(tasks)) {
+      const t = tasks[k]
+      const li = liMap[t.lid]
+      const ri = riMap[t.rid]
+      if (li === undefined || ri === undefined) continue
+      const c = ct(li, ri)
+      nodes.push({ key: k, cx: c.x, cy: c.y })
     }
-
-    return calcArrowPath(
-      from,
-      to,
-      {
-        hw: TW / 2,
-        hh: TH / 2,
-        rh: RH,
-        fromShape: ft.shape ?? undefined,
-        toShape: tt.shape ?? undefined,
-      },
-      obstacles,
-    )
+    obstacles = collectObstacles({
+      nodes,
+      fromKey: arrow.from,
+      toKey: arrow.to,
+      fromCx: from.x,
+      toCx: to.x,
+      rowY: from.y,
+      rowH: RH,
+      bboxW: TW,
+      bboxH: TH,
+    })
   }
+
+  return calcArrowPath(
+    from,
+    to,
+    {
+      hw: TW / 2,
+      hh: TH / 2,
+      rh: RH,
+      fromShape: ft.shape ?? undefined,
+      toShape: tt.shape ?? undefined,
+    },
+    obstacles,
+  )
+}
 ```
 
 - [ ] **Step 3: TypeScript 型チェック・全テスト実行**
@@ -675,6 +664,7 @@ Expected: 全 PASS（既存テストへの影響なし、aPath は外部 API で
 Run: `npm run dev`
 
 ブラウザで以下を確認:
+
 1. 既存フローを開いて、矢印が従来どおり描画されるか（リグレッションなし）
 2. 同一行 A→B、A→C の構成を作って A→C が B を下に迂回するか
 3. B の直下にノードを配置して A→C が上に迂回するか
@@ -693,6 +683,7 @@ git commit -m "feat(#314): wire obstacles into FlowEditor.aPath via collectObsta
 ## Task 5: SharedFlowViewer.computeArrowPath を更新して obstacles を渡す
 
 **Files:**
+
 - Modify: `src/features/shared/SharedFlowViewer.tsx`
 
 - [ ] **Step 1: import に collectObstacles, Bbox, ObstacleNode を追加**
@@ -717,48 +708,48 @@ import {
 既存の `computeArrowPath` 関数（`src/features/shared/SharedFlowViewer.tsx:93` 付近）を以下に置き換える:
 
 ```ts
-  // Arrow path calculation
-  const computeArrowPath = (arrow: Arrow): { d: string; mx: number; my: number } | null => {
-    const fromNode = nodeById[arrow.fromNodeId]
-    const toNode = nodeById[arrow.toNodeId]
-    if (!fromNode || !toNode) return null
+// Arrow path calculation
+const computeArrowPath = (arrow: Arrow): { d: string; mx: number; my: number } | null => {
+  const fromNode = nodeById[arrow.fromNodeId]
+  const toNode = nodeById[arrow.toNodeId]
+  if (!fromNode || !toNode) return null
 
-    const fli = laneIdToIndex[fromNode.laneId]
-    const tli = laneIdToIndex[toNode.laneId]
-    if (fli === undefined || tli === undefined) return null
+  const fli = laneIdToIndex[fromNode.laneId]
+  const tli = laneIdToIndex[toNode.laneId]
+  if (fli === undefined || tli === undefined) return null
 
-    const f = ct(fli, fromNode.rowIndex)
-    const t = ct(tli, toNode.rowIndex)
-    const hw = TW / 2,
-      hh = TH / 2
-    const s = exitPt(f, t, hw, hh, RH, fromNode.shape as 'diamond' | undefined)
-    const e = entryPt(t, f, hw, hh, RH, toNode.shape as 'diamond' | undefined)
+  const f = ct(fli, fromNode.rowIndex)
+  const t = ct(tli, toNode.rowIndex)
+  const hw = TW / 2,
+    hh = TH / 2
+  const s = exitPt(f, t, hw, hh, RH, fromNode.shape as 'diamond' | undefined)
+  const e = entryPt(t, f, hw, hh, RH, toNode.shape as 'diamond' | undefined)
 
-    // 同一行のときのみ obstacles を組み立てる
-    let obstacles: Bbox[] | undefined
-    if (fromNode.rowIndex === toNode.rowIndex) {
-      const nodes: ObstacleNode[] = []
-      for (const n of flow.nodes) {
-        const li = laneIdToIndex[n.laneId]
-        if (li === undefined) continue
-        const c = ct(li, n.rowIndex)
-        nodes.push({ key: n.id, cx: c.x, cy: c.y })
-      }
-      obstacles = collectObstacles({
-        nodes,
-        fromKey: fromNode.id,
-        toKey: toNode.id,
-        fromCx: f.x,
-        toCx: t.x,
-        rowY: f.y,
-        rowH: RH,
-        bboxW: TW,
-        bboxH: TH,
-      })
+  // 同一行のときのみ obstacles を組み立てる
+  let obstacles: Bbox[] | undefined
+  if (fromNode.rowIndex === toNode.rowIndex) {
+    const nodes: ObstacleNode[] = []
+    for (const n of flow.nodes) {
+      const li = laneIdToIndex[n.laneId]
+      if (li === undefined) continue
+      const c = ct(li, n.rowIndex)
+      nodes.push({ key: n.id, cx: c.x, cy: c.y })
     }
-
-    return buildArrowPath(s, e, f, t, obstacles)
+    obstacles = collectObstacles({
+      nodes,
+      fromKey: fromNode.id,
+      toKey: toNode.id,
+      fromCx: f.x,
+      toCx: t.x,
+      rowY: f.y,
+      rowH: RH,
+      bboxW: TW,
+      bboxH: TH,
+    })
   }
+
+  return buildArrowPath(s, e, f, t, obstacles)
+}
 ```
 
 - [ ] **Step 3: 全テスト実行**
@@ -778,6 +769,7 @@ git commit -m "feat(#314): wire obstacles into SharedFlowViewer.computeArrowPath
 ## Task 6: Playwright で実画面検証（受け入れ基準シナリオ）
 
 **Files:**
+
 - Save: `.screenshots/issue-314-*.png`
 
 - [ ] **Step 1: dev server を起動**
@@ -822,6 +814,7 @@ LCP > 1000ms の場合は実装パフォーマンスを見直す。
 - [ ] **Step 4: 共有ビューでも同様に確認**
 
 共有リンクを発行（または既存の共有 URL を使用）し、同じ A→C 構成が共有ビューでも下迂回するか確認。
+
 - スクリーンショット: `.screenshots/issue-314-shared-view-detour.png`
 
 - [ ] **Step 5: 全テスト最終実行**

--- a/docs/plans/2026-04-29-arrow-detour-plan.md
+++ b/docs/plans/2026-04-29-arrow-detour-plan.md
@@ -1,0 +1,834 @@
+# Arrow Detour 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 同一行で複数レーンをまたぐ矢印が経路上のノードを貫通する問題を解消し、自動で下（または上）に迂回するパスを生成する。
+
+**Architecture:** `arrow-routing.ts` の `buildArrowPath` に第5引数 `obstacles?: Bbox[]` を追加。内部ヘルパー `detectDetour` が「水平直線・経路上に障害ノードあり」を検知し迂回 Y 座標を返す。`collectObstacles` ヘルパーが「同一行＋直上・直下行のノード」を bbox 化。`FlowEditor.aPath` と `SharedFlowViewer.computeArrowPath` が同ヘルパーで bbox を組み立てて渡す。
+
+**Tech Stack:** TypeScript, React, Vitest, Playwright
+
+**Spec:** `docs/plans/2026-04-29-arrow-detour-design.md`
+
+**Issue:** [#314](https://github.com/tomohirof/flowline/issues/314)
+
+---
+
+## 想定座標系（テスト中で繰り返し使う基準）
+
+`hw = 76`, `hh = 28`, `rh = 84`（`TW = 152`, `TH = 56`, `RH = 84`）
+
+- ノード A: 中心 `(200, 200)`
+- ノード B: 中心 `(400, 200)`（同一行）
+- ノード C: 中心 `(600, 200)`（同一行、A の右）
+- ノード D: 中心 `(400, 284)`（B の直下、`rid+1`）
+- ノード E: 中心 `(400, 116)`（B の直上、`rid-1`）
+
+矢印 A→C:
+- `exitPt(A, C)` → 横出口 `s = (276, 200)`（A.x + hw）
+- `entryPt(C, A)` → 横入口 `e = (524, 200)`（C.x - hw）
+
+B の bbox `{ x: 400, y: 200, w: 152, h: 56 }`:
+- 最下端 = `200 + 28 = 228`
+- 最上端 = `200 - 28 = 172`
+
+`DETOUR_MARGIN = 14` のとき:
+- 下迂回 detourY = `228 + 14 = 242`
+- 上迂回 detourY = `172 - 14 = 158`
+
+---
+
+## File Structure
+
+| ファイル | 役割 |
+|----------|------|
+| `src/lib/arrow-routing.ts` | `Bbox`/`ObstacleNode`/`CollectObstaclesArgs` 型, `DETOUR_MARGIN`, `detectDetour`（内部）, `buildArrowPath` 拡張, `collectObstacles` |
+| `src/lib/flow-engine.ts` | `calcArrowPath` の `obstacles` パススルー |
+| `src/features/editor/FlowEditor.tsx` | `aPath` で bbox 抽出 + `calcArrowPath` 呼び出し |
+| `src/features/shared/SharedFlowViewer.tsx` | `computeArrowPath` で bbox 抽出 + `buildArrowPath` 呼び出し |
+| `src/lib/arrow-routing.test.ts` | 新規。`Bbox`/`detectDetour`（buildArrowPath 経由）、`collectObstacles` のテスト |
+| `src/lib/flow-engine.test.ts` | `calcArrowPath` の `obstacles` パススルーテスト追加 |
+
+---
+
+## Task 1: arrow-routing.ts に Bbox 型と buildArrowPath の obstacles 引数を追加（TDD）
+
+**Files:**
+- Create: `src/lib/arrow-routing.test.ts`
+- Modify: `src/lib/arrow-routing.ts`
+
+- [ ] **Step 1: 新規テストファイル `src/lib/arrow-routing.test.ts` を作成し、buildArrowPath の `obstacles` 拡張に関するテストを書く（FAIL を確認するための失敗テスト）**
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { buildArrowPath, type Bbox } from './arrow-routing'
+
+describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
+  // 共通の始終点（A→C 同一行、A=(200,200), C=(600,200) のときの exitPt/entryPt 後の値）
+  const s = { x: 276, y: 200 }
+  const e = { x: 524, y: 200 }
+  const fc = { x: 200, y: 200 }
+  const tc = { x: 600, y: 200 }
+
+  it('obstacles 省略 → 既存の直線パスを返す（後方互換）', () => {
+    const r = buildArrowPath(s, e, fc, tc)
+    expect(r.d).toBe('M276,200 L524,200')
+    expect(r.mx).toBe(400)
+    expect(r.my).toBe(200)
+  })
+
+  it('obstacles が空配列 → 既存の直線パスを返す', () => {
+    const r = buildArrowPath(s, e, fc, tc, [])
+    expect(r.d).toBe('M276,200 L524,200')
+  })
+
+  it('同一行・障害1個・上下空き → 下迂回パス（detourY = 障害下端 + 14）', () => {
+    const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B])
+    // detourY = 200 + 28 + 14 = 242
+    expect(r.d).toBe('M276,200 L276,242 L524,242 L524,200')
+    expect(r.mx).toBe(400)
+    expect(r.my).toBe(242)
+  })
+
+  it('同一行・障害1個・直下塞がり → 上迂回（detourY = 障害上端 - 14）', () => {
+    const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
+    const D: Bbox = { x: 400, y: 284, w: 152, h: 56 } // B の直下
+    const r = buildArrowPath(s, e, fc, tc, [B, D])
+    // detourY = 200 - 28 - 14 = 158
+    expect(r.d).toBe('M276,200 L276,158 L524,158 L524,200')
+    expect(r.my).toBe(158)
+  })
+
+  it('同一行・障害1個・両塞がり → 下優先で下迂回', () => {
+    const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
+    const D: Bbox = { x: 400, y: 284, w: 152, h: 56 }
+    const E: Bbox = { x: 400, y: 116, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B, D, E])
+    expect(r.my).toBe(242) // 下迂回
+  })
+
+  it('同一行・障害2個・下空き → まとめて下迂回（detourY は最下端の最大）', () => {
+    const B: Bbox = { x: 380, y: 200, w: 152, h: 56 }   // 最下端 228
+    const C2: Bbox = { x: 480, y: 200, w: 152, h: 80 }  // 最下端 240
+    // 始終点を広げる: A=(200,200) → 終点=(700,200)
+    const sExt = { x: 276, y: 200 }
+    const eExt = { x: 624, y: 200 }
+    const r = buildArrowPath(sExt, eExt, { x: 200, y: 200 }, { x: 700, y: 200 }, [B, C2])
+    // 最下端 max(228, 240) = 240, detourY = 254
+    expect(r.my).toBe(254)
+    expect(r.d).toBe('M276,200 L276,254 L624,254 L624,200')
+  })
+
+  it('同一行・障害2個・1つだけ直下塞がり → 上迂回', () => {
+    const B: Bbox = { x: 380, y: 200, w: 152, h: 56 }
+    const C2: Bbox = { x: 480, y: 200, w: 152, h: 56 }
+    const Bdown: Bbox = { x: 380, y: 284, w: 152, h: 56 }  // B 直下のみ塞がり
+    const sExt = { x: 276, y: 200 }
+    const eExt = { x: 624, y: 200 }
+    const r = buildArrowPath(
+      sExt, eExt,
+      { x: 200, y: 200 }, { x: 700, y: 200 },
+      [B, C2, Bdown],
+    )
+    // 1つでも直下塞がりがあれば上迂回。最上端 min(172, 172) = 172, detourY = 158
+    expect(r.my).toBe(158)
+  })
+
+  it('同一行・障害なし（経路上に bbox がない）→ 直線', () => {
+    // bbox が始終点 X 範囲外
+    const farLeft: Bbox = { x: 100, y: 200, w: 152, h: 56 }
+    const farRight: Bbox = { x: 800, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [farLeft, farRight])
+    expect(r.d).toBe('M276,200 L524,200')
+  })
+
+  it('斜め方向（dy >= 2）→ 既存の Z/L 字ロジック（迂回しない）', () => {
+    // s=(276,200), e=(524,300) のような斜めパス
+    const sDiag = { x: 276, y: 200 }
+    const eDiag = { x: 524, y: 300 }
+    const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(sDiag, eDiag, { x: 200, y: 200 }, { x: 600, y: 300 }, [B])
+    // dy=100, dx=248: 縦出口でない（s.y - fc.y = 0, s.x - fc.x = 76 → sV false）
+    // 横出口→縦入口（または両横）→ 既存ロジックの結果
+    expect(r.d).not.toContain('L276,242')  // 迂回パスではない
+  })
+
+  it('始終点が同じ X（自己参照） → inRow 空 → 直線', () => {
+    const B: Bbox = { x: 200, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(
+      { x: 200, y: 200 }, { x: 200, y: 200 },
+      { x: 200, y: 200 }, { x: 200, y: 200 },
+      [B],
+    )
+    expect(r.d).toBe('M200,200 L200,200')
+  })
+
+  it('from/to 自身の bbox が混入しても X±1 マージンで除外される', () => {
+    // start=(276,200) の真上にある bbox（A 自身を表すかのような位置）は inRow 判定で除外される
+    const fromSelfBbox: Bbox = { x: 200, y: 200, w: 152, h: 56 }  // 左端 124, 右端 276
+    const toSelfBbox: Bbox = { x: 600, y: 200, w: 152, h: 56 }    // 左端 524, 右端 676
+    const r = buildArrowPath(s, e, fc, tc, [fromSelfBbox, toSelfBbox])
+    // どちらも inRow フィルタの X 判定で除外される（X±1 マージン）
+    expect(r.d).toBe('M276,200 L524,200')
+  })
+})
+```
+
+- [ ] **Step 2: テスト実行 → FAIL を確認**
+
+Run: `npx vitest run src/lib/arrow-routing.test.ts`
+Expected: 全テスト FAIL（`Bbox` 型なし、`buildArrowPath` が 5 引数を受け付けない）
+
+- [ ] **Step 3: `src/lib/arrow-routing.ts` に Bbox 型と buildArrowPath 拡張を実装**
+
+`src/lib/arrow-routing.ts` のファイル先頭の `Point` インターフェースの直後に追加:
+
+```ts
+export interface Bbox {
+  x: number  // 中心 X
+  y: number  // 中心 Y
+  w: number  // 幅
+  h: number  // 高さ
+}
+
+const DETOUR_MARGIN = 14
+
+function detectDetour(
+  s: Point,
+  e: Point,
+  obstacles: Bbox[],
+): { detourY: number } | null {
+  // 水平直線でなければ迂回しない
+  if (Math.abs(e.y - s.y) >= 2) return null
+
+  const xLow = Math.min(s.x, e.x)
+  const xHigh = Math.max(s.x, e.x)
+  const rowY = s.y
+
+  // 経路上の障害ノード = 同一行（rowY と Y が重なる）かつ X が始終点の間
+  const inRow = obstacles.filter(
+    (b) =>
+      Math.abs(b.y - rowY) < b.h / 2 + 2 &&
+      b.x - b.w / 2 < xHigh - 1 &&
+      b.x + b.w / 2 > xLow + 1,
+  )
+  if (inRow.length === 0) return null
+
+  // 上下塞がり判定（X 重なりするノードが直上/直下に存在するか）
+  const xOverlap = (a: Bbox, b: Bbox) => Math.abs(a.x - b.x) < (a.w + b.w) / 2
+  const downBlocked = inRow.some((obs) =>
+    obstacles.some((b) => b.y > obs.y + 1 && xOverlap(obs, b)),
+  )
+  const upBlocked = inRow.some((obs) =>
+    obstacles.some((b) => b.y < obs.y - 1 && xOverlap(obs, b)),
+  )
+
+  // 方向決定: 下空きなら下、下塞がり＆上空きなら上、両塞がりは下優先
+  const goDown = !downBlocked || upBlocked
+
+  // detourY: 障害ノード群の最下端 + マージン or 最上端 - マージン
+  const detourY = goDown
+    ? Math.max(...inRow.map((o) => o.y + o.h / 2)) + DETOUR_MARGIN
+    : Math.min(...inRow.map((o) => o.y - o.h / 2)) - DETOUR_MARGIN
+
+  return { detourY }
+}
+```
+
+そして既存の `buildArrowPath` の宣言と本体を以下に置き換える:
+
+```ts
+export const buildArrowPath = (
+  s: Point,
+  e: Point,
+  fc: Point,
+  tc: Point,
+  obstacles?: Bbox[],
+): ArrowPath => {
+  const dx = e.x - s.x,
+    dy = e.y - s.y
+
+  // 迂回モード: 同一行で経路上に障害ノードがある場合
+  if (obstacles && obstacles.length > 0) {
+    const detour = detectDetour(s, e, obstacles)
+    if (detour) {
+      const { detourY } = detour
+      const d = `M${s.x},${s.y} L${s.x},${detourY} L${e.x},${detourY} L${e.x},${e.y}`
+      return { d, mx: (s.x + e.x) / 2, my: detourY }
+    }
+  }
+
+  let d: string
+
+  // 直線パス: ほぼ垂直またはほぼ水平
+  if (Math.abs(dx) < 2 || Math.abs(dy) < 2) {
+    d = `M${s.x},${s.y} L${e.x},${e.y}`
+  } else {
+    // 出口が縦方向かどうかを判定（ノード中心との差で判別）
+    const sV = Math.abs(s.y - fc.y) > Math.abs(s.x - fc.x)
+    const eV = Math.abs(e.y - tc.y) > Math.abs(e.x - tc.x)
+
+    if (sV && eV) {
+      // 両方縦出口: Z字パス（横方向に折り返す）
+      const my = (s.y + e.y) / 2
+      d = `M${s.x},${s.y} L${s.x},${my} L${e.x},${my} L${e.x},${e.y}`
+    } else if (!sV && !eV) {
+      // 両方横出口: Z字パス（縦方向に折り返す）
+      const mx = (s.x + e.x) / 2
+      d = `M${s.x},${s.y} L${mx},${s.y} L${mx},${e.y} L${e.x},${e.y}`
+    } else if (sV) {
+      // 縦出口→横入口: L字パス
+      d = `M${s.x},${s.y} L${s.x},${e.y} L${e.x},${e.y}`
+    } else {
+      // 横出口→縦入口: L字パス
+      d = `M${s.x},${s.y} L${e.x},${s.y} L${e.x},${e.y}`
+    }
+  }
+
+  return { d, mx: (s.x + e.x) / 2, my: (s.y + e.y) / 2 }
+}
+```
+
+- [ ] **Step 4: テスト実行 → PASS を確認**
+
+Run: `npx vitest run src/lib/arrow-routing.test.ts`
+Expected: 全テスト PASS
+
+- [ ] **Step 5: 既存テスト全件実行（リグレッション確認）**
+
+Run: `npm test`
+Expected: 既存テストも含めて全 PASS
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts
+git commit -m "feat(#314): add Bbox type and obstacle-aware arrow detour to buildArrowPath"
+```
+
+---
+
+## Task 2: flow-engine.ts の calcArrowPath を obstacles パススルーに拡張（TDD）
+
+**Files:**
+- Modify: `src/lib/flow-engine.ts`
+- Modify: `src/lib/flow-engine.test.ts`
+
+- [ ] **Step 1: `src/lib/flow-engine.test.ts` の `describe('calcArrowPath', ...)` ブロックの末尾（既存テストの後）に obstacles テストを追加**
+
+`src/lib/flow-engine.test.ts` の既存 `describe('calcArrowPath', ...)` ブロックの最後の `it` の後ろに以下を追加:
+
+```ts
+  it('should pass obstacles through to buildArrowPath and produce detour path', () => {
+    // A=(200,200) → C=(600,200) 同一行、間に B (400,200) 障害
+    const obstacles = [{ x: 400, y: 200, w: 152, h: 56 }]
+    const r = calcArrowPath(
+      { x: 200, y: 200 },
+      { x: 600, y: 200 },
+      { hw: 76, hh: 28, rh: 84 },
+      obstacles,
+    )
+    expect(r).not.toBeNull()
+    // exitPt: dx=400 横出口 {276,200}, entryPt: 横入口 {524,200}
+    // 迂回: detourY = 228 + 14 = 242
+    expect(r.d).toBe('M276,200 L276,242 L524,242 L524,200')
+    expect(r.mx).toBe(400)
+    expect(r.my).toBe(242)
+  })
+
+  it('should ignore obstacles when arrow is not horizontal', () => {
+    const obstacles = [{ x: 200, y: 200, w: 152, h: 56 }]
+    const r = calcArrowPath(
+      { x: 100, y: 100 },
+      { x: 100, y: 300 },
+      { hw: 76, hh: 28, rh: 84 },
+      obstacles,
+    )
+    // 縦パスなので obstacles 無視 → 既存の直線
+    expect(r.d).toBe('M100,128 L100,272')
+  })
+```
+
+- [ ] **Step 2: テスト実行 → FAIL を確認**
+
+Run: `npx vitest run src/lib/flow-engine.test.ts -t "obstacles"`
+Expected: FAIL（`calcArrowPath` が 4 引数を受け付けない）
+
+- [ ] **Step 3: `src/lib/flow-engine.ts` の `calcArrowPath` を拡張**
+
+ファイル冒頭の import を:
+
+```ts
+import { exitPt, entryPt, buildArrowPath } from './arrow-routing'
+import type { Point, Bbox } from './arrow-routing'
+```
+
+`calcArrowPath` の関数定義を以下に置き換える:
+
+```ts
+export function calcArrowPath(
+  from: NodePos,
+  to: NodePos,
+  config: ArrowConfig,
+  obstacles?: Bbox[],
+): ArrowPathResult {
+  const f: Point = { x: from.x, y: from.y }
+  const t: Point = { x: to.x, y: to.y }
+  const s = exitPt(f, t, config.hw, config.hh, config.rh, config.fromShape)
+  const e = entryPt(t, f, config.hw, config.hh, config.rh, config.toShape)
+  return buildArrowPath(s, e, f, t, obstacles)
+}
+```
+
+- [ ] **Step 4: テスト実行 → PASS を確認**
+
+Run: `npx vitest run src/lib/flow-engine.test.ts`
+Expected: 既存テスト含む全 PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/lib/flow-engine.ts src/lib/flow-engine.test.ts
+git commit -m "feat(#314): pass obstacles through calcArrowPath to buildArrowPath"
+```
+
+---
+
+## Task 3: arrow-routing.ts に collectObstacles ヘルパー追加（TDD）
+
+**Files:**
+- Modify: `src/lib/arrow-routing.ts`
+- Modify: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: `src/lib/arrow-routing.test.ts` の末尾に collectObstacles のテストを追加**
+
+ファイル先頭の import を:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import {
+  buildArrowPath,
+  collectObstacles,
+  type Bbox,
+  type ObstacleNode,
+} from './arrow-routing'
+```
+
+ファイル末尾に新規 describe ブロック追加:
+
+```ts
+describe('collectObstacles', () => {
+  // A=(200,200), B=(400,200), C=(600,200) 同一行 (rowY=200)
+  // D=(400,284) B 直下行, E=(400,116) B 直上行
+  // F=(400,368) 2行下（除外対象）
+  const TW = 152, TH = 56, RH = 84
+
+  const baseNodes: ObstacleNode[] = [
+    { key: 'A', cx: 200, cy: 200 },
+    { key: 'B', cx: 400, cy: 200 },
+    { key: 'C', cx: 600, cy: 200 },
+    { key: 'D', cx: 400, cy: 284 },
+    { key: 'E', cx: 400, cy: 116 },
+    { key: 'F', cx: 400, cy: 368 },
+  ]
+
+  it('A→C: 同一行の B（from-to 間）と直上 E・直下 D を集める。F（2行下）は除外', () => {
+    const result = collectObstacles({
+      nodes: baseNodes,
+      fromKey: 'A',
+      toKey: 'C',
+      fromCx: 200,
+      toCx: 600,
+      rowY: 200,
+      rowH: RH,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    // B (同一行・間), D (直下), E (直上) が含まれる
+    const cxs = result.map((b) => b.x).sort((a, b) => a - b)
+    expect(result).toHaveLength(3)
+    expect(cxs).toEqual([400, 400, 400])
+    // F (cy=368) は除外
+    expect(result.every((b) => b.y !== 368)).toBe(true)
+  })
+
+  it('from/to 自身は除外される', () => {
+    const result = collectObstacles({
+      nodes: baseNodes,
+      fromKey: 'A',
+      toKey: 'C',
+      fromCx: 200,
+      toCx: 600,
+      rowY: 200,
+      rowH: RH,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    // A, C は含まれない
+    const ys = result.map((b) => `${b.x},${b.y}`)
+    expect(ys).not.toContain('200,200')
+    expect(ys).not.toContain('600,200')
+  })
+
+  it('A→B（隣接、間にノードなし）: 同一行は from-to 間限定なので空、直上下は X 制限なしで含む', () => {
+    const result = collectObstacles({
+      nodes: baseNodes,
+      fromKey: 'A',
+      toKey: 'B',
+      fromCx: 200,
+      toCx: 400,
+      rowY: 200,
+      rowH: RH,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    // 同一行: A=200, B=400 が from/to で除外。C=600 は X 範囲外で除外。→ 0件
+    // 直上下: D, E, F は X 制限なしだが F は 2行下で除外。D, E のみ含まれる。
+    expect(result).toHaveLength(2)
+    const cys = result.map((b) => b.y).sort((a, b) => a - b)
+    expect(cys).toEqual([116, 284])
+  })
+
+  it('Bbox の w, h は引数の bboxW, bboxH と一致する', () => {
+    const result = collectObstacles({
+      nodes: baseNodes,
+      fromKey: 'A',
+      toKey: 'C',
+      fromCx: 200,
+      toCx: 600,
+      rowY: 200,
+      rowH: RH,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    expect(result.every((b) => b.w === TW && b.h === TH)).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: テスト実行 → FAIL を確認**
+
+Run: `npx vitest run src/lib/arrow-routing.test.ts`
+Expected: 新規テスト FAIL（`collectObstacles` 未定義）
+
+- [ ] **Step 3: `src/lib/arrow-routing.ts` の末尾に collectObstacles 実装を追加**
+
+```ts
+export interface ObstacleNode {
+  key: string
+  cx: number  // 中心 X
+  cy: number  // 中心 Y
+}
+
+export interface CollectObstaclesArgs {
+  nodes: ObstacleNode[]
+  fromKey: string
+  toKey: string
+  fromCx: number
+  toCx: number
+  rowY: number
+  rowH: number    // 行高さ（直上/直下行判定用）
+  bboxW: number
+  bboxH: number
+}
+
+/**
+ * 矢印の同一行・直上行・直下行にあるノードを bbox 配列に変換する。
+ * 同一行は from-to 間レーンに限定。直上/直下行は X 制限なしで含める（上下塞がり判定用）。
+ * from/to 自身および 2 行以上離れたノードは除外する。
+ */
+export function collectObstacles(args: CollectObstaclesArgs): Bbox[] {
+  const { nodes, fromKey, toKey, fromCx, toCx, rowY, rowH, bboxW, bboxH } = args
+  const xLow = Math.min(fromCx, toCx)
+  const xHigh = Math.max(fromCx, toCx)
+  const result: Bbox[] = []
+  for (const n of nodes) {
+    if (n.key === fromKey || n.key === toKey) continue
+    const dy = Math.abs(n.cy - rowY)
+    const onRow = dy < bboxH / 2 + 2
+    // 直上/直下行のみを採用（dy が rowH に近い）。2行以上離れたノードは除外。
+    const onAdjacentRow = !onRow && dy > rowH - bboxH / 2 && dy < rowH + bboxH / 2
+    if (onRow) {
+      // 同一行: from-to 間レーンに限定（始終点 X は除外）
+      if (n.cx > xLow + 1 && n.cx < xHigh - 1) {
+        result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+      }
+    } else if (onAdjacentRow) {
+      // 直上/直下行: 上下塞がり判定用に X 制限なしで含める
+      result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+    }
+  }
+  return result
+}
+```
+
+- [ ] **Step 4: テスト実行 → PASS を確認**
+
+Run: `npx vitest run src/lib/arrow-routing.test.ts`
+Expected: 全テスト PASS
+
+- [ ] **Step 5: 全テスト実行（リグレッション確認）**
+
+Run: `npm test`
+Expected: 全 PASS
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts
+git commit -m "feat(#314): add collectObstacles helper for in-row + adjacent-row bbox extraction"
+```
+
+---
+
+## Task 4: FlowEditor.aPath を更新して obstacles を渡す
+
+**Files:**
+- Modify: `src/features/editor/FlowEditor.tsx`
+
+- [ ] **Step 1: import に collectObstacles, Bbox, ObstacleNode 型を追加**
+
+`src/features/editor/FlowEditor.tsx:36` の既存 import 文:
+
+```ts
+import { DS } from '../../lib/arrow-routing'
+```
+
+を以下に置き換える:
+
+```ts
+import {
+  DS,
+  collectObstacles,
+  type Bbox,
+  type ObstacleNode,
+} from '../../lib/arrow-routing'
+```
+
+`flow-engine` 由来の `calcArrowPath` import（`src/features/editor/FlowEditor.tsx:50`）は変更不要。
+
+- [ ] **Step 2: `aPath` 関数を obstacles 抽出付きに更新**
+
+`src/features/editor/FlowEditor.tsx` の `aPath` 関数（`src/features/editor/FlowEditor.tsx:1362` 付近）を以下に置き換える:
+
+```ts
+  const aPath = (arrow: InternalArrow): ArrowPathResult | null => {
+    const ft = tasks[arrow.from],
+      tt = tasks[arrow.to]
+    if (!ft || !tt) return null
+    const fli = liMap[ft.lid],
+      fri = riMap[ft.rid],
+      tli = liMap[tt.lid],
+      tri = riMap[tt.rid]
+    if ([fli, fri, tli, tri].some((v) => v === undefined)) return null
+    const from = ct(fli, fri)
+    const to = ct(tli, tri)
+
+    // 同一行のときのみ obstacles を組み立てる
+    let obstacles: Bbox[] | undefined
+    if (fri === tri) {
+      const nodes: ObstacleNode[] = []
+      for (const k of Object.keys(tasks)) {
+        const t = tasks[k]
+        const li = liMap[t.lid]
+        const ri = riMap[t.rid]
+        if (li === undefined || ri === undefined) continue
+        const c = ct(li, ri)
+        nodes.push({ key: k, cx: c.x, cy: c.y })
+      }
+      obstacles = collectObstacles({
+        nodes,
+        fromKey: arrow.from,
+        toKey: arrow.to,
+        fromCx: from.x,
+        toCx: to.x,
+        rowY: from.y,
+        rowH: RH,
+        bboxW: TW,
+        bboxH: TH,
+      })
+    }
+
+    return calcArrowPath(
+      from,
+      to,
+      {
+        hw: TW / 2,
+        hh: TH / 2,
+        rh: RH,
+        fromShape: ft.shape ?? undefined,
+        toShape: tt.shape ?? undefined,
+      },
+      obstacles,
+    )
+  }
+```
+
+- [ ] **Step 3: TypeScript 型チェック・全テスト実行**
+
+Run: `npm test`
+Expected: 全 PASS（既存テストへの影響なし、aPath は外部 API ではないので単体テストはなし）
+
+- [ ] **Step 4: dev server を起動して目視確認（手動チェックポイント）**
+
+Run: `npm run dev`
+
+ブラウザで以下を確認:
+1. 既存フローを開いて、矢印が従来どおり描画されるか（リグレッションなし）
+2. 同一行 A→B、A→C の構成を作って A→C が B を下に迂回するか
+3. B の直下にノードを配置して A→C が上に迂回するか
+
+問題があれば Step 2 に戻って修正。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/editor/FlowEditor.tsx
+git commit -m "feat(#314): wire obstacles into FlowEditor.aPath via collectObstacles"
+```
+
+---
+
+## Task 5: SharedFlowViewer.computeArrowPath を更新して obstacles を渡す
+
+**Files:**
+- Modify: `src/features/shared/SharedFlowViewer.tsx`
+
+- [ ] **Step 1: import に collectObstacles, Bbox, ObstacleNode を追加**
+
+`src/features/shared/SharedFlowViewer.tsx` の冒頭、既存の `arrow-routing` import を以下のように拡張:
+
+```ts
+import {
+  exitPt,
+  entryPt,
+  buildArrowPath,
+  collectObstacles,
+  DS,
+  type Point,
+  type Bbox,
+  type ObstacleNode,
+} from '../../lib/arrow-routing'
+```
+
+- [ ] **Step 2: `computeArrowPath` を obstacles 抽出付きに更新**
+
+既存の `computeArrowPath` 関数（`src/features/shared/SharedFlowViewer.tsx:93` 付近）を以下に置き換える:
+
+```ts
+  // Arrow path calculation
+  const computeArrowPath = (arrow: Arrow): { d: string; mx: number; my: number } | null => {
+    const fromNode = nodeById[arrow.fromNodeId]
+    const toNode = nodeById[arrow.toNodeId]
+    if (!fromNode || !toNode) return null
+
+    const fli = laneIdToIndex[fromNode.laneId]
+    const tli = laneIdToIndex[toNode.laneId]
+    if (fli === undefined || tli === undefined) return null
+
+    const f = ct(fli, fromNode.rowIndex)
+    const t = ct(tli, toNode.rowIndex)
+    const hw = TW / 2,
+      hh = TH / 2
+    const s = exitPt(f, t, hw, hh, RH, fromNode.shape as 'diamond' | undefined)
+    const e = entryPt(t, f, hw, hh, RH, toNode.shape as 'diamond' | undefined)
+
+    // 同一行のときのみ obstacles を組み立てる
+    let obstacles: Bbox[] | undefined
+    if (fromNode.rowIndex === toNode.rowIndex) {
+      const nodes: ObstacleNode[] = []
+      for (const n of flow.nodes) {
+        const li = laneIdToIndex[n.laneId]
+        if (li === undefined) continue
+        const c = ct(li, n.rowIndex)
+        nodes.push({ key: n.id, cx: c.x, cy: c.y })
+      }
+      obstacles = collectObstacles({
+        nodes,
+        fromKey: fromNode.id,
+        toKey: toNode.id,
+        fromCx: f.x,
+        toCx: t.x,
+        rowY: f.y,
+        rowH: RH,
+        bboxW: TW,
+        bboxH: TH,
+      })
+    }
+
+    return buildArrowPath(s, e, f, t, obstacles)
+  }
+```
+
+- [ ] **Step 3: 全テスト実行**
+
+Run: `npm test`
+Expected: 全 PASS
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/features/shared/SharedFlowViewer.tsx
+git commit -m "feat(#314): wire obstacles into SharedFlowViewer.computeArrowPath"
+```
+
+---
+
+## Task 6: Playwright で実画面検証（受け入れ基準シナリオ）
+
+**Files:**
+- Save: `.screenshots/issue-314-*.png`
+
+- [ ] **Step 1: dev server を起動**
+
+Run: `npm run dev`
+
+- [ ] **Step 2: Playwright で受け入れ基準のシナリオを実行**
+
+`mcp__playwright__browser_navigate` で `http://localhost:5173`（または該当ポート）にアクセスし、以下を確認:
+
+1. **A→B、A→C 同一行 → A→C が B を下に迂回**
+   - 同一行に A, B, C を配置（A→B, A→C 矢印）
+   - スクリーンショット: `.screenshots/issue-314-down-detour.png`
+2. **A→C 単独（B あり）も同様に下迂回**
+   - A→B 矢印を削除し A→C のみにする
+   - スクリーンショット: `.screenshots/issue-314-down-detour-no-ab.png`
+3. **A→B 単独（隣接、間にノードなし）→ 直線**
+   - 並びを A, B のみにして A→B
+   - スクリーンショット: `.screenshots/issue-314-adjacent-line.png`
+4. **B の直下にノード → A→C は上に迂回**
+   - B の直下行（同レーン rid+1）に追加ノード D を配置
+   - スクリーンショット: `.screenshots/issue-314-up-detour.png`
+5. **同一レーンの縦方向は従来挙動（迂回しない）**
+   - A の同レーン下にノードを配置し、その下にさらにもう1つ → 縦の矢印が貫通する従来挙動のままを確認
+   - スクリーンショット: `.screenshots/issue-314-vertical-unchanged.png`
+
+- [ ] **Step 3: LCP（Largest Contentful Paint）測定**
+
+`mcp__playwright__browser_evaluate` で以下を実行し、LCP が 1 秒以内であることを確認:
+
+```js
+new Promise((resolve) => {
+  new PerformanceObserver((list) => {
+    const entries = list.getEntries()
+    resolve(entries[entries.length - 1].startTime)
+  }).observe({ type: 'largest-contentful-paint', buffered: true })
+})
+```
+
+LCP > 1000ms の場合は実装パフォーマンスを見直す。
+
+- [ ] **Step 4: 共有ビューでも同様に確認**
+
+共有リンクを発行（または既存の共有 URL を使用）し、同じ A→C 構成が共有ビューでも下迂回するか確認。
+- スクリーンショット: `.screenshots/issue-314-shared-view-detour.png`
+
+- [ ] **Step 5: 全テスト最終実行**
+
+Run: `npm test`
+Expected: 全 PASS
+
+- [ ] **Step 6: スクリーンショットをコミット（gitignore でなければ）**
+
+`.screenshots/` は `.gitignore` に含まれているため、目視確認のみで OK。コミット不要。

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -1364,6 +1364,16 @@ export default function FlowEditor({
     }, 500)
   }
 
+  // 全タスクの中心座標を1度だけ収集（同一行 obstacles 判定で aPath 経由で再利用）
+  const obstacleNodes: ObstacleNode[] = []
+  for (const [k, t] of Object.entries(tasks)) {
+    const li = liMap[t.lid]
+    const ri = riMap[t.rid]
+    if (li === undefined || ri === undefined) continue
+    const c = ct(li, ri)
+    obstacleNodes.push({ key: k, cx: c.x, cy: c.y })
+  }
+
   const aPath = (arrow: InternalArrow): ArrowPathResult | null => {
     const ft = tasks[arrow.from],
       tt = tasks[arrow.to]
@@ -1379,17 +1389,8 @@ export default function FlowEditor({
     // 同一行のときのみ obstacles を組み立てる（迂回判定用）
     let obstacles: Bbox[] | undefined
     if (fri === tri) {
-      const nodes: ObstacleNode[] = []
-      for (const k of Object.keys(tasks)) {
-        const t = tasks[k]
-        const li = liMap[t.lid]
-        const ri = riMap[t.rid]
-        if (li === undefined || ri === undefined) continue
-        const c = ct(li, ri)
-        nodes.push({ key: k, cx: c.x, cy: c.y })
-      }
       obstacles = collectObstacles({
-        nodes,
+        nodes: obstacleNodes,
         fromKey: arrow.from,
         toKey: arrow.to,
         fromCx: from.x,

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -33,12 +33,7 @@ import { PALETTES, THEMES } from './theme-constants'
 import { toBlob } from 'html-to-image'
 import { pickPixelRatio, buildExportSvg } from './png-export'
 import { calcLaneWidth } from './calcLaneWidth'
-import {
-  DS,
-  collectObstacles,
-  type Bbox,
-  type ObstacleNode,
-} from '../../lib/arrow-routing'
+import { DS, collectObstacles, type Bbox, type ObstacleNode } from '../../lib/arrow-routing'
 import { useToast } from './hooks/useToast'
 import { ToastList } from './components/Toast'
 import { I, Ico } from './components/EditorIcons'

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -33,7 +33,12 @@ import { PALETTES, THEMES } from './theme-constants'
 import { toBlob } from 'html-to-image'
 import { pickPixelRatio, buildExportSvg } from './png-export'
 import { calcLaneWidth } from './calcLaneWidth'
-import { DS } from '../../lib/arrow-routing'
+import {
+  DS,
+  collectObstacles,
+  type Bbox,
+  type ObstacleNode,
+} from '../../lib/arrow-routing'
 import { useToast } from './hooks/useToast'
 import { ToastList } from './components/Toast'
 import { I, Ico } from './components/EditorIcons'
@@ -1370,13 +1375,44 @@ export default function FlowEditor({
     if ([fli, fri, tli, tri].some((v) => v === undefined)) return null
     const from = ct(fli, fri)
     const to = ct(tli, tri)
-    return calcArrowPath(from, to, {
-      hw: TW / 2,
-      hh: TH / 2,
-      rh: RH,
-      fromShape: ft.shape ?? undefined,
-      toShape: tt.shape ?? undefined,
-    })
+
+    // 同一行のときのみ obstacles を組み立てる（迂回判定用）
+    let obstacles: Bbox[] | undefined
+    if (fri === tri) {
+      const nodes: ObstacleNode[] = []
+      for (const k of Object.keys(tasks)) {
+        const t = tasks[k]
+        const li = liMap[t.lid]
+        const ri = riMap[t.rid]
+        if (li === undefined || ri === undefined) continue
+        const c = ct(li, ri)
+        nodes.push({ key: k, cx: c.x, cy: c.y })
+      }
+      obstacles = collectObstacles({
+        nodes,
+        fromKey: arrow.from,
+        toKey: arrow.to,
+        fromCx: from.x,
+        toCx: to.x,
+        rowY: from.y,
+        rowH: RH,
+        bboxW: TW,
+        bboxH: TH,
+      })
+    }
+
+    return calcArrowPath(
+      from,
+      to,
+      {
+        hw: TW / 2,
+        hh: TH / 2,
+        rh: RH,
+        fromShape: ft.shape ?? undefined,
+        toShape: tt.shape ?? undefined,
+      },
+      obstacles,
+    )
   }
 
   const exportMermaid = (): string => {

--- a/src/features/shared/SharedFlowViewer.test.tsx
+++ b/src/features/shared/SharedFlowViewer.test.tsx
@@ -415,9 +415,7 @@ describe('SharedFlowViewer', () => {
         { id: 'node-b', laneId: 'lane-2', rowIndex: 0, label: 'B', note: null, orderIndex: 1 },
         { id: 'node-c', laneId: 'lane-3', rowIndex: 0, label: 'C', note: null, orderIndex: 2 },
       ],
-      arrows: [
-        { id: 'arrow-1', fromNodeId: 'node-a', toNodeId: 'node-c', comment: null },
-      ],
+      arrows: [{ id: 'arrow-1', fromNodeId: 'node-a', toNodeId: 'node-c', comment: null }],
     }
     render(<SharedFlowViewer flow={detourFlow} />)
     // 矢印 svg path（marker-end 付き）を取得
@@ -442,9 +440,7 @@ describe('SharedFlowViewer', () => {
         { id: 'node-a', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
         { id: 'node-b', laneId: 'lane-2', rowIndex: 0, label: 'B', note: null, orderIndex: 1 },
       ],
-      arrows: [
-        { id: 'arrow-1', fromNodeId: 'node-a', toNodeId: 'node-b', comment: null },
-      ],
+      arrows: [{ id: 'arrow-1', fromNodeId: 'node-a', toNodeId: 'node-b', comment: null }],
     }
     render(<SharedFlowViewer flow={straightFlow} />)
     const paths = Array.from(document.querySelectorAll('path')).filter((p) =>

--- a/src/features/shared/SharedFlowViewer.test.tsx
+++ b/src/features/shared/SharedFlowViewer.test.tsx
@@ -401,4 +401,59 @@ describe('SharedFlowViewer', () => {
       expect(arrowPath!.getAttribute('stroke-dasharray')).toBe('none')
     })
   })
+
+  it('同一行で経路上にノードがある矢印は迂回パスを生成する（A→C, 間にB）', () => {
+    const detourFlow = {
+      ...mockFlow,
+      lanes: [
+        { id: 'lane-1', name: 'A', colorIndex: 0, position: 0 },
+        { id: 'lane-2', name: 'B', colorIndex: 1, position: 1 },
+        { id: 'lane-3', name: 'C', colorIndex: 2, position: 2 },
+      ],
+      nodes: [
+        { id: 'node-a', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+        { id: 'node-b', laneId: 'lane-2', rowIndex: 0, label: 'B', note: null, orderIndex: 1 },
+        { id: 'node-c', laneId: 'lane-3', rowIndex: 0, label: 'C', note: null, orderIndex: 2 },
+      ],
+      arrows: [
+        { id: 'arrow-1', fromNodeId: 'node-a', toNodeId: 'node-c', comment: null },
+      ],
+    }
+    render(<SharedFlowViewer flow={detourFlow} />)
+    // 矢印 svg path（marker-end 付き）を取得
+    const paths = Array.from(document.querySelectorAll('path')).filter((p) =>
+      p.getAttribute('marker-end')?.startsWith('url(#sm-'),
+    )
+    expect(paths.length).toBeGreaterThanOrEqual(1)
+    const d = paths[0].getAttribute('d')!
+    // 迂回パスは 4 セグメント（M L L L）。直線パスは M L のみなので区別可能
+    const segmentCount = d.match(/[ML]/g)?.length ?? 0
+    expect(segmentCount).toBe(4)
+  })
+
+  it('同一行で隣接レーン（間にノードなし）の矢印は直線パス', () => {
+    const straightFlow = {
+      ...mockFlow,
+      lanes: [
+        { id: 'lane-1', name: 'A', colorIndex: 0, position: 0 },
+        { id: 'lane-2', name: 'B', colorIndex: 1, position: 1 },
+      ],
+      nodes: [
+        { id: 'node-a', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+        { id: 'node-b', laneId: 'lane-2', rowIndex: 0, label: 'B', note: null, orderIndex: 1 },
+      ],
+      arrows: [
+        { id: 'arrow-1', fromNodeId: 'node-a', toNodeId: 'node-b', comment: null },
+      ],
+    }
+    render(<SharedFlowViewer flow={straightFlow} />)
+    const paths = Array.from(document.querySelectorAll('path')).filter((p) =>
+      p.getAttribute('marker-end')?.startsWith('url(#sm-'),
+    )
+    expect(paths.length).toBeGreaterThanOrEqual(1)
+    const d = paths[0].getAttribute('d')!
+    // 直線パスは M L の 2 セグメント
+    const segmentCount = d.match(/[ML]/g)?.length ?? 0
+    expect(segmentCount).toBe(2)
+  })
 })

--- a/src/features/shared/SharedFlowViewer.tsx
+++ b/src/features/shared/SharedFlowViewer.tsx
@@ -99,6 +99,8 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
   })
 
   // 全ノードの中心座標を1度だけ収集（同一行 obstacles 判定で再利用）
+  // FlowEditor 側は riMap[t.rid] で行インデックスを取得するが、本ビューアでは
+  // flow.nodes に直接 rowIndex があるためそのまま ct() に渡せる（両者は等価）。
   const obstacleNodes: ObstacleNode[] = []
   for (const n of flow.nodes) {
     const li = laneIdToIndex[n.laneId]

--- a/src/features/shared/SharedFlowViewer.tsx
+++ b/src/features/shared/SharedFlowViewer.tsx
@@ -5,7 +5,16 @@ import { BRAND } from '../../constants/brand'
 import { PALETTES, THEMES } from '../editor/theme-constants'
 import styles from './SharedFlowViewer.module.css'
 import { calcLaneWidth } from '../editor/calcLaneWidth'
-import { exitPt, entryPt, buildArrowPath, DS, type Point } from '../../lib/arrow-routing'
+import {
+  exitPt,
+  entryPt,
+  buildArrowPath,
+  collectObstacles,
+  DS,
+  type Point,
+  type Bbox,
+  type ObstacleNode,
+} from '../../lib/arrow-routing'
 import { formatRelativeTime } from '../../lib/relative-time'
 import { isGroupSub, isGroupParent, getGroupWidth } from '../../lib/lane-group-utils'
 import { parseNote, measureMemoHeight, MEMO_W } from '../editor/memo-utils'
@@ -89,6 +98,15 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
     nodeById[n.id] = n
   })
 
+  // 全ノードの中心座標を1度だけ収集（同一行 obstacles 判定で再利用）
+  const obstacleNodes: ObstacleNode[] = []
+  for (const n of flow.nodes) {
+    const li = laneIdToIndex[n.laneId]
+    if (li === undefined) continue
+    const c = ct(li, n.rowIndex)
+    obstacleNodes.push({ key: n.id, cx: c.x, cy: c.y })
+  }
+
   // Arrow path calculation
   const computeArrowPath = (arrow: Arrow): { d: string; mx: number; my: number } | null => {
     const fromNode = nodeById[arrow.fromNodeId]
@@ -105,7 +123,24 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
       hh = TH / 2
     const s = exitPt(f, t, hw, hh, RH, fromNode.shape as 'diamond' | undefined)
     const e = entryPt(t, f, hw, hh, RH, toNode.shape as 'diamond' | undefined)
-    return buildArrowPath(s, e, f, t)
+
+    // 同一行のときのみ obstacles を組み立てる（迂回判定用）
+    let obstacles: Bbox[] | undefined
+    if (fromNode.rowIndex === toNode.rowIndex) {
+      obstacles = collectObstacles({
+        nodes: obstacleNodes,
+        fromKey: fromNode.id,
+        toKey: toNode.id,
+        fromCx: f.x,
+        toCx: t.x,
+        rowY: f.y,
+        rowH: RH,
+        bboxW: TW,
+        bboxH: TH,
+      })
+    }
+
+    return buildArrowPath(s, e, f, t, obstacles)
   }
 
   const arrowPaths = flow.arrows

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -99,4 +99,18 @@ describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
     const r = buildArrowPath(s, e, fc, tc, [fromSelfBbox, toSelfBbox])
     expect(r.d).toBe('M276,200 L524,200')
   })
+
+  it('同一行・右→左方向でも下迂回する（s.x > e.x）', () => {
+    // s と e を逆転（s.x=524 → e.x=276）。同一行 (y=200)、間に B (400,200)
+    const sR = { x: 524, y: 200 }
+    const eR = { x: 276, y: 200 }
+    const fcR = { x: 600, y: 200 }
+    const tcR = { x: 200, y: 200 }
+    const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(sR, eR, fcR, tcR, [B])
+    // detourY = 200 + 28 + 14 = 242。左右が反転したミラーパス
+    expect(r.d).toBe('M524,200 L524,242 L276,242 L276,200')
+    expect(r.mx).toBe(400)
+    expect(r.my).toBe(242)
+  })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -206,4 +206,40 @@ describe('collectObstacles', () => {
     })
     expect(result.every((b) => b.w === TW && b.h === TH)).toBe(true)
   })
+
+  it('nodes が空配列 → 空配列を返す', () => {
+    const result = collectObstacles({
+      nodes: [],
+      fromKey: 'A',
+      toKey: 'C',
+      fromCx: 200,
+      toCx: 600,
+      rowY: 200,
+      rowH: RH,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    expect(result).toEqual([])
+  })
+
+  it('右→左方向（fromCx > toCx）でも同一行・隣接行を正しく抽出', () => {
+    // fromCx=600 (C), toCx=200 (A) と入れ替え。間に B (cx=400) があるはず
+    const result = collectObstacles({
+      nodes: baseNodes,
+      fromKey: 'C',
+      toKey: 'A',
+      fromCx: 600,
+      toCx: 200,
+      rowY: 200,
+      rowH: RH,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    // 同一行: B (400, 200) が含まれる、C/A は from/to で除外
+    // 直上下: D (400, 284) と E (400, 116)
+    // F (400, 368) は 2 行下で除外
+    expect(result).toHaveLength(3)
+    const cys = result.map((b) => b.y).sort((a, b) => a - b)
+    expect(cys).toEqual([116, 200, 284])
+  })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import {
-  buildArrowPath,
-  collectObstacles,
-  type Bbox,
-  type ObstacleNode,
-} from './arrow-routing'
+import { buildArrowPath, collectObstacles, type Bbox, type ObstacleNode } from './arrow-routing'
 
 describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
   // 共通の始終点（A→C 同一行、A=(200,200), C=(600,200) のときの exitPt/entryPt 後の値）
@@ -65,11 +60,7 @@ describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
     const Bdown: Bbox = { x: 380, y: 284, w: 152, h: 56 }
     const sExt = { x: 276, y: 200 }
     const eExt = { x: 624, y: 200 }
-    const r = buildArrowPath(
-      sExt, eExt,
-      { x: 200, y: 200 }, { x: 700, y: 200 },
-      [B, C2, Bdown],
-    )
+    const r = buildArrowPath(sExt, eExt, { x: 200, y: 200 }, { x: 700, y: 200 }, [B, C2, Bdown])
     expect(r.my).toBe(158)
   })
 
@@ -91,8 +82,10 @@ describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
   it('始終点が同じ X（自己参照） → inRow 空 → 直線', () => {
     const B: Bbox = { x: 200, y: 200, w: 152, h: 56 }
     const r = buildArrowPath(
-      { x: 200, y: 200 }, { x: 200, y: 200 },
-      { x: 200, y: 200 }, { x: 200, y: 200 },
+      { x: 200, y: 200 },
+      { x: 200, y: 200 },
+      { x: 200, y: 200 },
+      { x: 200, y: 200 },
       [B],
     )
     expect(r.d).toBe('M200,200 L200,200')
@@ -124,7 +117,9 @@ describe('collectObstacles', () => {
   // A=(200,200), B=(400,200), C=(600,200) 同一行 (rowY=200)
   // D=(400,284) B 直下行, E=(400,116) B 直上行
   // F=(400,368) 2行下（除外対象）
-  const TW = 152, TH = 56, RH = 84
+  const TW = 152,
+    TH = 56,
+    RH = 84
 
   const baseNodes: ObstacleNode[] = [
     { key: 'A', cx: 200, cy: 200 },

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { buildArrowPath, type Bbox } from './arrow-routing'
+import {
+  buildArrowPath,
+  collectObstacles,
+  type Bbox,
+  type ObstacleNode,
+} from './arrow-routing'
 
 describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
   // 共通の始終点（A→C 同一行、A=(200,200), C=(600,200) のときの exitPt/entryPt 後の値）
@@ -112,5 +117,93 @@ describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
     expect(r.d).toBe('M524,200 L524,242 L276,242 L276,200')
     expect(r.mx).toBe(400)
     expect(r.my).toBe(242)
+  })
+})
+
+describe('collectObstacles', () => {
+  // A=(200,200), B=(400,200), C=(600,200) 同一行 (rowY=200)
+  // D=(400,284) B 直下行, E=(400,116) B 直上行
+  // F=(400,368) 2行下（除外対象）
+  const TW = 152, TH = 56, RH = 84
+
+  const baseNodes: ObstacleNode[] = [
+    { key: 'A', cx: 200, cy: 200 },
+    { key: 'B', cx: 400, cy: 200 },
+    { key: 'C', cx: 600, cy: 200 },
+    { key: 'D', cx: 400, cy: 284 },
+    { key: 'E', cx: 400, cy: 116 },
+    { key: 'F', cx: 400, cy: 368 },
+  ]
+
+  it('A→C: 同一行の B（from-to 間）と直上 E・直下 D を集める。F（2行下）は除外', () => {
+    const result = collectObstacles({
+      nodes: baseNodes,
+      fromKey: 'A',
+      toKey: 'C',
+      fromCx: 200,
+      toCx: 600,
+      rowY: 200,
+      rowH: RH,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    // B (同一行・間), D (直下), E (直上) が含まれる
+    const cxs = result.map((b) => b.x).sort((a, b) => a - b)
+    expect(result).toHaveLength(3)
+    expect(cxs).toEqual([400, 400, 400])
+    // F (cy=368) は除外
+    expect(result.every((b) => b.y !== 368)).toBe(true)
+  })
+
+  it('from/to 自身は除外される', () => {
+    const result = collectObstacles({
+      nodes: baseNodes,
+      fromKey: 'A',
+      toKey: 'C',
+      fromCx: 200,
+      toCx: 600,
+      rowY: 200,
+      rowH: RH,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    // A, C は含まれない
+    const ys = result.map((b) => `${b.x},${b.y}`)
+    expect(ys).not.toContain('200,200')
+    expect(ys).not.toContain('600,200')
+  })
+
+  it('A→B（隣接、間にノードなし）: 同一行は from-to 間限定なので空、直上下は X 制限なしで含む', () => {
+    const result = collectObstacles({
+      nodes: baseNodes,
+      fromKey: 'A',
+      toKey: 'B',
+      fromCx: 200,
+      toCx: 400,
+      rowY: 200,
+      rowH: RH,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    // 同一行: A=200, B=400 が from/to で除外。C=600 は X 範囲外で除外。→ 0件
+    // 直上下: D, E, F は X 制限なしだが F は 2行下で除外。D, E のみ含まれる。
+    expect(result).toHaveLength(2)
+    const cys = result.map((b) => b.y).sort((a, b) => a - b)
+    expect(cys).toEqual([116, 284])
+  })
+
+  it('Bbox の w, h は引数の bboxW, bboxH と一致する', () => {
+    const result = collectObstacles({
+      nodes: baseNodes,
+      fromKey: 'A',
+      toKey: 'C',
+      fromCx: 200,
+      toCx: 600,
+      rowY: 200,
+      rowH: RH,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    expect(result.every((b) => b.w === TW && b.h === TH)).toBe(true)
   })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { buildArrowPath, type Bbox } from './arrow-routing'
+
+describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
+  // 共通の始終点（A→C 同一行、A=(200,200), C=(600,200) のときの exitPt/entryPt 後の値）
+  const s = { x: 276, y: 200 }
+  const e = { x: 524, y: 200 }
+  const fc = { x: 200, y: 200 }
+  const tc = { x: 600, y: 200 }
+
+  it('obstacles 省略 → 既存の直線パスを返す（後方互換）', () => {
+    const r = buildArrowPath(s, e, fc, tc)
+    expect(r.d).toBe('M276,200 L524,200')
+    expect(r.mx).toBe(400)
+    expect(r.my).toBe(200)
+  })
+
+  it('obstacles が空配列 → 既存の直線パスを返す', () => {
+    const r = buildArrowPath(s, e, fc, tc, [])
+    expect(r.d).toBe('M276,200 L524,200')
+  })
+
+  it('同一行・障害1個・上下空き → 下迂回パス（detourY = 障害下端 + 14）', () => {
+    const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B])
+    expect(r.d).toBe('M276,200 L276,242 L524,242 L524,200')
+    expect(r.mx).toBe(400)
+    expect(r.my).toBe(242)
+  })
+
+  it('同一行・障害1個・直下塞がり → 上迂回（detourY = 障害上端 - 14）', () => {
+    const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
+    const D: Bbox = { x: 400, y: 284, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B, D])
+    expect(r.d).toBe('M276,200 L276,158 L524,158 L524,200')
+    expect(r.my).toBe(158)
+  })
+
+  it('同一行・障害1個・両塞がり → 下優先で下迂回', () => {
+    const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
+    const D: Bbox = { x: 400, y: 284, w: 152, h: 56 }
+    const E: Bbox = { x: 400, y: 116, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B, D, E])
+    expect(r.my).toBe(242)
+  })
+
+  it('同一行・障害2個・下空き → まとめて下迂回（detourY は最下端の最大）', () => {
+    const B: Bbox = { x: 380, y: 200, w: 152, h: 56 }
+    const C2: Bbox = { x: 480, y: 200, w: 152, h: 80 }
+    const sExt = { x: 276, y: 200 }
+    const eExt = { x: 624, y: 200 }
+    const r = buildArrowPath(sExt, eExt, { x: 200, y: 200 }, { x: 700, y: 200 }, [B, C2])
+    expect(r.my).toBe(254)
+    expect(r.d).toBe('M276,200 L276,254 L624,254 L624,200')
+  })
+
+  it('同一行・障害2個・1つだけ直下塞がり → 上迂回', () => {
+    const B: Bbox = { x: 380, y: 200, w: 152, h: 56 }
+    const C2: Bbox = { x: 480, y: 200, w: 152, h: 56 }
+    const Bdown: Bbox = { x: 380, y: 284, w: 152, h: 56 }
+    const sExt = { x: 276, y: 200 }
+    const eExt = { x: 624, y: 200 }
+    const r = buildArrowPath(
+      sExt, eExt,
+      { x: 200, y: 200 }, { x: 700, y: 200 },
+      [B, C2, Bdown],
+    )
+    expect(r.my).toBe(158)
+  })
+
+  it('同一行・障害なし（経路上に bbox がない）→ 直線', () => {
+    const farLeft: Bbox = { x: 100, y: 200, w: 152, h: 56 }
+    const farRight: Bbox = { x: 800, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [farLeft, farRight])
+    expect(r.d).toBe('M276,200 L524,200')
+  })
+
+  it('斜め方向（dy >= 2）→ 既存の Z/L 字ロジック（迂回しない）', () => {
+    const sDiag = { x: 276, y: 200 }
+    const eDiag = { x: 524, y: 300 }
+    const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(sDiag, eDiag, { x: 200, y: 200 }, { x: 600, y: 300 }, [B])
+    expect(r.d).not.toContain('L276,242')
+  })
+
+  it('始終点が同じ X（自己参照） → inRow 空 → 直線', () => {
+    const B: Bbox = { x: 200, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(
+      { x: 200, y: 200 }, { x: 200, y: 200 },
+      { x: 200, y: 200 }, { x: 200, y: 200 },
+      [B],
+    )
+    expect(r.d).toBe('M200,200 L200,200')
+  })
+
+  it('from/to 自身の bbox が混入しても X±1 マージンで除外される', () => {
+    const fromSelfBbox: Bbox = { x: 200, y: 200, w: 152, h: 56 }
+    const toSelfBbox: Bbox = { x: 600, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [fromSelfBbox, toSelfBbox])
+    expect(r.d).toBe('M276,200 L524,200')
+  })
+})

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -31,6 +31,9 @@ function detectDetour(s: Point, e: Point, obstacles: Bbox[]): { detourY: number 
   if (inRow.length === 0) return null
 
   // 上下塞がり判定（X 重なりするノードが直上/直下に存在するか）
+  // 前提: obstacles 配列には呼び出し側で「同一行＋直上行＋直下行のみ」をフィルタ済み
+  // のノードが入っていること（collectObstacles ヘルパーがこれを保証する）。Y 距離の
+  // 厳密チェックを省略しているのはこの前提のため。
   const xOverlap = (a: Bbox, b: Bbox) => Math.abs(a.x - b.x) < (a.w + b.w) / 2
   const downBlocked = inRow.some((obs) =>
     obstacles.some((b) => b.y > obs.y + 1 && xOverlap(obs, b)),
@@ -191,7 +194,7 @@ export interface ObstacleNode {
   cy: number // 中心 Y
 }
 
-export interface CollectObstaclesArgs {
+interface CollectObstaclesArgs {
   nodes: ObstacleNode[]
   fromKey: string
   toKey: string

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -192,3 +192,50 @@ export const buildArrowPath = (
 
   return { d, mx: (s.x + e.x) / 2, my: (s.y + e.y) / 2 }
 }
+
+export interface ObstacleNode {
+  key: string
+  cx: number  // 中心 X
+  cy: number  // 中心 Y
+}
+
+export interface CollectObstaclesArgs {
+  nodes: ObstacleNode[]
+  fromKey: string
+  toKey: string
+  fromCx: number
+  toCx: number
+  rowY: number
+  rowH: number    // 行高さ（直上/直下行判定用）
+  bboxW: number
+  bboxH: number
+}
+
+/**
+ * 矢印の同一行・直上行・直下行にあるノードを bbox 配列に変換する。
+ * 同一行は from-to 間レーンに限定。直上/直下行は X 制限なしで含める（上下塞がり判定用）。
+ * from/to 自身および 2 行以上離れたノードは除外する。
+ */
+export function collectObstacles(args: CollectObstaclesArgs): Bbox[] {
+  const { nodes, fromKey, toKey, fromCx, toCx, rowY, rowH, bboxW, bboxH } = args
+  const xLow = Math.min(fromCx, toCx)
+  const xHigh = Math.max(fromCx, toCx)
+  const result: Bbox[] = []
+  for (const n of nodes) {
+    if (n.key === fromKey || n.key === toKey) continue
+    const dy = Math.abs(n.cy - rowY)
+    const onRow = dy < bboxH / 2 + 2
+    // 直上/直下行のみを採用（dy が rowH に近い）。2行以上離れたノードは除外。
+    const onAdjacentRow = !onRow && dy > rowH - bboxH / 2 && dy < rowH + bboxH / 2
+    if (onRow) {
+      // 同一行: from-to 間レーンに限定（始終点 X は除外）
+      if (n.cx > xLow + 1 && n.cx < xHigh - 1) {
+        result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+      }
+    } else if (onAdjacentRow) {
+      // 直上/直下行: 上下塞がり判定用に X 制限なしで含める
+      result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+    }
+  }
+  return result
+}

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -207,14 +207,21 @@ export interface CollectObstaclesArgs {
   toCx: number
   rowY: number
   rowH: number    // 行高さ（直上/直下行判定用）
-  bboxW: number
-  bboxH: number
+  bboxW: number   // 全ノード共通の bbox 幅。呼び出し側の TW を渡す。
+  bboxH: number   // 全ノード共通の bbox 高さ。呼び出し側の TH を渡す。
 }
 
 /**
  * 矢印の同一行・直上行・直下行にあるノードを bbox 配列に変換する。
  * 同一行は from-to 間レーンに限定。直上/直下行は X 制限なしで含める（上下塞がり判定用）。
  * from/to 自身および 2 行以上離れたノードは除外する。
+ *
+ * 呼び出し側は同一行（fromRow === toRow）のときのみ本関数を呼ぶ想定。
+ * rowY には fromNode の Y 座標を渡すこと。
+ *
+ * 注意: 固定グリッドレイアウトを前提に、dy が `bboxH/2 + 2` と `rowH - bboxH/2` の間
+ * にあるノード（典型値 30〜56px）は意図的に除外される。これはレイアウトアニメーション中の
+ * 中間状態などを obstacle 扱いしないための保守的な設計。
  */
 export function collectObstacles(args: CollectObstaclesArgs): Bbox[] {
   const { nodes, fromKey, toKey, fromCx, toCx, rowY, rowH, bboxW, bboxH } = args

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -3,6 +3,59 @@ export interface Point {
   y: number
 }
 
+export interface Bbox {
+  x: number  // 中心 X
+  y: number  // 中心 Y
+  w: number  // 幅
+  h: number  // 高さ
+}
+
+const DETOUR_MARGIN = 14
+
+function detectDetour(
+  s: Point,
+  e: Point,
+  obstacles: Bbox[],
+): { detourY: number } | null {
+  // 水平直線でなければ迂回しない
+  if (Math.abs(e.y - s.y) >= 2) return null
+
+  const xLow = Math.min(s.x, e.x)
+  const xHigh = Math.max(s.x, e.x)
+  const rowY = s.y
+
+  // 水平移動がなければ迂回対象なし
+  if (xLow >= xHigh - 1) return null
+
+  // 経路上の障害ノード = 同一行（rowY と Y が重なる）かつ X が始終点の間
+  const inRow = obstacles.filter(
+    (b) =>
+      Math.abs(b.y - rowY) < b.h / 2 + 2 &&
+      b.x - b.w / 2 < xHigh - 1 &&
+      b.x + b.w / 2 > xLow + 1,
+  )
+  if (inRow.length === 0) return null
+
+  // 上下塞がり判定（X 重なりするノードが直上/直下に存在するか）
+  const xOverlap = (a: Bbox, b: Bbox) => Math.abs(a.x - b.x) < (a.w + b.w) / 2
+  const downBlocked = inRow.some((obs) =>
+    obstacles.some((b) => b.y > obs.y + 1 && xOverlap(obs, b)),
+  )
+  const upBlocked = inRow.some((obs) =>
+    obstacles.some((b) => b.y < obs.y - 1 && xOverlap(obs, b)),
+  )
+
+  // 方向決定: 下空きなら下、下塞がり＆上空きなら上、両塞がりは下優先
+  const goDown = !downBlocked || upBlocked
+
+  // detourY: 障害ノード群の最下端 + マージン or 最上端 - マージン
+  const detourY = goDown
+    ? Math.max(...inRow.map((o) => o.y + o.h / 2)) + DETOUR_MARGIN
+    : Math.min(...inRow.map((o) => o.y - o.h / 2)) - DETOUR_MARGIN
+
+  return { detourY }
+}
+
 interface ArrowPath {
   d: string
   mx: number
@@ -90,9 +143,26 @@ export const entryPt = (
  *
  * 戻り値の mx, my はラベル配置用の中間点。
  */
-export const buildArrowPath = (s: Point, e: Point, fc: Point, tc: Point): ArrowPath => {
+export const buildArrowPath = (
+  s: Point,
+  e: Point,
+  fc: Point,
+  tc: Point,
+  obstacles?: Bbox[],
+): ArrowPath => {
   const dx = e.x - s.x,
     dy = e.y - s.y
+
+  // 迂回モード: 同一行で経路上に障害ノードがある場合
+  if (obstacles && obstacles.length > 0) {
+    const detour = detectDetour(s, e, obstacles)
+    if (detour) {
+      const { detourY } = detour
+      const d = `M${s.x},${s.y} L${s.x},${detourY} L${e.x},${detourY} L${e.x},${e.y}`
+      return { d, mx: (s.x + e.x) / 2, my: detourY }
+    }
+  }
+
   let d: string
 
   // 直線パス: ほぼ垂直またはほぼ水平

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -4,19 +4,15 @@ export interface Point {
 }
 
 export interface Bbox {
-  x: number  // 中心 X
-  y: number  // 中心 Y
-  w: number  // 幅
-  h: number  // 高さ
+  x: number // 中心 X
+  y: number // 中心 Y
+  w: number // 幅
+  h: number // 高さ
 }
 
 const DETOUR_MARGIN = 14
 
-function detectDetour(
-  s: Point,
-  e: Point,
-  obstacles: Bbox[],
-): { detourY: number } | null {
+function detectDetour(s: Point, e: Point, obstacles: Bbox[]): { detourY: number } | null {
   // 水平直線でなければ迂回しない
   if (Math.abs(e.y - s.y) >= 2) return null
 
@@ -30,9 +26,7 @@ function detectDetour(
   // 経路上の障害ノード = 同一行（rowY と Y が重なる）かつ X が始終点の間
   const inRow = obstacles.filter(
     (b) =>
-      Math.abs(b.y - rowY) < b.h / 2 + 2 &&
-      b.x - b.w / 2 < xHigh - 1 &&
-      b.x + b.w / 2 > xLow + 1,
+      Math.abs(b.y - rowY) < b.h / 2 + 2 && b.x - b.w / 2 < xHigh - 1 && b.x + b.w / 2 > xLow + 1,
   )
   if (inRow.length === 0) return null
 
@@ -41,9 +35,7 @@ function detectDetour(
   const downBlocked = inRow.some((obs) =>
     obstacles.some((b) => b.y > obs.y + 1 && xOverlap(obs, b)),
   )
-  const upBlocked = inRow.some((obs) =>
-    obstacles.some((b) => b.y < obs.y - 1 && xOverlap(obs, b)),
-  )
+  const upBlocked = inRow.some((obs) => obstacles.some((b) => b.y < obs.y - 1 && xOverlap(obs, b)))
 
   // 方向決定: 下空きなら下、下塞がり＆上空きなら上、両塞がりは下優先
   const goDown = !downBlocked || upBlocked
@@ -195,8 +187,8 @@ export const buildArrowPath = (
 
 export interface ObstacleNode {
   key: string
-  cx: number  // 中心 X
-  cy: number  // 中心 Y
+  cx: number // 中心 X
+  cy: number // 中心 Y
 }
 
 export interface CollectObstaclesArgs {
@@ -206,9 +198,9 @@ export interface CollectObstaclesArgs {
   fromCx: number
   toCx: number
   rowY: number
-  rowH: number    // 行高さ（直上/直下行判定用）
-  bboxW: number   // 全ノード共通の bbox 幅。呼び出し側の TW を渡す。
-  bboxH: number   // 全ノード共通の bbox 高さ。呼び出し側の TH を渡す。
+  rowH: number // 行高さ（直上/直下行判定用）
+  bboxW: number // 全ノード共通の bbox 幅。呼び出し側の TW を渡す。
+  bboxH: number // 全ノード共通の bbox 高さ。呼び出し側の TH を渡す。
 }
 
 /**

--- a/src/lib/flow-engine.test.ts
+++ b/src/lib/flow-engine.test.ts
@@ -216,6 +216,35 @@ describe('calcArrowPath', () => {
     // exitPt diamond: |dx|<1, dy>0 → {x: 300, y: 200+34} = {x: 300, y: 234}
     expect(result!.d).toContain('M300,234')
   })
+
+  it('should pass obstacles through to buildArrowPath and produce detour path', () => {
+    // A=(200,200) → C=(600,200) 同一行、間に B (400,200) 障害
+    const obstacles = [{ x: 400, y: 200, w: 152, h: 56 }]
+    const r = calcArrowPath(
+      { x: 200, y: 200 },
+      { x: 600, y: 200 },
+      { hw: 76, hh: 28, rh: 84 },
+      obstacles,
+    )
+    expect(r).not.toBeNull()
+    // exitPt: dx=400 横出口 {276,200}, entryPt: 横入口 {524,200}
+    // 迂回: detourY = 228 + 14 = 242
+    expect(r.d).toBe('M276,200 L276,242 L524,242 L524,200')
+    expect(r.mx).toBe(400)
+    expect(r.my).toBe(242)
+  })
+
+  it('should ignore obstacles when arrow is not horizontal', () => {
+    const obstacles = [{ x: 200, y: 200, w: 152, h: 56 }]
+    const r = calcArrowPath(
+      { x: 100, y: 100 },
+      { x: 100, y: 300 },
+      { hw: 76, hh: 28, rh: 84 },
+      obstacles,
+    )
+    // 縦パスなので obstacles 無視 → 既存の直線
+    expect(r.d).toBe('M100,128 L100,272')
+  })
 })
 
 /* ========================================================= */

--- a/src/lib/flow-engine.ts
+++ b/src/lib/flow-engine.ts
@@ -1,7 +1,7 @@
 import type { InternalArrow, ArrowPathResult } from './types'
 import type { TaskData, MemoData } from '../features/editor/types'
 import { exitPt, entryPt, buildArrowPath } from './arrow-routing'
-import type { Point } from './arrow-routing'
+import type { Point, Bbox } from './arrow-routing'
 
 /* --------------------------------------------------------- */
 /* calcArrowPath types                                       */
@@ -28,12 +28,17 @@ interface ArrowConfig {
  * ノード中心座標とサイズ設定から、矢印のSVGパスを計算する。
  * exitPt → entryPt → buildArrowPath の順に呼び出す薄いラッパー。
  */
-export function calcArrowPath(from: NodePos, to: NodePos, config: ArrowConfig): ArrowPathResult {
+export function calcArrowPath(
+  from: NodePos,
+  to: NodePos,
+  config: ArrowConfig,
+  obstacles?: Bbox[],
+): ArrowPathResult {
   const f: Point = { x: from.x, y: from.y }
   const t: Point = { x: to.x, y: to.y }
   const s = exitPt(f, t, config.hw, config.hh, config.rh, config.fromShape)
   const e = entryPt(t, f, config.hw, config.hh, config.rh, config.toShape)
-  return buildArrowPath(s, e, f, t)
+  return buildArrowPath(s, e, f, t, obstacles)
 }
 
 /**

--- a/src/lib/flow-engine.ts
+++ b/src/lib/flow-engine.ts
@@ -27,6 +27,9 @@ interface ArrowConfig {
 /**
  * ノード中心座標とサイズ設定から、矢印のSVGパスを計算する。
  * exitPt → entryPt → buildArrowPath の順に呼び出す薄いラッパー。
+ *
+ * @param obstacles - 同一行上の障害ノード bbox 配列。省略時または空配列時は通常パスを返す。
+ *   水平直線パスの経路上に bbox がある場合、自動的に迂回パスを生成する。
  */
 export function calcArrowPath(
   from: NodePos,


### PR DESCRIPTION
## Summary
- 同一行（同じ `rid`）で複数レーンをまたぐ矢印が、経路上のノードを貫通する問題を解消
- `arrow-routing.ts` に `Bbox` 型と内部 `detectDetour` ヘルパーを追加。`buildArrowPath` の第5引数 `obstacles?: Bbox[]` で迂回パス生成
- 迂回方向は下優先（直下塞がりなら上、両塞がりは下優先）。マージン 14px（行間中央）
- `collectObstacles` ヘルパーで同一行＋直上・直下行のノードを bbox 化、エディタ・共有ビューア共通で利用
- `FlowEditor.aPath` と `SharedFlowViewer.computeArrowPath` で `obstacleNodes` を render 毎に1回だけホイスト構築（O(K×M) → O(M+K)）

## Issue
Closes #314

## 設計・計画
- Design: `docs/plans/2026-04-29-arrow-detour-design.md`
- Plan: `docs/plans/2026-04-29-arrow-detour-plan.md`

## 受け入れ基準
- [x] 同一行で A→B、A→C があるとき、A→C が B を避けて下に迂回する
- [x] 同一行で A→C 単独（B あり）の場合も同様に迂回する
- [x] 同一行で A→B 単独（隣接レーン、間にノードなし）は従来どおり直線
- [x] 直下にノードがある場合は上へ迂回
- [x] 縦方向（同一レーン）の貫通は対象外で従来挙動のまま
- [x] エディタと共有ビューアの両方で同じ挙動
- [ ] LCP 1秒以内（preview ビルドで再計測予定 / dev mode は参考外）
- [x] 全テスト pass（1449 PASS, 1 skipped）
- [ ] 実ブラウザ目視確認

## Test plan
- [x] `arrow-routing.test.ts` 18 ケース（迂回判定の主要シナリオ網羅）
  - 障害なし / 単一障害下空き / 直下塞がり上空き / 両塞がり下優先
  - 複数障害まとめて下迂回 / 直下1つ塞がり上迂回
  - 経路外 bbox は無視 / 斜めパスは迂回しない / 自己参照 / from-to 自身除外（X±1）
  - 右→左方向ミラー / 空配列
- [x] `flow-engine.test.ts` calcArrowPath obstacles パススルー 2 ケース
- [x] `SharedFlowViewer.test.tsx` 迂回 4 セグメント / 隣接 2 セグメント DOM 検証
- [ ] preview build で LCP 1 秒以内確認
- [ ] 実ブラウザで A→B/A→C 同一行配置、直下塞がり、隣接直線の 4 シナリオ目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)