### PR TITLE
feat(#316): 矢印を双方向（両端矢じり）にできるようにする

### DIFF
--- a/api/lib/flow-transform.ts
+++ b/api/lib/flow-transform.ts
@@ -49,6 +49,7 @@ export interface ArrowRow {
   comment: string | null
   color: string | null
   dash: string | null
+  bidirectional: number | null
   created_at: string
   updated_at: string
 }
@@ -102,6 +103,7 @@ export function toArrow(row: ArrowRow) {
     comment: row.comment,
     color: row.color,
     dash: row.dash,
+    bidirectional: row.bidirectional === 1,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }

--- a/api/lib/validators.ts
+++ b/api/lib/validators.ts
@@ -29,6 +29,7 @@ const arrowSchema = z.object({
   comment: z.string().nullable().optional(),
   color: z.string().nullable().optional(),
   dash: z.string().nullable().optional(),
+  bidirectional: z.boolean().optional(),
 })
 
 export const createFlowSchema = z.object({

--- a/api/routes/flows.ts
+++ b/api/routes/flows.ts
@@ -265,7 +265,7 @@ flows.post('/', async (c) => {
     statements.push(
       db
         .prepare(
-          'INSERT INTO arrows (id, flow_id, from_node_id, to_node_id, comment, color, dash) VALUES (?, ?, ?, ?, ?, ?, ?)',
+          'INSERT INTO arrows (id, flow_id, from_node_id, to_node_id, comment, color, dash, bidirectional) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
         )
         .bind(
           arrow.id,
@@ -275,6 +275,7 @@ flows.post('/', async (c) => {
           arrow.comment ?? null,
           arrow.color ?? null,
           arrow.dash ?? null,
+          arrow.bidirectional ? 1 : 0,
         ),
     )
   }
@@ -425,7 +426,7 @@ flows.put('/:id', async (c) => {
         statements.push(
           db
             .prepare(
-              'INSERT INTO arrows (id, flow_id, from_node_id, to_node_id, comment, color, dash) VALUES (?, ?, ?, ?, ?, ?, ?)',
+              'INSERT INTO arrows (id, flow_id, from_node_id, to_node_id, comment, color, dash, bidirectional) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
             )
             .bind(
               arrow.id,
@@ -435,6 +436,7 @@ flows.put('/:id', async (c) => {
               arrow.comment ?? null,
               arrow.color ?? null,
               arrow.dash ?? null,
+              arrow.bidirectional ? 1 : 0,
             ),
         )
       }

--- a/docs/plans/2026-04-29-arrow-bidirectional-design.md
+++ b/docs/plans/2026-04-29-arrow-bidirectional-design.md
@@ -1,0 +1,194 @@
+# 双方向矢印（両端矢じり）対応 — 設計書
+
+- Issue: [#316](https://github.com/tomohirof/flowline/issues/316)
+- 日付: 2026-04-29
+
+## 背景
+
+現在、矢印は片方向（SVG `markerEnd` のみ）でしか描画できない。業務フローでは「相互やりとり」「往復」を表現したいケースがあり、双方向矢印が必要。
+
+## ゴール
+
+- 選択中の矢印に対し、RightPanel から「双方向」を切替えられる。
+- 双方向の矢印は SVG `path` の両端（`markerStart` + `markerEnd`）に矢じりが付く。
+- 編集画面（FlowEditor）と共有ビュー（SharedFlowViewer）で同じ表示。
+- コメント・線色・線種は片方向と同じ仕様で動作。
+- 既存の片方向矢印・既存データに影響なし（後方互換）。
+
+## 非ゴール（別 issue で対応）
+
+- AI 生成プロンプトで双方向矢印を出力できるようにする。
+- OGP Worker（`workers/ogp/src/index.ts`）の双方向対応。
+
+## 設計
+
+### 1. データモデル
+
+`InternalArrow`（UI 内部表現）と `Arrow`（DB 境界）の両方に `bidirectional` を追加する。`from`/`to` は双方向時も保持する（片方向に戻したときに元の向きが復元できる + Mermaid 出力で順序を維持）。
+
+**`src/lib/types.ts`**
+
+```ts
+export interface InternalArrow {
+  id: string
+  from: string
+  to: string
+  comment: string
+  color?: string
+  dash?: string
+  bidirectional?: boolean
+}
+```
+
+**`src/features/editor/types.ts`**
+
+```ts
+export interface Arrow {
+  id: string
+  fromNodeId: string
+  toNodeId: string
+  comment: string | null
+  color?: string | null
+  dash?: string | null
+  bidirectional?: boolean | null
+}
+```
+
+省略時・null 時は片方向扱い。
+
+### 2. DB マイグレーション
+
+**`migrations/0011_arrow_bidirectional.sql`**:
+
+```sql
+ALTER TABLE arrows ADD COLUMN bidirectional INTEGER DEFAULT 0;
+```
+
+- D1（SQLite）なので INTEGER 0/1 で表現。
+- DEFAULT 0 で既存行は全て片方向扱い → 後方互換。
+- `tests/db/migration.test.ts` にスキーマ検証テストを追加。
+
+### 3. API バリデータと永続化
+
+**`api/lib/validators.ts`** — `arrowSchema` に `bidirectional` を追加:
+
+```ts
+const arrowSchema = z.object({
+  id: z.string().min(1),
+  fromNodeId: z.string().min(1),
+  toNodeId: z.string().min(1),
+  comment: z.string().nullable().optional(),
+  color: z.string().nullable().optional(),
+  dash: z.string().nullable().optional(),
+  bidirectional: z.boolean().optional(),
+})
+```
+
+**`api/routes/flows.ts` 系**:
+
+- INSERT 時: `arrow.bidirectional ? 1 : 0` でバインド。
+- SELECT 時: `Boolean(row.bidirectional)` に変換して `Arrow` として返却。
+- 既存行は DEFAULT 0 で `false` として返るので後方互換維持。
+
+**FlowEditor 側の変換**（`FlowEditor.tsx:124-134` 付近）:
+
+- DB 形式 `Arrow.bidirectional` → 内部形式 `InternalArrow.bidirectional` を引き継ぐ。
+- 保存時の逆変換も同様。
+
+### 4. UI（RightPanel）
+
+**`src/features/editor/components/RightPanel.tsx`** の操作セクション（`l.653-673`）を 3 ボタン構成に変更:
+
+```
+[⇄ 双方向]  [⇄ 方向を逆転]  [削除]
+```
+
+仕様:
+
+- 「⇄ 双方向」ボタン: クリックで `selArrowData.bidirectional` を toggle。active 時は背景色 `T.accent` で強調（既存の選択中スタイル流用）、`aria-pressed` で状態を伝達。
+- 「⇄ 方向を逆転」ボタン: `bidirectional === true` のとき `disabled`（双方向では意味がないため）。
+- i18n 追加:
+  - `src/locales/ja/editor.json` → `"arrowBidirectional": "⇄ 双方向"`
+  - `src/locales/en/editor.json` → `"arrowBidirectional": "⇄ Bidirectional"`
+
+### 5. 描画（SVG）
+
+両ファイルの矢印描画 `<g>` セクションで以下の変更を行う:
+
+1. **`<defs>` に `markerStart` 用の `<marker>` を追加** — id を `m-start-${arrow.id}`（FlowEditor）/ `sm-start-${arrow.id}`（SharedFlowViewer）形式にし、`orient="auto-start-reverse"` で始点側に向きを反転。`polygon` の `fill` は既存の `markerEnd` と同色。
+
+2. **`<path>` 属性を条件分岐**:
+
+```tsx
+<path
+  d={d}
+  ...
+  markerStart={arrow.bidirectional ? `url(#m-start-${arrow.id})` : undefined}
+  markerEnd={`url(#m-${arrow.id})`}
+/>
+```
+
+矢印の `path` 計算ロジック（`src/lib/arrow-routing.ts`）はそのまま。両端に矢じりが付くだけで経路は変えない。
+
+### 6. Mermaid 出力
+
+**`FlowEditor.tsx:1488-1492`** 付近の Mermaid 生成ロジックを双方向対応に分岐:
+
+```ts
+const arrowOp = a.bidirectional ? '<-->' : '-->'
+if (a.comment) {
+  m += `    ${fromId} ${arrowOp}|${esc(a.comment)}| ${toId}\n`
+} else {
+  m += `    ${fromId} ${arrowOp} ${toId}\n`
+}
+```
+
+Mermaid 標準の双方向構文 `<-->` を使用。
+
+## テスト戦略
+
+### ユニット
+
+- `useArrows.test.ts`: `bidirectional` フィールドが `setArrows` で保持されることを確認。
+- `flow-engine.test.ts`: 双方向矢印を含むフロー変換が両方向プロパティを保持。
+
+### コンポーネント
+
+- `FlowEditor.test.tsx`: 双方向矢印 `path` に `marker-start` と `marker-end` が両方付くこと、片方向は `marker-end` のみ。
+- `SharedFlowViewer.test.tsx`: 同上（共有ビュー側、id プレフィックス `sm-`）。
+- RightPanel テスト: 双方向ボタンクリックで toggle、ON 時に「方向を逆転」ボタンが `disabled`。
+
+### API / DB
+
+- `tests/db/migration.test.ts`: マイグレーション 0011 適用後、`arrows.bidirectional` カラムが存在し DEFAULT 0。
+- `tests/api/routes/flows.test.ts`: `bidirectional: true` で POST → GET で復元、未指定時は false で返却。
+
+### E2E（実画面検証）
+
+- 矢印選択 → 双方向 ON → 保存 → リロードで状態維持。
+- PNG エクスポートに両端の矢じりが反映されること。
+
+### 回帰
+
+- 既存の `marker-end` 前提のテスト群（例: `FlowEditor.test.tsx:1812-1813`, `SharedFlowViewer.test.tsx:398` 等）が引き続きパス。
+
+## 受け入れ条件
+
+- [ ] エディタで矢印を双方向にできる。
+- [ ] 共有ビューでも双方向で表示される。
+- [ ] DB 保存・復元が正しく動く（後方互換含む）。
+- [ ] PNG エクスポートに両端の矢じりが反映される。
+- [ ] 既存の片方向矢印・既存データに影響がない。
+- [ ] LCP 1 秒以内（CLAUDE.md ルール準拠）。
+
+## 関連ファイル
+
+- `src/lib/types.ts`
+- `src/features/editor/types.ts`
+- `src/features/editor/FlowEditor.tsx`
+- `src/features/shared/SharedFlowViewer.tsx`
+- `src/features/editor/components/RightPanel.tsx`
+- `src/locales/ja/editor.json`, `src/locales/en/editor.json`
+- `api/lib/validators.ts`
+- `api/routes/flows.ts`（および関連ルート）
+- `migrations/0011_arrow_bidirectional.sql`（新規）

--- a/docs/plans/2026-04-29-arrow-bidirectional-plan.md
+++ b/docs/plans/2026-04-29-arrow-bidirectional-plan.md
@@ -58,9 +58,11 @@ cat ~/.claude/rules/testing.md
 ## ファイル構成
 
 **作成:**
+
 - `migrations/0011_arrow_bidirectional.sql` — DB マイグレーション
 
 **修正（型・データ層）:**
+
 - `src/lib/types.ts` — `InternalArrow` に `bidirectional`
 - `src/features/editor/types.ts` — `Arrow` に `bidirectional`
 - `api/lib/validators.ts` — zod schema に `bidirectional`
@@ -69,14 +71,17 @@ cat ~/.claude/rules/testing.md
 - `src/features/editor/FlowEditor.tsx` — `flowToInternal` / `internalStateToPayload` で引き継ぎ
 
 **修正（描画）:**
+
 - `src/features/editor/FlowEditor.tsx` — `markerStart` 追加 + Mermaid 出力分岐
 - `src/features/shared/SharedFlowViewer.tsx` — `markerStart` 追加
 
 **修正（UI）:**
+
 - `src/features/editor/components/RightPanel.tsx` — 「⇄ 双方向」ボタン追加 + 「方向を逆転」を条件付き disabled
 - `src/locales/ja/editor.json`, `src/locales/en/editor.json` — i18n キー追加
 
 **修正（テスト）:**
+
 - `tests/db/migration.test.ts` — マイグレーション 0011 検証
 - `tests/api/routes/flows.test.ts` — `bidirectional` の round-trip
 - `src/features/editor/hooks/useArrows.test.ts` — `bidirectional` 保持
@@ -88,6 +93,7 @@ cat ~/.claude/rules/testing.md
 ## Task 1: DB マイグレーション 0011
 
 **Files:**
+
 - Create: `migrations/0011_arrow_bidirectional.sql`
 - Test: `tests/db/migration.test.ts`
 
@@ -96,59 +102,57 @@ cat ~/.claude/rules/testing.md
 `tests/db/migration.test.ts` の末尾（`'should have created_at and updated_at on all tables'` テストの直前）に追加:
 
 ```ts
-  it('should add bidirectional column to arrows (0011)', () => {
-    const db = new Database(':memory:')
-    db.pragma('foreign_keys = ON')
-    const files = [
-      '0001_initial.sql',
-      '0002_node_arrow_styles.sql',
-      '0003_user_settings.sql',
-      '0004_email_verification.sql',
-      '0005_soft_delete.sql',
-      '0006_ai_admin.sql',
-      '0007_node_shape.sql',
-      '0008_projects.sql',
-      '0009_invitation_codes.sql',
-      '0010_project_members.sql',
-      '0011_arrow_bidirectional.sql',
-    ]
-    for (const f of files) {
-      const sql = readFileSync(resolve(__dirname, '../../migrations/', f), 'utf-8')
-      for (const stmt of sql.split(';').filter((s) => s.trim())) {
-        db.exec(stmt + ';')
-      }
+it('should add bidirectional column to arrows (0011)', () => {
+  const db = new Database(':memory:')
+  db.pragma('foreign_keys = ON')
+  const files = [
+    '0001_initial.sql',
+    '0002_node_arrow_styles.sql',
+    '0003_user_settings.sql',
+    '0004_email_verification.sql',
+    '0005_soft_delete.sql',
+    '0006_ai_admin.sql',
+    '0007_node_shape.sql',
+    '0008_projects.sql',
+    '0009_invitation_codes.sql',
+    '0010_project_members.sql',
+    '0011_arrow_bidirectional.sql',
+  ]
+  for (const f of files) {
+    const sql = readFileSync(resolve(__dirname, '../../migrations/', f), 'utf-8')
+    for (const stmt of sql.split(';').filter((s) => s.trim())) {
+      db.exec(stmt + ';')
     }
-    const cols = db.prepare('PRAGMA table_info(arrows)').all() as Array<{
-      name: string
-      dflt_value: string | null
-    }>
-    const bidir = cols.find((c) => c.name === 'bidirectional')
-    expect(bidir).toBeDefined()
-    expect(bidir?.dflt_value).toBe('0')
+  }
+  const cols = db.prepare('PRAGMA table_info(arrows)').all() as Array<{
+    name: string
+    dflt_value: string | null
+  }>
+  const bidir = cols.find((c) => c.name === 'bidirectional')
+  expect(bidir).toBeDefined()
+  expect(bidir?.dflt_value).toBe('0')
 
-    // 既存 INSERT が動くこと（DEFAULT 0 で挿入される）
-    db.prepare(
-      "INSERT INTO users (id, email, password_hash, name) VALUES ('u1', 'u1@test.com', 'h', 'U')",
-    ).run()
-    db.prepare("INSERT INTO flows (id, user_id) VALUES ('f1', 'u1')").run()
-    db.prepare(
-      "INSERT INTO lanes (id, flow_id, name, position) VALUES ('l1', 'f1', 'L', 0)",
-    ).run()
-    db.prepare(
-      "INSERT INTO nodes (id, flow_id, lane_id, row_index, order_index) VALUES ('n1', 'f1', 'l1', 0, 0)",
-    ).run()
-    db.prepare(
-      "INSERT INTO nodes (id, flow_id, lane_id, row_index, order_index) VALUES ('n2', 'f1', 'l1', 1, 1)",
-    ).run()
-    db.prepare(
-      "INSERT INTO arrows (id, flow_id, from_node_id, to_node_id) VALUES ('a1', 'f1', 'n1', 'n2')",
-    ).run()
-    const row = db.prepare("SELECT bidirectional FROM arrows WHERE id = 'a1'").get() as {
-      bidirectional: number
-    }
-    expect(row.bidirectional).toBe(0)
-    db.close()
-  })
+  // 既存 INSERT が動くこと（DEFAULT 0 で挿入される）
+  db.prepare(
+    "INSERT INTO users (id, email, password_hash, name) VALUES ('u1', 'u1@test.com', 'h', 'U')",
+  ).run()
+  db.prepare("INSERT INTO flows (id, user_id) VALUES ('f1', 'u1')").run()
+  db.prepare("INSERT INTO lanes (id, flow_id, name, position) VALUES ('l1', 'f1', 'L', 0)").run()
+  db.prepare(
+    "INSERT INTO nodes (id, flow_id, lane_id, row_index, order_index) VALUES ('n1', 'f1', 'l1', 0, 0)",
+  ).run()
+  db.prepare(
+    "INSERT INTO nodes (id, flow_id, lane_id, row_index, order_index) VALUES ('n2', 'f1', 'l1', 1, 1)",
+  ).run()
+  db.prepare(
+    "INSERT INTO arrows (id, flow_id, from_node_id, to_node_id) VALUES ('a1', 'f1', 'n1', 'n2')",
+  ).run()
+  const row = db.prepare("SELECT bidirectional FROM arrows WHERE id = 'a1'").get() as {
+    bidirectional: number
+  }
+  expect(row.bidirectional).toBe(0)
+  db.close()
+})
 ```
 
 - [ ] **Step 2: テスト失敗を確認**
@@ -188,6 +192,7 @@ git commit -m "feat(#316): add bidirectional column to arrows table"
 ## Task 2: 型定義（InternalArrow / Arrow）
 
 **Files:**
+
 - Modify: `src/lib/types.ts`
 - Modify: `src/features/editor/types.ts`
 
@@ -253,6 +258,7 @@ git commit -m "feat(#316): add bidirectional field to Arrow types"
 ## Task 3: API バリデータ + 永続化
 
 **Files:**
+
 - Modify: `api/lib/validators.ts`
 - Modify: `api/lib/flow-transform.ts`
 - Modify: `api/routes/flows.ts:264-280`, `api/routes/flows.ts:423-440`
@@ -263,52 +269,54 @@ git commit -m "feat(#316): add bidirectional field to Arrow types"
 `tests/api/routes/flows.test.ts` に新しい it を追加（既存の flow CRUD テストの近くに配置）:
 
 ```ts
-  it('should round-trip bidirectional arrow flag', async () => {
-    const userId = await createTestUser()
-    const token = await getAuthToken(userId)
+it('should round-trip bidirectional arrow flag', async () => {
+  const userId = await createTestUser()
+  const token = await getAuthToken(userId)
 
-    const createRes = await app.request(
-      '/api/flows',
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({
-          title: 'Bidir test',
-          themeId: 'cloud',
-          lanes: [{ id: 'l1', name: 'L', colorIndex: 0, position: 0 }],
-          nodes: [
-            { id: 'n1', laneId: 'l1', rowIndex: 0, label: 'A', orderIndex: 0 },
-            { id: 'n2', laneId: 'l1', rowIndex: 1, label: 'B', orderIndex: 1 },
-          ],
-          arrows: [
-            { id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', bidirectional: true },
-            { id: 'a2', fromNodeId: 'n2', toNodeId: 'n1' },
-          ],
-        }),
+  const createRes = await app.request(
+    '/api/flows',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
       },
-      env,
-    )
-    expect(createRes.status).toBe(201)
-    const { flow } = (await createRes.json()) as { flow: { id: string; arrows: Array<{ id: string; bidirectional?: boolean | null }> } }
-    const a1 = flow.arrows.find((a) => a.id === 'a1')
-    const a2 = flow.arrows.find((a) => a.id === 'a2')
-    expect(a1?.bidirectional).toBe(true)
-    expect(a2?.bidirectional ?? false).toBe(false)
+      body: JSON.stringify({
+        title: 'Bidir test',
+        themeId: 'cloud',
+        lanes: [{ id: 'l1', name: 'L', colorIndex: 0, position: 0 }],
+        nodes: [
+          { id: 'n1', laneId: 'l1', rowIndex: 0, label: 'A', orderIndex: 0 },
+          { id: 'n2', laneId: 'l1', rowIndex: 1, label: 'B', orderIndex: 1 },
+        ],
+        arrows: [
+          { id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', bidirectional: true },
+          { id: 'a2', fromNodeId: 'n2', toNodeId: 'n1' },
+        ],
+      }),
+    },
+    env,
+  )
+  expect(createRes.status).toBe(201)
+  const { flow } = (await createRes.json()) as {
+    flow: { id: string; arrows: Array<{ id: string; bidirectional?: boolean | null }> }
+  }
+  const a1 = flow.arrows.find((a) => a.id === 'a1')
+  const a2 = flow.arrows.find((a) => a.id === 'a2')
+  expect(a1?.bidirectional).toBe(true)
+  expect(a2?.bidirectional ?? false).toBe(false)
 
-    // GET でも同じ値が返ること
-    const getRes = await app.request(
-      `/api/flows/${flow.id}`,
-      { headers: { Authorization: `Bearer ${token}` } },
-      env,
-    )
-    expect(getRes.status).toBe(200)
-    const { flow: got } = (await getRes.json()) as { flow: typeof flow }
-    expect(got.arrows.find((a) => a.id === 'a1')?.bidirectional).toBe(true)
-    expect(got.arrows.find((a) => a.id === 'a2')?.bidirectional ?? false).toBe(false)
-  })
+  // GET でも同じ値が返ること
+  const getRes = await app.request(
+    `/api/flows/${flow.id}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+    env,
+  )
+  expect(getRes.status).toBe(200)
+  const { flow: got } = (await getRes.json()) as { flow: typeof flow }
+  expect(got.arrows.find((a) => a.id === 'a1')?.bidirectional).toBe(true)
+  expect(got.arrows.find((a) => a.id === 'a2')?.bidirectional ?? false).toBe(false)
+})
 ```
 
 注: `createTestUser` / `getAuthToken` / `env` / `app` は既存テストで使われているヘルパ。同ファイル内の既存テストの構造をそのまま流用すること。
@@ -379,25 +387,25 @@ export function toArrow(row: ArrowRow) {
 `api/routes/flows.ts:263-280` の arrows INSERT ループを:
 
 ```ts
-  // INSERT arrows
-  for (const arrow of arrows) {
-    statements.push(
-      db
-        .prepare(
-          'INSERT INTO arrows (id, flow_id, from_node_id, to_node_id, comment, color, dash, bidirectional) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
-        )
-        .bind(
-          arrow.id,
-          flowId,
-          arrow.fromNodeId,
-          arrow.toNodeId,
-          arrow.comment ?? null,
-          arrow.color ?? null,
-          arrow.dash ?? null,
-          arrow.bidirectional ? 1 : 0,
-        ),
-    )
-  }
+// INSERT arrows
+for (const arrow of arrows) {
+  statements.push(
+    db
+      .prepare(
+        'INSERT INTO arrows (id, flow_id, from_node_id, to_node_id, comment, color, dash, bidirectional) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+      )
+      .bind(
+        arrow.id,
+        flowId,
+        arrow.fromNodeId,
+        arrow.toNodeId,
+        arrow.comment ?? null,
+        arrow.color ?? null,
+        arrow.dash ?? null,
+        arrow.bidirectional ? 1 : 0,
+      ),
+  )
+}
 ```
 
 - [ ] **Step 6: INSERT 文に `bidirectional` を追加（PUT /flows/:id）**
@@ -405,25 +413,25 @@ export function toArrow(row: ArrowRow) {
 `api/routes/flows.ts:423-440` の同形式の INSERT ループも同じ変更を適用:
 
 ```ts
-      // INSERT new arrows
-      for (const arrow of safeArrows) {
-        statements.push(
-          db
-            .prepare(
-              'INSERT INTO arrows (id, flow_id, from_node_id, to_node_id, comment, color, dash, bidirectional) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
-            )
-            .bind(
-              arrow.id,
-              flowId,
-              arrow.fromNodeId,
-              arrow.toNodeId,
-              arrow.comment ?? null,
-              arrow.color ?? null,
-              arrow.dash ?? null,
-              arrow.bidirectional ? 1 : 0,
-            ),
-        )
-      }
+// INSERT new arrows
+for (const arrow of safeArrows) {
+  statements.push(
+    db
+      .prepare(
+        'INSERT INTO arrows (id, flow_id, from_node_id, to_node_id, comment, color, dash, bidirectional) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+      )
+      .bind(
+        arrow.id,
+        flowId,
+        arrow.fromNodeId,
+        arrow.toNodeId,
+        arrow.comment ?? null,
+        arrow.color ?? null,
+        arrow.dash ?? null,
+        arrow.bidirectional ? 1 : 0,
+      ),
+  )
+}
 ```
 
 - [ ] **Step 7: テスト pass を確認**
@@ -446,6 +454,7 @@ git commit -m "feat(#316): persist bidirectional flag on arrows API"
 ## Task 4: FlowEditor のデータ変換で bidirectional を引き継ぐ
 
 **Files:**
+
 - Modify: `src/features/editor/FlowEditor.tsx:124-134`, `src/features/editor/FlowEditor.tsx:188-203`
 - Test: `src/features/editor/hooks/useArrows.test.ts`
 
@@ -456,22 +465,20 @@ git commit -m "feat(#316): persist bidirectional flag on arrows API"
 `src/features/editor/hooks/useArrows.test.ts` の末尾（既存のテストグループ内）に追加:
 
 ```ts
-  it('should preserve bidirectional flag through setArrows', () => {
-    const arrows: InternalArrow[] = [
-      { id: 'a1', from: 'l0_r0', to: 'l0_r1', comment: '', bidirectional: true },
-    ]
-    const { result } = renderHook(() =>
-      useArrows({ ...defaultOptions, initialArrows: arrows }),
+it('should preserve bidirectional flag through setArrows', () => {
+  const arrows: InternalArrow[] = [
+    { id: 'a1', from: 'l0_r0', to: 'l0_r1', comment: '', bidirectional: true },
+  ]
+  const { result } = renderHook(() => useArrows({ ...defaultOptions, initialArrows: arrows }))
+  expect(result.current.arrows[0].bidirectional).toBe(true)
+  act(() => {
+    result.current.setArrows((p) =>
+      p.map((a) => (a.id === 'a1' ? { ...a, comment: 'updated' } : a)),
     )
-    expect(result.current.arrows[0].bidirectional).toBe(true)
-    act(() => {
-      result.current.setArrows((p) =>
-        p.map((a) => (a.id === 'a1' ? { ...a, comment: 'updated' } : a)),
-      )
-    })
-    expect(result.current.arrows[0].bidirectional).toBe(true)
-    expect(result.current.arrows[0].comment).toBe('updated')
   })
+  expect(result.current.arrows[0].bidirectional).toBe(true)
+  expect(result.current.arrows[0].comment).toBe('updated')
+})
 ```
 
 注: `defaultOptions` / `renderHook` / `act` / `InternalArrow` インポートは既存テストの形式に合わせる（同ファイルの既存 `it` を参照）。
@@ -489,19 +496,19 @@ npm test -- src/features/editor/hooks/useArrows.test.ts
 `src/features/editor/FlowEditor.tsx:124-134` の arrows 構築を:
 
 ```ts
-  // Build arrows
-  const arrows: InternalArrow[] = flow.arrows
-    .map((a) => {
-      const from = nodeIdToKey[a.fromNodeId]
-      const to = nodeIdToKey[a.toNodeId]
-      if (!from || !to) return null
-      const arr: InternalArrow = { id: a.id, from, to, comment: a.comment ?? '' }
-      if (a.color) arr.color = a.color
-      if (a.dash) arr.dash = a.dash
-      if (a.bidirectional) arr.bidirectional = true
-      return arr
-    })
-    .filter((a): a is InternalArrow => a !== null)
+// Build arrows
+const arrows: InternalArrow[] = flow.arrows
+  .map((a) => {
+    const from = nodeIdToKey[a.fromNodeId]
+    const to = nodeIdToKey[a.toNodeId]
+    if (!from || !to) return null
+    const arr: InternalArrow = { id: a.id, from, to, comment: a.comment ?? '' }
+    if (a.color) arr.color = a.color
+    if (a.dash) arr.dash = a.dash
+    if (a.bidirectional) arr.bidirectional = true
+    return arr
+  })
+  .filter((a): a is InternalArrow => a !== null)
 ```
 
 - [ ] **Step 4: `internalStateToPayload` で bidirectional を出力に含める**
@@ -509,23 +516,23 @@ npm test -- src/features/editor/hooks/useArrows.test.ts
 `src/features/editor/FlowEditor.tsx:188-203` の apiArrows ビルドを:
 
 ```ts
-  // Build API arrows using stable nodeIds
-  const apiArrows = arrows
-    .map((a) => {
-      const fromNodeId = keyToNodeId[a.from]
-      const toNodeId = keyToNodeId[a.to]
-      if (!fromNodeId || !toNodeId) return null
-      return {
-        id: a.id,
-        fromNodeId,
-        toNodeId,
-        comment: a.comment || null,
-        color: a.color || null,
-        dash: a.dash || null,
-        bidirectional: a.bidirectional ?? false,
-      }
-    })
-    .filter((a): a is NonNullable<typeof a> => a !== null)
+// Build API arrows using stable nodeIds
+const apiArrows = arrows
+  .map((a) => {
+    const fromNodeId = keyToNodeId[a.from]
+    const toNodeId = keyToNodeId[a.to]
+    if (!fromNodeId || !toNodeId) return null
+    return {
+      id: a.id,
+      fromNodeId,
+      toNodeId,
+      comment: a.comment || null,
+      color: a.color || null,
+      dash: a.dash || null,
+      bidirectional: a.bidirectional ?? false,
+    }
+  })
+  .filter((a): a is NonNullable<typeof a> => a !== null)
 ```
 
 - [ ] **Step 5: 型チェック + 既存テスト**
@@ -549,6 +556,7 @@ git commit -m "feat(#316): propagate bidirectional flag in FlowEditor conversion
 ## Task 5: SVG 描画 — FlowEditor
 
 **Files:**
+
 - Modify: `src/features/editor/FlowEditor.tsx:2688-2720`（矢印 `<g>` セクション）
 - Test: `src/features/editor/FlowEditor.test.tsx`
 
@@ -663,6 +671,7 @@ git commit -m "feat(#316): render marker-start for bidirectional arrows in FlowE
 ## Task 6: SVG 描画 — SharedFlowViewer
 
 **Files:**
+
 - Modify: `src/features/shared/SharedFlowViewer.tsx:495-512`
 - Test: `src/features/shared/SharedFlowViewer.test.tsx`
 
@@ -707,28 +716,23 @@ npm test -- src/features/shared/SharedFlowViewer.test.tsx -t "marker-start on bi
 `src/features/shared/SharedFlowViewer.tsx:495-512` 付近の矢印 marker 定義 + path を:
 
 ```tsx
-                  <marker
-                    id={`sm-${arrow.id}`}
-                    markerWidth="9"
-                    markerHeight="8"
-                    refX="8"
-                    refY="4"
-                    orient="auto"
-                  >
-                    <polygon points="0 0.5, 9 4, 0 7.5" fill={ac} />
-                  </marker>
-                  {arrow.bidirectional && (
-                    <marker
-                      id={`sm-start-${arrow.id}`}
-                      markerWidth="9"
-                      markerHeight="8"
-                      refX="8"
-                      refY="4"
-                      orient="auto-start-reverse"
-                    >
-                      <polygon points="0 0.5, 9 4, 0 7.5" fill={ac} />
-                    </marker>
-                  )}
+;<marker id={`sm-${arrow.id}`} markerWidth="9" markerHeight="8" refX="8" refY="4" orient="auto">
+  <polygon points="0 0.5, 9 4, 0 7.5" fill={ac} />
+</marker>
+{
+  arrow.bidirectional && (
+    <marker
+      id={`sm-start-${arrow.id}`}
+      markerWidth="9"
+      markerHeight="8"
+      refX="8"
+      refY="4"
+      orient="auto-start-reverse"
+    >
+      <polygon points="0 0.5, 9 4, 0 7.5" fill={ac} />
+    </marker>
+  )
+}
 ```
 
 そして `path` 要素に `markerStart` 属性を追加:
@@ -762,6 +766,7 @@ git commit -m "feat(#316): render marker-start for bidirectional arrows in Share
 ## Task 7: RightPanel UI — 「⇄ 双方向」ボタン
 
 **Files:**
+
 - Modify: `src/features/editor/components/RightPanel.tsx:653-673`
 - Modify: `src/locales/ja/editor.json`, `src/locales/en/editor.json`
 
@@ -796,40 +801,36 @@ git commit -m "feat(#316): render marker-start for bidirectional arrows in Share
 `src/features/editor/components/RightPanel.tsx:653-673` の `<PanelSection label={t('rightPanel.operations')}>` ブロックを:
 
 ```tsx
-        <PanelSection label={t('rightPanel.operations')}>
-          <div className={styles.panelActions}>
-            <PanelBtn
-              label={t('rightPanel.arrowBidirectional')}
-              color={T.accent}
-              active={!!selArrowData.bidirectional}
-              onClick={() =>
-                setArrows((p) =>
-                  p.map((a) =>
-                    a.id === selArrow ? { ...a, bidirectional: !a.bidirectional } : a,
-                  ),
-                )
-              }
-            />
-            <PanelBtn
-              label={t('rightPanel.arrowReverse')}
-              color={T.accent}
-              disabled={!!selArrowData.bidirectional}
-              onClick={() =>
-                setArrows((p) =>
-                  p.map((a) => (a.id === selArrow ? { ...a, from: a.to, to: a.from } : a)),
-                )
-              }
-            />
-            <PanelBtn
-              label={t('rightPanel.arrowDelete')}
-              color="#E06060"
-              onClick={() => {
-                setArrows((p) => p.filter((a) => a.id !== selArrow))
-                setSelArrow(null)
-              }}
-            />
-          </div>
-        </PanelSection>
+<PanelSection label={t('rightPanel.operations')}>
+  <div className={styles.panelActions}>
+    <PanelBtn
+      label={t('rightPanel.arrowBidirectional')}
+      color={T.accent}
+      active={!!selArrowData.bidirectional}
+      onClick={() =>
+        setArrows((p) =>
+          p.map((a) => (a.id === selArrow ? { ...a, bidirectional: !a.bidirectional } : a)),
+        )
+      }
+    />
+    <PanelBtn
+      label={t('rightPanel.arrowReverse')}
+      color={T.accent}
+      disabled={!!selArrowData.bidirectional}
+      onClick={() =>
+        setArrows((p) => p.map((a) => (a.id === selArrow ? { ...a, from: a.to, to: a.from } : a)))
+      }
+    />
+    <PanelBtn
+      label={t('rightPanel.arrowDelete')}
+      color="#E06060"
+      onClick={() => {
+        setArrows((p) => p.filter((a) => a.id !== selArrow))
+        setSelArrow(null)
+      }}
+    />
+  </div>
+</PanelSection>
 ```
 
 - [ ] **Step 3: PanelBtn が `active`/`disabled` プロパティに対応しているか確認・追加**
@@ -878,18 +879,18 @@ const PanelBtn = ({ label, color, onClick, active, disabled }: PanelBtnProps) =>
 `src/features/editor/components/RightPanel.test.tsx`（既存があれば）または `FlowEditor.test.tsx` 内に統合テストとして:
 
 ```ts
-  it('should toggle bidirectional flag on click', () => {
-    // FlowEditor を arrow 1 つ + 選択状態でレンダリング
-    // 既存テストで arrow 選択をシミュレートしている例を流用
-    const { container, getByText } = renderEditorWithSelectedArrow('a1')
-    const btn = getByText('⇄ 双方向').closest('button')!
-    expect(btn.getAttribute('aria-pressed')).toBe('false')
-    fireEvent.click(btn)
-    expect(btn.getAttribute('aria-pressed')).toBe('true')
-    // 双方向ON時、方向逆転ボタンが disabled
-    const reverseBtn = getByText('⇄ 方向を逆転').closest('button')!
-    expect(reverseBtn).toBeDisabled()
-  })
+it('should toggle bidirectional flag on click', () => {
+  // FlowEditor を arrow 1 つ + 選択状態でレンダリング
+  // 既存テストで arrow 選択をシミュレートしている例を流用
+  const { container, getByText } = renderEditorWithSelectedArrow('a1')
+  const btn = getByText('⇄ 双方向').closest('button')!
+  expect(btn.getAttribute('aria-pressed')).toBe('false')
+  fireEvent.click(btn)
+  expect(btn.getAttribute('aria-pressed')).toBe('true')
+  // 双方向ON時、方向逆転ボタンが disabled
+  const reverseBtn = getByText('⇄ 方向を逆転').closest('button')!
+  expect(reverseBtn).toBeDisabled()
+})
 ```
 
 注: `renderEditorWithSelectedArrow` は既存テストの選択シミュレーション手順を関数化。同等の処理を `FlowEditor.test.tsx` から探して再利用すること。既存テストファイルにヘルパが無ければ、選択状態を作る既存テストの手順をインライン化。
@@ -914,6 +915,7 @@ git commit -m "feat(#316): add bidirectional toggle button to RightPanel"
 ## Task 8: Mermaid 出力で双方向対応
 
 **Files:**
+
 - Modify: `src/features/editor/FlowEditor.tsx:1488-1492` 付近
 - Test: `src/features/editor/FlowEditor.test.tsx`
 
@@ -922,23 +924,23 @@ git commit -m "feat(#316): add bidirectional toggle button to RightPanel"
 `src/features/editor/FlowEditor.test.tsx` の Mermaid 出力テスト群（既存の Mermaid 関連テストを検索して追加）:
 
 ```ts
-  it('should output <--> for bidirectional arrows in Mermaid', () => {
-    const flow: Flow = {
-      ...minimalFlow(),
-      lanes: [{ id: 'l1', name: 'L', colorIndex: 0, position: 0 }],
-      nodes: [
-        { id: 'n1', laneId: 'l1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
-        { id: 'n2', laneId: 'l1', rowIndex: 1, label: 'B', note: null, orderIndex: 1 },
-      ],
-      arrows: [
-        { id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: null, bidirectional: true },
-        { id: 'a2', fromNodeId: 'n2', toNodeId: 'n1', comment: 'note', bidirectional: true },
-      ],
-    }
-    const mermaid = buildMermaid(flow)  // または FlowEditor 経由
-    expect(mermaid).toContain('<-->')
-    expect(mermaid).toMatch(/<-->\|note\|/)
-  })
+it('should output <--> for bidirectional arrows in Mermaid', () => {
+  const flow: Flow = {
+    ...minimalFlow(),
+    lanes: [{ id: 'l1', name: 'L', colorIndex: 0, position: 0 }],
+    nodes: [
+      { id: 'n1', laneId: 'l1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+      { id: 'n2', laneId: 'l1', rowIndex: 1, label: 'B', note: null, orderIndex: 1 },
+    ],
+    arrows: [
+      { id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: null, bidirectional: true },
+      { id: 'a2', fromNodeId: 'n2', toNodeId: 'n1', comment: 'note', bidirectional: true },
+    ],
+  }
+  const mermaid = buildMermaid(flow) // または FlowEditor 経由
+  expect(mermaid).toContain('<-->')
+  expect(mermaid).toMatch(/<-->\|note\|/)
+})
 ```
 
 注: Mermaid は FlowEditor 内のロジックなので、既存 Mermaid テストの呼び出し方法（モーダル経由 or 関数 export）を確認して合わせる。`buildMermaid` のような export 関数が無ければ、既存テストパターン通りボタンクリックでクリップボード書込をスパイする方式を採用。
@@ -956,13 +958,13 @@ npm test -- src/features/editor/FlowEditor.test.tsx -t "Mermaid"
 `src/features/editor/FlowEditor.tsx:1488-1492` 付近を:
 
 ```ts
-      if (!fromId || !toId) return
-      const arrowOp = a.bidirectional ? '<-->' : '-->'
-      if (a.comment) {
-        m += `    ${fromId} ${arrowOp}|${esc(a.comment)}| ${toId}\n`
-      } else {
-        m += `    ${fromId} ${arrowOp} ${toId}\n`
-      }
+if (!fromId || !toId) return
+const arrowOp = a.bidirectional ? '<-->' : '-->'
+if (a.comment) {
+  m += `    ${fromId} ${arrowOp}|${esc(a.comment)}| ${toId}\n`
+} else {
+  m += `    ${fromId} ${arrowOp} ${toId}\n`
+}
 ```
 
 注: `m += ...` のインデントは既存コードに合わせる。Read で当該箇所を確認の上で編集。
@@ -1033,6 +1035,7 @@ npm run dev
 - [ ] **Step 3: 矢印を選択し「⇄ 双方向」をクリック**
 
 操作:
+
 1. 既存または新規フローを開く
 2. 矢印を 1 本クリック → RightPanel に「⇄ 双方向」ボタンが表示されることを確認
 3. クリック → 矢印の両端に矢じりが付くことを確認

--- a/docs/plans/2026-04-29-arrow-bidirectional-plan.md
+++ b/docs/plans/2026-04-29-arrow-bidirectional-plan.md
@@ -1,0 +1,1169 @@
+# 双方向矢印（両端矢じり）対応 — 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 矢印を双方向（両端に矢じり）にできるようにする。RightPanel から切替、DB に永続化、編集画面・共有ビュー・Mermaid 出力で対応。
+
+**Architecture:** `Arrow` / `InternalArrow` に `bidirectional?: boolean` を追加。DB は `arrows.bidirectional INTEGER DEFAULT 0`。SVG は `<defs>` に `markerStart` 用 marker を追加し `path` の `markerStart` 属性で条件分岐。`from`/`to` は双方向時も保持（片方向に戻したとき復元 + Mermaid 順序維持）。
+
+**Tech Stack:** TypeScript / React / Hono / Cloudflare D1 (SQLite) / Vitest / Zod
+
+**Issue:** [#316](https://github.com/tomohirof/flowline/issues/316)
+
+**Design doc:** `docs/plans/2026-04-29-arrow-bidirectional-design.md`
+
+---
+
+## Pre-flight: ワークツリー作成と issue ラベル
+
+### Task 0: 環境準備
+
+**Files:** （Git 操作のみ）
+
+- [ ] **Step 1: Issue にラベル付与**
+
+```bash
+gh issue edit 316 --add-label "作業開始"
+```
+
+- [ ] **Step 2: main を最新化**
+
+```bash
+git checkout main
+git fetch origin
+git merge --ff-only origin/main
+```
+
+ff-only が通らない場合は作業を中断して人間に報告。
+
+- [ ] **Step 3: ワークツリー作成 + .env リンク**
+
+```bash
+git worktree add .worktrees/feat-arrow-bidirectional-316 -b feat/arrow-bidirectional-316
+cd .worktrees/feat-arrow-bidirectional-316
+MAIN=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
+for f in "$MAIN"/.env*; do [ -f "$f" ] && ln -sf "$f" .; done
+```
+
+- [ ] **Step 4: テストルール読込**
+
+```bash
+cat ~/.claude/rules/testing.md
+```
+
+以降の全タスクは worktree `.worktrees/feat-arrow-bidirectional-316` 内で実行する。
+
+---
+
+## ファイル構成
+
+**作成:**
+- `migrations/0011_arrow_bidirectional.sql` — DB マイグレーション
+
+**修正（型・データ層）:**
+- `src/lib/types.ts` — `InternalArrow` に `bidirectional`
+- `src/features/editor/types.ts` — `Arrow` に `bidirectional`
+- `api/lib/validators.ts` — zod schema に `bidirectional`
+- `api/lib/flow-transform.ts` — `ArrowRow` / `toArrow` で `bidirectional` を扱う
+- `api/routes/flows.ts` — INSERT 時に `bidirectional` をバインド（2 箇所）
+- `src/features/editor/FlowEditor.tsx` — `flowToInternal` / `internalStateToPayload` で引き継ぎ
+
+**修正（描画）:**
+- `src/features/editor/FlowEditor.tsx` — `markerStart` 追加 + Mermaid 出力分岐
+- `src/features/shared/SharedFlowViewer.tsx` — `markerStart` 追加
+
+**修正（UI）:**
+- `src/features/editor/components/RightPanel.tsx` — 「⇄ 双方向」ボタン追加 + 「方向を逆転」を条件付き disabled
+- `src/locales/ja/editor.json`, `src/locales/en/editor.json` — i18n キー追加
+
+**修正（テスト）:**
+- `tests/db/migration.test.ts` — マイグレーション 0011 検証
+- `tests/api/routes/flows.test.ts` — `bidirectional` の round-trip
+- `src/features/editor/hooks/useArrows.test.ts` — `bidirectional` 保持
+- `src/features/editor/FlowEditor.test.tsx` — `marker-start`/`marker-end` 検証
+- `src/features/shared/SharedFlowViewer.test.tsx` — 共有ビュー側の検証
+
+---
+
+## Task 1: DB マイグレーション 0011
+
+**Files:**
+- Create: `migrations/0011_arrow_bidirectional.sql`
+- Test: `tests/db/migration.test.ts`
+
+- [ ] **Step 1: 失敗テストを追加**
+
+`tests/db/migration.test.ts` の末尾（`'should have created_at and updated_at on all tables'` テストの直前）に追加:
+
+```ts
+  it('should add bidirectional column to arrows (0011)', () => {
+    const db = new Database(':memory:')
+    db.pragma('foreign_keys = ON')
+    const files = [
+      '0001_initial.sql',
+      '0002_node_arrow_styles.sql',
+      '0003_user_settings.sql',
+      '0004_email_verification.sql',
+      '0005_soft_delete.sql',
+      '0006_ai_admin.sql',
+      '0007_node_shape.sql',
+      '0008_projects.sql',
+      '0009_invitation_codes.sql',
+      '0010_project_members.sql',
+      '0011_arrow_bidirectional.sql',
+    ]
+    for (const f of files) {
+      const sql = readFileSync(resolve(__dirname, '../../migrations/', f), 'utf-8')
+      for (const stmt of sql.split(';').filter((s) => s.trim())) {
+        db.exec(stmt + ';')
+      }
+    }
+    const cols = db.prepare('PRAGMA table_info(arrows)').all() as Array<{
+      name: string
+      dflt_value: string | null
+    }>
+    const bidir = cols.find((c) => c.name === 'bidirectional')
+    expect(bidir).toBeDefined()
+    expect(bidir?.dflt_value).toBe('0')
+
+    // 既存 INSERT が動くこと（DEFAULT 0 で挿入される）
+    db.prepare(
+      "INSERT INTO users (id, email, password_hash, name) VALUES ('u1', 'u1@test.com', 'h', 'U')",
+    ).run()
+    db.prepare("INSERT INTO flows (id, user_id) VALUES ('f1', 'u1')").run()
+    db.prepare(
+      "INSERT INTO lanes (id, flow_id, name, position) VALUES ('l1', 'f1', 'L', 0)",
+    ).run()
+    db.prepare(
+      "INSERT INTO nodes (id, flow_id, lane_id, row_index, order_index) VALUES ('n1', 'f1', 'l1', 0, 0)",
+    ).run()
+    db.prepare(
+      "INSERT INTO nodes (id, flow_id, lane_id, row_index, order_index) VALUES ('n2', 'f1', 'l1', 1, 1)",
+    ).run()
+    db.prepare(
+      "INSERT INTO arrows (id, flow_id, from_node_id, to_node_id) VALUES ('a1', 'f1', 'n1', 'n2')",
+    ).run()
+    const row = db.prepare("SELECT bidirectional FROM arrows WHERE id = 'a1'").get() as {
+      bidirectional: number
+    }
+    expect(row.bidirectional).toBe(0)
+    db.close()
+  })
+```
+
+- [ ] **Step 2: テスト失敗を確認**
+
+```bash
+npm test -- tests/db/migration.test.ts
+```
+
+期待: 「ENOENT: ...0011_arrow_bidirectional.sql」または該当 it が FAIL。
+
+- [ ] **Step 3: マイグレーション SQL を作成**
+
+`migrations/0011_arrow_bidirectional.sql`:
+
+```sql
+-- Add bidirectional flag to arrows table
+ALTER TABLE arrows ADD COLUMN bidirectional INTEGER DEFAULT 0;
+```
+
+- [ ] **Step 4: テスト pass を確認**
+
+```bash
+npm test -- tests/db/migration.test.ts
+```
+
+期待: 全 pass。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add migrations/0011_arrow_bidirectional.sql tests/db/migration.test.ts
+git commit -m "feat(#316): add bidirectional column to arrows table"
+```
+
+---
+
+## Task 2: 型定義（InternalArrow / Arrow）
+
+**Files:**
+- Modify: `src/lib/types.ts`
+- Modify: `src/features/editor/types.ts`
+
+このタスクは型追加のみで挙動を変えない。後続タスクのテストで担保される。
+
+- [ ] **Step 1: `InternalArrow` に `bidirectional` を追加**
+
+`src/lib/types.ts` を以下に変更:
+
+```ts
+/** 内部矢印データ（DOM/React非依存） */
+export interface InternalArrow {
+  id: string
+  from: string
+  to: string
+  comment: string
+  color?: string
+  dash?: string
+  bidirectional?: boolean
+}
+
+/** 矢印パス計算結果（DOM/React非依存） */
+export interface ArrowPathResult {
+  d: string
+  mx: number
+  my: number
+}
+```
+
+- [ ] **Step 2: `Arrow` に `bidirectional` を追加**
+
+`src/features/editor/types.ts:94-101` の `Arrow` インターフェースを:
+
+```ts
+export interface Arrow {
+  id: string
+  fromNodeId: string
+  toNodeId: string
+  comment: string | null
+  color?: string | null
+  dash?: string | null
+  bidirectional?: boolean | null
+}
+```
+
+- [ ] **Step 3: 型チェック**
+
+```bash
+npm run typecheck
+```
+
+期待: エラーなし（既存の `InternalArrow` 利用箇所は省略可能フィールド追加なので壊れない）。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/lib/types.ts src/features/editor/types.ts
+git commit -m "feat(#316): add bidirectional field to Arrow types"
+```
+
+---
+
+## Task 3: API バリデータ + 永続化
+
+**Files:**
+- Modify: `api/lib/validators.ts`
+- Modify: `api/lib/flow-transform.ts`
+- Modify: `api/routes/flows.ts:264-280`, `api/routes/flows.ts:423-440`
+- Test: `tests/api/routes/flows.test.ts`
+
+- [ ] **Step 1: 失敗テストを追加**
+
+`tests/api/routes/flows.test.ts` に新しい it を追加（既存の flow CRUD テストの近くに配置）:
+
+```ts
+  it('should round-trip bidirectional arrow flag', async () => {
+    const userId = await createTestUser()
+    const token = await getAuthToken(userId)
+
+    const createRes = await app.request(
+      '/api/flows',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          title: 'Bidir test',
+          themeId: 'cloud',
+          lanes: [{ id: 'l1', name: 'L', colorIndex: 0, position: 0 }],
+          nodes: [
+            { id: 'n1', laneId: 'l1', rowIndex: 0, label: 'A', orderIndex: 0 },
+            { id: 'n2', laneId: 'l1', rowIndex: 1, label: 'B', orderIndex: 1 },
+          ],
+          arrows: [
+            { id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', bidirectional: true },
+            { id: 'a2', fromNodeId: 'n2', toNodeId: 'n1' },
+          ],
+        }),
+      },
+      env,
+    )
+    expect(createRes.status).toBe(201)
+    const { flow } = (await createRes.json()) as { flow: { id: string; arrows: Array<{ id: string; bidirectional?: boolean | null }> } }
+    const a1 = flow.arrows.find((a) => a.id === 'a1')
+    const a2 = flow.arrows.find((a) => a.id === 'a2')
+    expect(a1?.bidirectional).toBe(true)
+    expect(a2?.bidirectional ?? false).toBe(false)
+
+    // GET でも同じ値が返ること
+    const getRes = await app.request(
+      `/api/flows/${flow.id}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+      env,
+    )
+    expect(getRes.status).toBe(200)
+    const { flow: got } = (await getRes.json()) as { flow: typeof flow }
+    expect(got.arrows.find((a) => a.id === 'a1')?.bidirectional).toBe(true)
+    expect(got.arrows.find((a) => a.id === 'a2')?.bidirectional ?? false).toBe(false)
+  })
+```
+
+注: `createTestUser` / `getAuthToken` / `env` / `app` は既存テストで使われているヘルパ。同ファイル内の既存テストの構造をそのまま流用すること。
+
+- [ ] **Step 2: テスト失敗を確認**
+
+```bash
+npm test -- tests/api/routes/flows.test.ts
+```
+
+期待: `a1.bidirectional` が undefined のため FAIL。
+
+- [ ] **Step 3: zod schema に `bidirectional` を追加**
+
+`api/lib/validators.ts:25-32` の `arrowSchema` を:
+
+```ts
+const arrowSchema = z.object({
+  id: z.string().min(1),
+  fromNodeId: z.string().min(1),
+  toNodeId: z.string().min(1),
+  comment: z.string().nullable().optional(),
+  color: z.string().nullable().optional(),
+  dash: z.string().nullable().optional(),
+  bidirectional: z.boolean().optional(),
+})
+```
+
+- [ ] **Step 4: `ArrowRow` / `toArrow` に `bidirectional` を追加**
+
+`api/lib/flow-transform.ts:44-54` の `ArrowRow`:
+
+```ts
+export interface ArrowRow {
+  id: string
+  flow_id: string
+  from_node_id: string
+  to_node_id: string
+  comment: string | null
+  color: string | null
+  dash: string | null
+  bidirectional: number | null
+  created_at: string
+  updated_at: string
+}
+```
+
+`api/lib/flow-transform.ts:97-108` の `toArrow`:
+
+```ts
+export function toArrow(row: ArrowRow) {
+  return {
+    id: row.id,
+    fromNodeId: row.from_node_id,
+    toNodeId: row.to_node_id,
+    comment: row.comment,
+    color: row.color,
+    dash: row.dash,
+    bidirectional: row.bidirectional === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+```
+
+- [ ] **Step 5: INSERT 文に `bidirectional` を追加（POST /flows）**
+
+`api/routes/flows.ts:263-280` の arrows INSERT ループを:
+
+```ts
+  // INSERT arrows
+  for (const arrow of arrows) {
+    statements.push(
+      db
+        .prepare(
+          'INSERT INTO arrows (id, flow_id, from_node_id, to_node_id, comment, color, dash, bidirectional) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        )
+        .bind(
+          arrow.id,
+          flowId,
+          arrow.fromNodeId,
+          arrow.toNodeId,
+          arrow.comment ?? null,
+          arrow.color ?? null,
+          arrow.dash ?? null,
+          arrow.bidirectional ? 1 : 0,
+        ),
+    )
+  }
+```
+
+- [ ] **Step 6: INSERT 文に `bidirectional` を追加（PUT /flows/:id）**
+
+`api/routes/flows.ts:423-440` の同形式の INSERT ループも同じ変更を適用:
+
+```ts
+      // INSERT new arrows
+      for (const arrow of safeArrows) {
+        statements.push(
+          db
+            .prepare(
+              'INSERT INTO arrows (id, flow_id, from_node_id, to_node_id, comment, color, dash, bidirectional) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            )
+            .bind(
+              arrow.id,
+              flowId,
+              arrow.fromNodeId,
+              arrow.toNodeId,
+              arrow.comment ?? null,
+              arrow.color ?? null,
+              arrow.dash ?? null,
+              arrow.bidirectional ? 1 : 0,
+            ),
+        )
+      }
+```
+
+- [ ] **Step 7: テスト pass を確認**
+
+```bash
+npm test -- tests/api/routes/flows.test.ts
+```
+
+期待: 新テスト含む全 pass。
+
+- [ ] **Step 8: コミット**
+
+```bash
+git add api/lib/validators.ts api/lib/flow-transform.ts api/routes/flows.ts tests/api/routes/flows.test.ts
+git commit -m "feat(#316): persist bidirectional flag on arrows API"
+```
+
+---
+
+## Task 4: FlowEditor のデータ変換で bidirectional を引き継ぐ
+
+**Files:**
+- Modify: `src/features/editor/FlowEditor.tsx:124-134`, `src/features/editor/FlowEditor.tsx:188-203`
+- Test: `src/features/editor/hooks/useArrows.test.ts`
+
+`useArrows` hook 自体は spread 保持で既に対応されているが、念のためテストで保証する。FlowEditor 側の `flowToInternal` / `internalStateToPayload` も `bidirectional` を引き継ぐ必要がある。
+
+- [ ] **Step 1: useArrows で bidirectional が保持される失敗テストを追加**
+
+`src/features/editor/hooks/useArrows.test.ts` の末尾（既存のテストグループ内）に追加:
+
+```ts
+  it('should preserve bidirectional flag through setArrows', () => {
+    const arrows: InternalArrow[] = [
+      { id: 'a1', from: 'l0_r0', to: 'l0_r1', comment: '', bidirectional: true },
+    ]
+    const { result } = renderHook(() =>
+      useArrows({ ...defaultOptions, initialArrows: arrows }),
+    )
+    expect(result.current.arrows[0].bidirectional).toBe(true)
+    act(() => {
+      result.current.setArrows((p) =>
+        p.map((a) => (a.id === 'a1' ? { ...a, comment: 'updated' } : a)),
+      )
+    })
+    expect(result.current.arrows[0].bidirectional).toBe(true)
+    expect(result.current.arrows[0].comment).toBe('updated')
+  })
+```
+
+注: `defaultOptions` / `renderHook` / `act` / `InternalArrow` インポートは既存テストの形式に合わせる（同ファイルの既存 `it` を参照）。
+
+- [ ] **Step 2: テスト pass を確認（型追加済みなので即 pass のはず）**
+
+```bash
+npm test -- src/features/editor/hooks/useArrows.test.ts
+```
+
+期待: 全 pass。
+
+- [ ] **Step 3: `flowToInternal` で bidirectional を引き継ぐ**
+
+`src/features/editor/FlowEditor.tsx:124-134` の arrows 構築を:
+
+```ts
+  // Build arrows
+  const arrows: InternalArrow[] = flow.arrows
+    .map((a) => {
+      const from = nodeIdToKey[a.fromNodeId]
+      const to = nodeIdToKey[a.toNodeId]
+      if (!from || !to) return null
+      const arr: InternalArrow = { id: a.id, from, to, comment: a.comment ?? '' }
+      if (a.color) arr.color = a.color
+      if (a.dash) arr.dash = a.dash
+      if (a.bidirectional) arr.bidirectional = true
+      return arr
+    })
+    .filter((a): a is InternalArrow => a !== null)
+```
+
+- [ ] **Step 4: `internalStateToPayload` で bidirectional を出力に含める**
+
+`src/features/editor/FlowEditor.tsx:188-203` の apiArrows ビルドを:
+
+```ts
+  // Build API arrows using stable nodeIds
+  const apiArrows = arrows
+    .map((a) => {
+      const fromNodeId = keyToNodeId[a.from]
+      const toNodeId = keyToNodeId[a.to]
+      if (!fromNodeId || !toNodeId) return null
+      return {
+        id: a.id,
+        fromNodeId,
+        toNodeId,
+        comment: a.comment || null,
+        color: a.color || null,
+        dash: a.dash || null,
+        bidirectional: a.bidirectional ?? false,
+      }
+    })
+    .filter((a): a is NonNullable<typeof a> => a !== null)
+```
+
+- [ ] **Step 5: 型チェック + 既存テスト**
+
+```bash
+npm run typecheck
+npm test -- src/features/editor/FlowEditor.test.tsx src/features/editor/hooks/useArrows.test.ts
+```
+
+期待: 全 pass（既存 marker-end 前提テストは無影響）。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/editor/FlowEditor.tsx src/features/editor/hooks/useArrows.test.ts
+git commit -m "feat(#316): propagate bidirectional flag in FlowEditor conversions"
+```
+
+---
+
+## Task 5: SVG 描画 — FlowEditor
+
+**Files:**
+- Modify: `src/features/editor/FlowEditor.tsx:2688-2720`（矢印 `<g>` セクション）
+- Test: `src/features/editor/FlowEditor.test.tsx`
+
+- [ ] **Step 1: 失敗テストを追加**
+
+`src/features/editor/FlowEditor.test.tsx` の末尾近く（既存の matrker-end 検証テスト群の近く）に追加:
+
+```ts
+  it('should render marker-start on bidirectional arrow', () => {
+    const flow: Flow = {
+      ...minimalFlow(),
+      lanes: [{ id: 'l1', name: 'L', colorIndex: 0, position: 0 }],
+      nodes: [
+        { id: 'n1', laneId: 'l1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+        { id: 'n2', laneId: 'l1', rowIndex: 1, label: 'B', note: null, orderIndex: 1 },
+      ],
+      arrows: [
+        { id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: null, bidirectional: true },
+        { id: 'a2', fromNodeId: 'n2', toNodeId: 'n1', comment: null, bidirectional: false },
+      ],
+    }
+    const { container } = render(<FlowEditor flow={flow} {...defaultProps} />)
+    const a1Path = container.querySelector('path[marker-end="url(#m-a1)"]')
+    const a2Path = container.querySelector('path[marker-end="url(#m-a2)"]')
+    expect(a1Path?.getAttribute('marker-start')).toBe('url(#m-start-a1)')
+    expect(a2Path?.getAttribute('marker-start')).toBeNull()
+    // start marker defined in defs
+    expect(container.querySelector('marker#m-start-a1')).toBeTruthy()
+  })
+```
+
+注: `minimalFlow()` / `defaultProps` は同ファイル既存ヘルパ／props セットを流用。`Flow` インポート確認。
+
+- [ ] **Step 2: テスト失敗を確認**
+
+```bash
+npm test -- src/features/editor/FlowEditor.test.tsx -t "marker-start on bidirectional"
+```
+
+期待: FAIL。
+
+- [ ] **Step 3: 描画コードを更新**
+
+`src/features/editor/FlowEditor.tsx:2696-2720` の矢印 `<g>` セクションを:
+
+```tsx
+              return (
+                <g key={`av-${arrow.id}`}>
+                  <defs>
+                    <marker
+                      id={`m-${arrow.id}`}
+                      markerWidth="9"
+                      markerHeight="8"
+                      refX="8"
+                      refY="4"
+                      orient="auto"
+                    >
+                      <polygon
+                        points="0 0.5, 9 4, 0 7.5"
+                        fill={isSel ? arrow.color || T.accent : ac}
+                      />
+                    </marker>
+                    {arrow.bidirectional && (
+                      <marker
+                        id={`m-start-${arrow.id}`}
+                        markerWidth="9"
+                        markerHeight="8"
+                        refX="8"
+                        refY="4"
+                        orient="auto-start-reverse"
+                      >
+                        <polygon
+                          points="0 0.5, 9 4, 0 7.5"
+                          fill={isSel ? arrow.color || T.accent : ac}
+                        />
+                      </marker>
+                    )}
+                  </defs>
+                  <path
+                    d={d}
+                    stroke={isSel ? selC : ac}
+                    strokeWidth={isSel ? 2.5 : 2}
+                    strokeDasharray={dashArr}
+                    fill="none"
+                    markerStart={
+                      arrow.bidirectional ? `url(#m-start-${arrow.id})` : undefined
+                    }
+                    markerEnd={`url(#m-${arrow.id})`}
+                    style={{ pointerEvents: 'none' }}
+                  />
+```
+
+（残りのコメントピル等は既存通り）
+
+- [ ] **Step 4: テスト pass を確認**
+
+```bash
+npm test -- src/features/editor/FlowEditor.test.tsx
+```
+
+期待: 新規 + 既存テスト全 pass（既存は `marker-end` のみチェックなので無影響）。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/editor/FlowEditor.tsx src/features/editor/FlowEditor.test.tsx
+git commit -m "feat(#316): render marker-start for bidirectional arrows in FlowEditor"
+```
+
+---
+
+## Task 6: SVG 描画 — SharedFlowViewer
+
+**Files:**
+- Modify: `src/features/shared/SharedFlowViewer.tsx:495-512`
+- Test: `src/features/shared/SharedFlowViewer.test.tsx`
+
+- [ ] **Step 1: 失敗テストを追加**
+
+`src/features/shared/SharedFlowViewer.test.tsx` の末尾近くに追加（既存の `marker-end` 検証テストを参考に）:
+
+```ts
+  it('should render marker-start on bidirectional arrow in shared view', () => {
+    const flow: Flow = {
+      ...minimalFlow(),
+      lanes: [{ id: 'l1', name: 'L', colorIndex: 0, position: 0 }],
+      nodes: [
+        { id: 'n1', laneId: 'l1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+        { id: 'n2', laneId: 'l1', rowIndex: 1, label: 'B', note: null, orderIndex: 1 },
+      ],
+      arrows: [
+        { id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: null, bidirectional: true },
+      ],
+    }
+    const { container } = render(<SharedFlowViewer flow={flow} />)
+    const path = Array.from(container.querySelectorAll('path')).find((p) =>
+      p.getAttribute('marker-end')?.startsWith('url(#sm-'),
+    )
+    expect(path?.getAttribute('marker-start')).toBe('url(#sm-start-a1)')
+    expect(container.querySelector('marker#sm-start-a1')).toBeTruthy()
+  })
+```
+
+注: `minimalFlow()` は既存ヘルパを参照。
+
+- [ ] **Step 2: テスト失敗を確認**
+
+```bash
+npm test -- src/features/shared/SharedFlowViewer.test.tsx -t "marker-start on bidirectional"
+```
+
+期待: FAIL。
+
+- [ ] **Step 3: 描画コードを更新**
+
+`src/features/shared/SharedFlowViewer.tsx:495-512` 付近の矢印 marker 定義 + path を:
+
+```tsx
+                  <marker
+                    id={`sm-${arrow.id}`}
+                    markerWidth="9"
+                    markerHeight="8"
+                    refX="8"
+                    refY="4"
+                    orient="auto"
+                  >
+                    <polygon points="0 0.5, 9 4, 0 7.5" fill={ac} />
+                  </marker>
+                  {arrow.bidirectional && (
+                    <marker
+                      id={`sm-start-${arrow.id}`}
+                      markerWidth="9"
+                      markerHeight="8"
+                      refX="8"
+                      refY="4"
+                      orient="auto-start-reverse"
+                    >
+                      <polygon points="0 0.5, 9 4, 0 7.5" fill={ac} />
+                    </marker>
+                  )}
+```
+
+そして `path` 要素に `markerStart` 属性を追加:
+
+```tsx
+                  markerStart={
+                    arrow.bidirectional ? `url(#sm-start-${arrow.id})` : undefined
+                  }
+                  markerEnd={`url(#sm-${arrow.id})`}
+```
+
+注: 周辺コードの既存変数名（`ac` など）と既存 `<path>` 属性をそのまま利用すること。SharedFlowViewer.tsx の現コードを Read して、id プレフィックス（`sm-`）と既存属性名を確認の上で編集。
+
+- [ ] **Step 4: テスト pass を確認**
+
+```bash
+npm test -- src/features/shared/SharedFlowViewer.test.tsx
+```
+
+期待: 新規 + 既存全 pass。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/shared/SharedFlowViewer.tsx src/features/shared/SharedFlowViewer.test.tsx
+git commit -m "feat(#316): render marker-start for bidirectional arrows in SharedFlowViewer"
+```
+
+---
+
+## Task 7: RightPanel UI — 「⇄ 双方向」ボタン
+
+**Files:**
+- Modify: `src/features/editor/components/RightPanel.tsx:653-673`
+- Modify: `src/locales/ja/editor.json`, `src/locales/en/editor.json`
+
+- [ ] **Step 1: i18n キーを追加**
+
+`src/locales/ja/editor.json` の `rightPanel` セクション（L51-56 付近）に `arrowBidirectional` を追加:
+
+```json
+    "arrowComment": "コメント",
+    "arrowCommentPlaceholder": "ラベルを追加…",
+    "arrowColor": "線の色",
+    "arrowStyle": "線の種類",
+    "arrowBidirectional": "⇄ 双方向",
+    "arrowReverse": "⇄ 方向を逆転",
+    "arrowDelete": "削除",
+```
+
+`src/locales/en/editor.json` の同セクションに:
+
+```json
+    "arrowComment": "Comment",
+    "arrowCommentPlaceholder": "Add label…",
+    "arrowColor": "Line color",
+    "arrowStyle": "Line style",
+    "arrowBidirectional": "⇄ Bidirectional",
+    "arrowReverse": "⇄ Reverse direction",
+    "arrowDelete": "Delete",
+```
+
+- [ ] **Step 2: RightPanel の操作セクションを変更**
+
+`src/features/editor/components/RightPanel.tsx:653-673` の `<PanelSection label={t('rightPanel.operations')}>` ブロックを:
+
+```tsx
+        <PanelSection label={t('rightPanel.operations')}>
+          <div className={styles.panelActions}>
+            <PanelBtn
+              label={t('rightPanel.arrowBidirectional')}
+              color={T.accent}
+              active={!!selArrowData.bidirectional}
+              onClick={() =>
+                setArrows((p) =>
+                  p.map((a) =>
+                    a.id === selArrow ? { ...a, bidirectional: !a.bidirectional } : a,
+                  ),
+                )
+              }
+            />
+            <PanelBtn
+              label={t('rightPanel.arrowReverse')}
+              color={T.accent}
+              disabled={!!selArrowData.bidirectional}
+              onClick={() =>
+                setArrows((p) =>
+                  p.map((a) => (a.id === selArrow ? { ...a, from: a.to, to: a.from } : a)),
+                )
+              }
+            />
+            <PanelBtn
+              label={t('rightPanel.arrowDelete')}
+              color="#E06060"
+              onClick={() => {
+                setArrows((p) => p.filter((a) => a.id !== selArrow))
+                setSelArrow(null)
+              }}
+            />
+          </div>
+        </PanelSection>
+```
+
+- [ ] **Step 3: PanelBtn が `active`/`disabled` プロパティに対応しているか確認・追加**
+
+`src/features/editor/components/RightPanel.tsx` または `src/features/editor/components/PanelBtn.tsx`（あれば）を Read し、既存の `PanelBtn` コンポーネントが `active?: boolean` と `disabled?: boolean` を受け付けるか確認:
+
+- 受け付けない場合: PanelBtn の Props と JSX を以下のように拡張する:
+
+```tsx
+interface PanelBtnProps {
+  label: string
+  color: string
+  onClick: () => void
+  active?: boolean
+  disabled?: boolean
+}
+
+const PanelBtn = ({ label, color, onClick, active, disabled }: PanelBtnProps) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={disabled}
+    aria-pressed={active}
+    style={{
+      flex: 1,
+      padding: '6px 8px',
+      borderRadius: 6,
+      border: `1px solid ${color}`,
+      background: active ? color : 'transparent',
+      color: active ? '#fff' : color,
+      opacity: disabled ? 0.4 : 1,
+      cursor: disabled ? 'not-allowed' : 'pointer',
+      fontSize: 12,
+      fontWeight: 600,
+    }}
+  >
+    {label}
+  </button>
+)
+```
+
+注: 既存スタイルを尊重すること。色やサイズは現在の PanelBtn 実装に合わせる。Read で既存実装を必ず確認の上、最小差分で `active` と `disabled` を追加する。
+
+- [ ] **Step 4: テスト追加（RightPanel が編集動作を返すこと）**
+
+`src/features/editor/components/RightPanel.test.tsx`（既存があれば）または `FlowEditor.test.tsx` 内に統合テストとして:
+
+```ts
+  it('should toggle bidirectional flag on click', () => {
+    // FlowEditor を arrow 1 つ + 選択状態でレンダリング
+    // 既存テストで arrow 選択をシミュレートしている例を流用
+    const { container, getByText } = renderEditorWithSelectedArrow('a1')
+    const btn = getByText('⇄ 双方向').closest('button')!
+    expect(btn.getAttribute('aria-pressed')).toBe('false')
+    fireEvent.click(btn)
+    expect(btn.getAttribute('aria-pressed')).toBe('true')
+    // 双方向ON時、方向逆転ボタンが disabled
+    const reverseBtn = getByText('⇄ 方向を逆転').closest('button')!
+    expect(reverseBtn).toBeDisabled()
+  })
+```
+
+注: `renderEditorWithSelectedArrow` は既存テストの選択シミュレーション手順を関数化。同等の処理を `FlowEditor.test.tsx` から探して再利用すること。既存テストファイルにヘルパが無ければ、選択状態を作る既存テストの手順をインライン化。
+
+- [ ] **Step 5: テスト pass を確認**
+
+```bash
+npm test
+```
+
+期待: 全 pass。FAIL があれば原因調査して修正。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/editor/components/RightPanel.tsx src/locales/ja/editor.json src/locales/en/editor.json src/features/editor/FlowEditor.test.tsx
+git commit -m "feat(#316): add bidirectional toggle button to RightPanel"
+```
+
+---
+
+## Task 8: Mermaid 出力で双方向対応
+
+**Files:**
+- Modify: `src/features/editor/FlowEditor.tsx:1488-1492` 付近
+- Test: `src/features/editor/FlowEditor.test.tsx`
+
+- [ ] **Step 1: 失敗テストを追加**
+
+`src/features/editor/FlowEditor.test.tsx` の Mermaid 出力テスト群（既存の Mermaid 関連テストを検索して追加）:
+
+```ts
+  it('should output <--> for bidirectional arrows in Mermaid', () => {
+    const flow: Flow = {
+      ...minimalFlow(),
+      lanes: [{ id: 'l1', name: 'L', colorIndex: 0, position: 0 }],
+      nodes: [
+        { id: 'n1', laneId: 'l1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+        { id: 'n2', laneId: 'l1', rowIndex: 1, label: 'B', note: null, orderIndex: 1 },
+      ],
+      arrows: [
+        { id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: null, bidirectional: true },
+        { id: 'a2', fromNodeId: 'n2', toNodeId: 'n1', comment: 'note', bidirectional: true },
+      ],
+    }
+    const mermaid = buildMermaid(flow)  // または FlowEditor 経由
+    expect(mermaid).toContain('<-->')
+    expect(mermaid).toMatch(/<-->\|note\|/)
+  })
+```
+
+注: Mermaid は FlowEditor 内のロジックなので、既存 Mermaid テストの呼び出し方法（モーダル経由 or 関数 export）を確認して合わせる。`buildMermaid` のような export 関数が無ければ、既存テストパターン通りボタンクリックでクリップボード書込をスパイする方式を採用。
+
+- [ ] **Step 2: テスト失敗を確認**
+
+```bash
+npm test -- src/features/editor/FlowEditor.test.tsx -t "Mermaid"
+```
+
+期待: FAIL（双方向時も `-->` のため）。
+
+- [ ] **Step 3: Mermaid 生成ロジックを更新**
+
+`src/features/editor/FlowEditor.tsx:1488-1492` 付近を:
+
+```ts
+      if (!fromId || !toId) return
+      const arrowOp = a.bidirectional ? '<-->' : '-->'
+      if (a.comment) {
+        m += `    ${fromId} ${arrowOp}|${esc(a.comment)}| ${toId}\n`
+      } else {
+        m += `    ${fromId} ${arrowOp} ${toId}\n`
+      }
+```
+
+注: `m += ...` のインデントは既存コードに合わせる。Read で当該箇所を確認の上で編集。
+
+- [ ] **Step 4: テスト pass を確認**
+
+```bash
+npm test -- src/features/editor/FlowEditor.test.tsx
+```
+
+期待: 全 pass。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/editor/FlowEditor.tsx src/features/editor/FlowEditor.test.tsx
+git commit -m "feat(#316): emit Mermaid <--> for bidirectional arrows"
+```
+
+---
+
+## Task 9: 全体テスト + Lint
+
+**Files:** （実行のみ）
+
+- [ ] **Step 1: 全テスト実行**
+
+```bash
+npm test
+```
+
+期待: 全 pass。FAIL があれば全て修正してから次へ。
+
+- [ ] **Step 2: 型チェック + Lint**
+
+```bash
+npm run typecheck
+npm run lint
+```
+
+期待: エラーなし。
+
+- [ ] **Step 3: 修正があればコミット**
+
+```bash
+git add -A
+git diff --staged --quiet || git commit -m "chore(#316): fix type/lint issues"
+```
+
+---
+
+## Task 10: 実画面検証（Playwright / chrome-devtools）
+
+**Files:** （目視検証 + スクリーンショット）
+
+- [ ] **Step 1: 開発サーバー起動**
+
+```bash
+npm run dev
+```
+
+別タブで継続実行。
+
+- [ ] **Step 2: ログインしてエディタを開く**
+
+`.env.local` の `E2E_USER_EMAIL` / `E2E_USER_PASSWORD` を使用。
+
+- [ ] **Step 3: 矢印を選択し「⇄ 双方向」をクリック**
+
+操作:
+1. 既存または新規フローを開く
+2. 矢印を 1 本クリック → RightPanel に「⇄ 双方向」ボタンが表示されることを確認
+3. クリック → 矢印の両端に矢じりが付くことを確認
+4. 「⇄ 方向を逆転」ボタンが disabled になっていることを確認
+5. 再度「⇄ 双方向」をクリック → 片方向に戻ることを確認
+
+スクリーンショット保存先: `.screenshots/arrow-bidirectional-{toggle-on,toggle-off}.png`
+
+- [ ] **Step 4: 保存 → リロードで状態維持を確認**
+
+1. 双方向ON状態でしばらく待ち（autosave 確認）
+2. ページリロード
+3. 矢印が双方向のまま表示されることを確認
+
+- [ ] **Step 5: 共有ビューでも確認**
+
+1. 共有 URL を取得（既存の共有機能を使用）
+2. 別ウィンドウで共有 URL を開く
+3. 双方向矢印が両端矢じりで表示されることを確認
+
+- [ ] **Step 6: PNG エクスポート確認**
+
+1. PNG エクスポート機能を実行
+2. 出力 PNG を開いて両端矢じりが描画されていることを確認
+
+- [ ] **Step 7: LCP 1秒以内確認**
+
+chrome-devtools の Performance タブで Largest Contentful Paint を計測。1秒超えていれば実装を見直し。
+
+- [ ] **Step 8: 開発サーバー停止**
+
+```bash
+# 起動した dev サーバーを停止
+```
+
+問題なければ次へ。問題があれば該当タスクに戻って修正。
+
+---
+
+## Task 11: main 同期 + push + PR
+
+**Files:** （Git 操作のみ）
+
+- [ ] **Step 1: main 最新化 + rebase**
+
+```bash
+git pull origin main --rebase
+npm test
+```
+
+全 pass 必須。
+
+- [ ] **Step 2: push**
+
+```bash
+git push -u origin feat/arrow-bidirectional-316
+```
+
+- [ ] **Step 3: PR 作成**
+
+```bash
+gh pr create --title "feat(#316): 矢印を双方向（両端矢じり）にできるようにする" --body "$(cat <<'EOF'
+## Summary
+- 矢印に `bidirectional` フラグを追加（DB / API / UI / Mermaid 出力）
+- RightPanel の操作セクションに「⇄ 双方向」ボタン追加。ON 時は「⇄ 方向を逆転」を disabled
+- SVG `<path>` に `markerStart` を条件付きで追加し両端に矢じりを描画
+- Closes #316
+
+## Test plan
+- [x] DB マイグレーション 0011 のスキーマテスト
+- [x] API round-trip テスト（POST → GET）
+- [x] FlowEditor / SharedFlowViewer の `marker-start` 描画テスト
+- [x] RightPanel のトグル + reverse disabled テスト
+- [x] Mermaid `<-->` 出力テスト
+- [x] 実画面で双方向切替・保存・リロード・共有ビュー・PNG エクスポート・LCP 確認
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: CI 監視**
+
+```bash
+gh pr checks --watch
+```
+
+FAIL があれば修正 → push → 再 watch。
+
+- [ ] **Step 5: 本番ビルド確認**
+
+`~/.claude/skills/preview/SKILL.md` の手順に従って実行。
+
+- [ ] **Step 6: レビュー依頼コメント**
+
+```bash
+gh pr comment --body '@claude PRをレビューして。
+以下の観点で確認すること：
+- バグ・ロジックの問題
+- コードの重複・共通化できる処理
+- 不要な複雑さ
+結果は最終行に [A:要修正] [B:条件つき承認] [C:承認OK] のいずれかで明記。'
+```
+
+- [ ] **Step 7: レビュー修正ループ**
+
+CLAUDE.md 「9. レビュー修正ループ」の手順に従う。
+
+- [ ] **Step 8: Merge & デプロイ確認**
+
+CLAUDE.md 「10. Merge & Deploy Verification」の手順に従う。
+
+- [ ] **Step 9: Worktree クリーンアップ**
+
+```bash
+cd "$MAIN"
+git worktree remove .worktrees/feat-arrow-bidirectional-316
+git branch -d feat/arrow-bidirectional-316
+git worktree list
+```
+
+---
+
+## 完了条件（受け入れ条件）
+
+- [ ] エディタで矢印を双方向にできる（実画面確認済み）
+- [ ] 共有ビューでも双方向で表示される
+- [ ] DB 保存・復元が正しく動く
+- [ ] PNG エクスポートに両端の矢じりが反映される
+- [ ] 既存の片方向矢印・既存データに影響がない
+- [ ] LCP 1 秒以内
+- [ ] CI 全 pass
+- [ ] PR が `[C:承認OK]` を取得
+- [ ] main にマージされ、本番デプロイ確認済み

--- a/migrations/0011_arrow_bidirectional.sql
+++ b/migrations/0011_arrow_bidirectional.sql
@@ -1,0 +1,2 @@
+-- Add bidirectional flag to arrows table
+ALTER TABLE arrows ADD COLUMN bidirectional INTEGER DEFAULT 0;

--- a/src/features/editor/FlowEditor.test.tsx
+++ b/src/features/editor/FlowEditor.test.tsx
@@ -1976,6 +1976,36 @@ describe('Mermaid flowchart TD export (#mermaid)', () => {
     expect(screen.getByText('rightPanel.mermaidCopy')).toBeInTheDocument()
     expect(screen.queryByText('rightPanel.mermaidCopied')).not.toBeInTheDocument()
   })
+
+  it('exportMermaid should emit <--> for bidirectional arrows', async () => {
+    const writeTextSpy = setupClipboardMock()
+    const flow: Flow = {
+      ...createMinimalFlow(),
+      lanes: [{ id: 'lane-1', name: 'L', colorIndex: 0, position: 0 }],
+      nodes: [
+        { id: 'n1', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+        { id: 'n2', laneId: 'lane-1', rowIndex: 1, label: 'B', note: null, orderIndex: 1 },
+        { id: 'n3', laneId: 'lane-1', rowIndex: 2, label: 'C', note: null, orderIndex: 2 },
+      ],
+      arrows: [
+        { id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: null, bidirectional: true },
+        { id: 'a2', fromNodeId: 'n2', toNodeId: 'n3', comment: 'sync', bidirectional: true },
+        { id: 'a3', fromNodeId: 'n1', toNodeId: 'n3', comment: null, bidirectional: false },
+      ],
+    }
+    render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+    const mermaid = await clickMermaidCopyButton(writeTextSpy)
+    // Bidirectional, no comment
+    expect(mermaid).toMatch(/n\d+ <--> n\d+/)
+    // Bidirectional, with comment
+    expect(mermaid).toMatch(/n\d+ <-->\|sync\| n\d+/)
+    // One-way still uses -->
+    expect(mermaid).toMatch(/n\d+ --> n\d+/)
+    // Make sure we don't emit the old --> for the bidirectional ones
+    const a1Match = mermaid.match(/n\d+ (?:<-->|-->)(?:\|[^|]*\|)?\s*n\d+/g) || []
+    const arrows = a1Match.filter((s) => s.includes('<-->')).length
+    expect(arrows).toBeGreaterThanOrEqual(2) // a1 and a2 are bidirectional
+  })
 })
 
 describe('auto-connect by flow position (#182)', () => {

--- a/src/features/editor/FlowEditor.test.tsx
+++ b/src/features/editor/FlowEditor.test.tsx
@@ -195,6 +195,27 @@ describe('visual constants (#44, #45)', () => {
     )
     expect(commentLabel).toBeTruthy()
   })
+
+  it('should render marker-start on bidirectional arrow', () => {
+    const flow = createMinimalFlow()
+    flow.nodes = [
+      { id: 'n1', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+      { id: 'n2', laneId: 'lane-1', rowIndex: 1, label: 'B', note: null, orderIndex: 1 },
+    ]
+    flow.arrows = [
+      { id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: null, bidirectional: true },
+      { id: 'a2', fromNodeId: 'n2', toNodeId: 'n1', comment: null, bidirectional: false },
+    ]
+    const { container } = render(
+      <FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />,
+    )
+    const a1Path = container.querySelector('path[marker-end="url(#m-a1)"]')
+    const a2Path = container.querySelector('path[marker-end="url(#m-a2)"]')
+    expect(a1Path?.getAttribute('marker-start')).toBe('url(#m-start-a1)')
+    expect(a2Path?.getAttribute('marker-start')).toBeNull()
+    expect(container.querySelector('marker#m-start-a1')).toBeTruthy()
+    expect(container.querySelector('marker#m-start-a2')).toBeNull()
+  })
 })
 
 describe('floating arrow controls (#46)', () => {

--- a/src/features/editor/FlowEditor.test.tsx
+++ b/src/features/editor/FlowEditor.test.tsx
@@ -206,9 +206,7 @@ describe('visual constants (#44, #45)', () => {
       { id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: null, bidirectional: true },
       { id: 'a2', fromNodeId: 'n2', toNodeId: 'n1', comment: null, bidirectional: false },
     ]
-    const { container } = render(
-      <FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />,
-    )
+    const { container } = render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
     const a1Path = container.querySelector('path[marker-end="url(#m-a1)"]')
     const a2Path = container.querySelector('path[marker-end="url(#m-a2)"]')
     expect(a1Path?.getAttribute('marker-start')).toBe('url(#m-start-a1)')

--- a/src/features/editor/FlowEditor.test.tsx
+++ b/src/features/editor/FlowEditor.test.tsx
@@ -3050,3 +3050,54 @@ describe('PNG export (#310)', () => {
     }
   })
 })
+
+describe('bidirectional arrow toggle (RightPanel)', () => {
+  const flowWithArrow = (): Flow => ({
+    id: 'f1',
+    title: 'T',
+    themeId: 'cloud',
+    shareToken: null,
+    projectId: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    lanes: [{ id: 'lane-1', name: 'L', colorIndex: 0, position: 0 }],
+    nodes: [
+      { id: 'n1', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+      { id: 'n2', laneId: 'lane-1', rowIndex: 1, label: 'B', note: null, orderIndex: 1 },
+    ],
+    arrows: [{ id: 'a1', fromNodeId: 'n1', toNodeId: 'n2', comment: null }],
+  })
+
+  it('should toggle bidirectional flag on click and disable reverse button', () => {
+    const { container } = render(
+      <FlowEditor flow={flowWithArrow()} onSave={vi.fn()} saveStatus="saved" />,
+    )
+    // Select the arrow first
+    const arrowHit = container.querySelector('path[pointer-events="stroke"][stroke-width="20"]')
+    expect(arrowHit).toBeTruthy()
+    fireEvent.click(arrowHit!)
+
+    // Find buttons by their label text (i18n in tests returns the key as-is)
+    const buttons = Array.from(container.querySelectorAll('button')) as HTMLButtonElement[]
+    const bidirBtn = buttons.find((b) => b.textContent?.includes('rightPanel.arrowBidirectional'))
+    const reverseBtn = buttons.find((b) => b.textContent?.includes('rightPanel.arrowReverse'))
+    expect(bidirBtn).toBeTruthy()
+    expect(reverseBtn).toBeTruthy()
+    expect(bidirBtn!.getAttribute('aria-pressed')).toBe('false')
+    expect(reverseBtn!.disabled).toBe(false)
+
+    // Toggle on
+    fireEvent.click(bidirBtn!)
+
+    // Re-query (component may re-render)
+    const buttonsAfter = Array.from(container.querySelectorAll('button')) as HTMLButtonElement[]
+    const bidirBtnAfter = buttonsAfter.find((b) =>
+      b.textContent?.includes('rightPanel.arrowBidirectional'),
+    )
+    const reverseBtnAfter = buttonsAfter.find((b) =>
+      b.textContent?.includes('rightPanel.arrowReverse'),
+    )
+    expect(bidirBtnAfter!.getAttribute('aria-pressed')).toBe('true')
+    expect(reverseBtnAfter!.disabled).toBe(true)
+  })
+})

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -2732,6 +2732,21 @@ export default function FlowEditor({
                         fill={isSel ? arrow.color || T.accent : ac}
                       />
                     </marker>
+                    {arrow.bidirectional && (
+                      <marker
+                        id={`m-start-${arrow.id}`}
+                        markerWidth="9"
+                        markerHeight="8"
+                        refX="8"
+                        refY="4"
+                        orient="auto-start-reverse"
+                      >
+                        <polygon
+                          points="0 0.5, 9 4, 0 7.5"
+                          fill={isSel ? arrow.color || T.accent : ac}
+                        />
+                      </marker>
+                    )}
                   </defs>
                   <path
                     d={d}
@@ -2739,6 +2754,9 @@ export default function FlowEditor({
                     strokeWidth={isSel ? 2.5 : 2}
                     strokeDasharray={dashArr}
                     fill="none"
+                    markerStart={
+                      arrow.bidirectional ? `url(#m-start-${arrow.id})` : undefined
+                    }
                     markerEnd={`url(#m-${arrow.id})`}
                     style={{ pointerEvents: 'none' }}
                   />

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -130,6 +130,7 @@ function flowToInternalState(flow: Flow): {
       const arr: InternalArrow = { id: a.id, from, to, comment: a.comment ?? '' }
       if (a.color) arr.color = a.color
       if (a.dash) arr.dash = a.dash
+      if (a.bidirectional) arr.bidirectional = true
       return arr
     })
     .filter((a): a is InternalArrow => a !== null)
@@ -199,6 +200,7 @@ function internalStateToPayload(
         comment: a.comment || null,
         color: a.color || null,
         dash: a.dash || null,
+        bidirectional: a.bidirectional ?? false,
       }
     })
     .filter((a): a is NonNullable<typeof a> => a !== null)

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -2755,9 +2755,7 @@ export default function FlowEditor({
                     strokeWidth={isSel ? 2.5 : 2}
                     strokeDasharray={dashArr}
                     fill="none"
-                    markerStart={
-                      arrow.bidirectional ? `url(#m-start-${arrow.id})` : undefined
-                    }
+                    markerStart={arrow.bidirectional ? `url(#m-start-${arrow.id})` : undefined}
                     markerEnd={`url(#m-${arrow.id})`}
                     style={{ pointerEvents: 'none' }}
                   />

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -1484,10 +1484,11 @@ export default function FlowEditor({
       const fromId = nodeIdMap.get(a.from)
       const toId = nodeIdMap.get(a.to)
       if (!fromId || !toId) return
+      const arrowOp = a.bidirectional ? '<-->' : '-->'
       if (a.comment) {
-        m += `    ${fromId} -->|${esc(a.comment)}| ${toId}\n`
+        m += `    ${fromId} ${arrowOp}|${esc(a.comment)}| ${toId}\n`
       } else {
-        m += `    ${fromId} --> ${toId}\n`
+        m += `    ${fromId} ${arrowOp} ${toId}\n`
       }
     })
 

--- a/src/features/editor/components/PanelParts.tsx
+++ b/src/features/editor/components/PanelParts.tsx
@@ -66,6 +66,7 @@ export const PanelBtn = ({
   onClick,
   full,
   disabled,
+  active,
 }: {
   label: string
   color: string
@@ -73,15 +74,17 @@ export const PanelBtn = ({
   onClick: () => void
   full?: boolean
   disabled?: boolean
+  active?: boolean
 }) => (
   <button
     onClick={onClick}
     disabled={disabled}
+    aria-pressed={active}
     className={`${styles.panelBtn} ${full ? styles.panelBtnFull : styles.panelBtnAuto}`}
     style={{
       border: `1px solid ${color}30`,
-      background: bg || `${color}10`,
-      color,
+      background: active ? color : bg || `${color}10`,
+      color: active ? '#fff' : color,
       opacity: disabled ? 0.5 : 1,
       cursor: disabled ? 'not-allowed' : 'pointer',
     }}

--- a/src/features/editor/components/RightPanel.tsx
+++ b/src/features/editor/components/RightPanel.tsx
@@ -658,9 +658,7 @@ export const RightPanel = ({
               active={!!selArrowData.bidirectional}
               onClick={() =>
                 setArrows((p) =>
-                  p.map((a) =>
-                    a.id === selArrow ? { ...a, bidirectional: !a.bidirectional } : a,
-                  ),
+                  p.map((a) => (a.id === selArrow ? { ...a, bidirectional: !a.bidirectional } : a)),
                 )
               }
             />

--- a/src/features/editor/components/RightPanel.tsx
+++ b/src/features/editor/components/RightPanel.tsx
@@ -653,8 +653,21 @@ export const RightPanel = ({
         <PanelSection label={t('rightPanel.operations')}>
           <div className={styles.panelActions}>
             <PanelBtn
+              label={t('rightPanel.arrowBidirectional')}
+              color={T.accent}
+              active={!!selArrowData.bidirectional}
+              onClick={() =>
+                setArrows((p) =>
+                  p.map((a) =>
+                    a.id === selArrow ? { ...a, bidirectional: !a.bidirectional } : a,
+                  ),
+                )
+              }
+            />
+            <PanelBtn
               label={t('rightPanel.arrowReverse')}
               color={T.accent}
+              disabled={!!selArrowData.bidirectional}
               onClick={() =>
                 setArrows((p) =>
                   p.map((a) => (a.id === selArrow ? { ...a, from: a.to, to: a.from } : a)),

--- a/src/features/editor/hooks/useArrows.test.ts
+++ b/src/features/editor/hooks/useArrows.test.ts
@@ -429,9 +429,7 @@ describe('useArrows', () => {
     const arrows: InternalArrow[] = [
       { id: 'a1', from: 'x', to: 'y', comment: '', bidirectional: true },
     ]
-    const { result } = renderHook(() =>
-      useArrows({ ...defaultOptions(), initialArrows: arrows }),
-    )
+    const { result } = renderHook(() => useArrows({ ...defaultOptions(), initialArrows: arrows }))
     expect(result.current.arrows[0].bidirectional).toBe(true)
     act(() => {
       result.current.setArrows((p) =>

--- a/src/features/editor/hooks/useArrows.test.ts
+++ b/src/features/editor/hooks/useArrows.test.ts
@@ -424,4 +424,21 @@ describe('useArrows', () => {
       expect(addConfirmToast).not.toHaveBeenCalled()
     })
   })
+
+  it('should preserve bidirectional flag through setArrows', () => {
+    const arrows: InternalArrow[] = [
+      { id: 'a1', from: 'x', to: 'y', comment: '', bidirectional: true },
+    ]
+    const { result } = renderHook(() =>
+      useArrows({ ...defaultOptions(), initialArrows: arrows }),
+    )
+    expect(result.current.arrows[0].bidirectional).toBe(true)
+    act(() => {
+      result.current.setArrows((p) =>
+        p.map((a) => (a.id === 'a1' ? { ...a, comment: 'updated' } : a)),
+      )
+    })
+    expect(result.current.arrows[0].bidirectional).toBe(true)
+    expect(result.current.arrows[0].comment).toBe('updated')
+  })
 })

--- a/src/features/editor/types.ts
+++ b/src/features/editor/types.ts
@@ -98,7 +98,7 @@ export interface Arrow {
   comment: string | null
   color?: string | null
   dash?: string | null
-  bidirectional?: boolean | null
+  bidirectional?: boolean
 }
 
 export interface Flow {

--- a/src/features/editor/types.ts
+++ b/src/features/editor/types.ts
@@ -98,6 +98,7 @@ export interface Arrow {
   comment: string | null
   color?: string | null
   dash?: string | null
+  bidirectional?: boolean | null
 }
 
 export interface Flow {

--- a/src/features/shared/SharedFlowViewer.test.tsx
+++ b/src/features/shared/SharedFlowViewer.test.tsx
@@ -479,4 +479,55 @@ describe('SharedFlowViewer', () => {
     const segmentCount = d.match(/[ML]/g)?.length ?? 0
     expect(segmentCount).toBe(2)
   })
+
+  it('should render marker-start on bidirectional arrow', () => {
+    const flow = {
+      ...mockFlow,
+      lanes: [
+        { id: 'lane-1', name: 'Lane 1', colorIndex: 0, position: 0 },
+        { id: 'lane-2', name: 'Lane 2', colorIndex: 1, position: 1 },
+      ],
+      nodes: [
+        { id: 'node-a', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+        { id: 'node-b', laneId: 'lane-2', rowIndex: 0, label: 'B', note: null, orderIndex: 1 },
+      ],
+      arrows: [
+        {
+          id: 'arrow-1',
+          fromNodeId: 'node-a',
+          toNodeId: 'node-b',
+          comment: null,
+          bidirectional: true,
+        },
+      ],
+    }
+    render(<SharedFlowViewer flow={flow} />)
+    const path = Array.from(document.querySelectorAll('path')).find((p) =>
+      p.getAttribute('marker-end')?.startsWith('url(#sm-'),
+    )
+    expect(path).toBeTruthy()
+    expect(path?.getAttribute('marker-start')).toBe('url(#sm-start-arrow-1)')
+    expect(document.querySelector('marker#sm-start-arrow-1')).toBeTruthy()
+  })
+
+  it('should not render marker-start on regular (one-way) arrow', () => {
+    const flow = {
+      ...mockFlow,
+      lanes: [
+        { id: 'lane-1', name: 'Lane 1', colorIndex: 0, position: 0 },
+        { id: 'lane-2', name: 'Lane 2', colorIndex: 1, position: 1 },
+      ],
+      nodes: [
+        { id: 'node-a', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+        { id: 'node-b', laneId: 'lane-2', rowIndex: 0, label: 'B', note: null, orderIndex: 1 },
+      ],
+      arrows: [{ id: 'arrow-1', fromNodeId: 'node-a', toNodeId: 'node-b', comment: null }],
+    }
+    render(<SharedFlowViewer flow={flow} />)
+    const path = Array.from(document.querySelectorAll('path')).find((p) =>
+      p.getAttribute('marker-end')?.startsWith('url(#sm-'),
+    )
+    expect(path?.getAttribute('marker-start')).toBeNull()
+    expect(document.querySelector('marker#sm-start-arrow-1')).toBeNull()
+  })
 })

--- a/src/features/shared/SharedFlowViewer.tsx
+++ b/src/features/shared/SharedFlowViewer.tsx
@@ -499,6 +499,18 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
                   >
                     <polygon points="0 0.5, 9 4, 0 7.5" fill={ac} />
                   </marker>
+                  {arrow.bidirectional && (
+                    <marker
+                      id={`sm-start-${arrow.id}`}
+                      markerWidth="9"
+                      markerHeight="8"
+                      refX="8"
+                      refY="4"
+                      orient="auto-start-reverse"
+                    >
+                      <polygon points="0 0.5, 9 4, 0 7.5" fill={ac} />
+                    </marker>
+                  )}
                 </defs>
                 <path
                   d={d}
@@ -506,6 +518,9 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
                   strokeWidth={2}
                   strokeDasharray={dashArr}
                   fill="none"
+                  markerStart={
+                    arrow.bidirectional ? `url(#sm-start-${arrow.id})` : undefined
+                  }
                   markerEnd={`url(#sm-${arrow.id})`}
                 />
                 {arrow.comment && (

--- a/src/features/shared/SharedFlowViewer.tsx
+++ b/src/features/shared/SharedFlowViewer.tsx
@@ -518,9 +518,7 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
                   strokeWidth={2}
                   strokeDasharray={dashArr}
                   fill="none"
-                  markerStart={
-                    arrow.bidirectional ? `url(#sm-start-${arrow.id})` : undefined
-                  }
+                  markerStart={arrow.bidirectional ? `url(#sm-start-${arrow.id})` : undefined}
                   markerEnd={`url(#sm-${arrow.id})`}
                 />
                 {arrow.comment && (

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,7 @@ export interface InternalArrow {
   comment: string
   color?: string
   dash?: string
+  bidirectional?: boolean
 }
 
 /** 矢印パス計算結果（DOM/React非依存） */

--- a/src/locales/en/editor.json
+++ b/src/locales/en/editor.json
@@ -52,6 +52,7 @@
     "arrowCommentPlaceholder": "Add label…",
     "arrowColor": "Line color",
     "arrowStyle": "Line style",
+    "arrowBidirectional": "⇄ Bidirectional",
     "arrowReverse": "⇄ Reverse direction",
     "arrowDelete": "Delete",
     "theme": "Theme",

--- a/src/locales/ja/editor.json
+++ b/src/locales/ja/editor.json
@@ -52,6 +52,7 @@
     "arrowCommentPlaceholder": "ラベルを追加…",
     "arrowColor": "線の色",
     "arrowStyle": "線の種類",
+    "arrowBidirectional": "⇄ 双方向",
     "arrowReverse": "⇄ 方向を逆転",
     "arrowDelete": "削除",
     "theme": "テーマ",

--- a/tests/api/routes/flows.test.ts
+++ b/tests/api/routes/flows.test.ts
@@ -519,6 +519,44 @@ describe('Flows API', () => {
       expect(getBody.flow.nodes[0].bg).toBe('#EEF5FF')
       expect(getBody.flow.arrows[0].color).toBe('#E06060')
     })
+
+    it('should round-trip bidirectional arrow flag', async () => {
+      const payload = {
+        title: 'Bidir Flow',
+        themeId: 'cloud',
+        lanes: [{ id: 'lane-1', name: 'L', colorIndex: 0, position: 0 }],
+        nodes: [
+          { id: 'node-1', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+          { id: 'node-2', laneId: 'lane-1', rowIndex: 1, label: 'B', note: null, orderIndex: 1 },
+        ],
+        arrows: [
+          {
+            id: 'arrow-1',
+            fromNodeId: 'node-1',
+            toNodeId: 'node-2',
+            comment: null,
+            bidirectional: true,
+          },
+          { id: 'arrow-2', fromNodeId: 'node-2', toNodeId: 'node-1', comment: null },
+        ],
+      }
+      const createRes = await postJson('/api/flows', payload, env, cookie)
+      expect(createRes.status).toBe(201)
+      const created = (await createRes.json()) as {
+        flow: { id: string; arrows: Array<{ id: string; bidirectional?: boolean | null }> }
+      }
+      const a1 = created.flow.arrows.find((a) => a.id === 'arrow-1')
+      const a2 = created.flow.arrows.find((a) => a.id === 'arrow-2')
+      expect(a1?.bidirectional).toBe(true)
+      expect(a2?.bidirectional ?? false).toBe(false)
+
+      // GET should return the same value
+      const getRes = await getWithCookie(`/api/flows/${created.flow.id}`, env, cookie)
+      expect(getRes.status).toBe(200)
+      const got = (await getRes.json()) as typeof created
+      expect(got.flow.arrows.find((a) => a.id === 'arrow-1')?.bidirectional).toBe(true)
+      expect(got.flow.arrows.find((a) => a.id === 'arrow-2')?.bidirectional ?? false).toBe(false)
+    })
   })
 
   // ========================================

--- a/tests/db/migration.test.ts
+++ b/tests/db/migration.test.ts
@@ -196,6 +196,59 @@ describe('D1 Migration', () => {
     db.close()
   })
 
+  it('should add bidirectional column to arrows (0011)', () => {
+    const db = new Database(':memory:')
+    db.pragma('foreign_keys = ON')
+    const files = [
+      '0001_initial.sql',
+      '0002_node_arrow_styles.sql',
+      '0003_user_settings.sql',
+      '0004_email_verification.sql',
+      '0005_soft_delete.sql',
+      '0006_ai_admin.sql',
+      '0007_node_shape.sql',
+      '0008_projects.sql',
+      '0009_invitation_codes.sql',
+      '0010_project_members.sql',
+      '0011_arrow_bidirectional.sql',
+    ]
+    for (const f of files) {
+      const sql = readFileSync(resolve(__dirname, '../../migrations/', f), 'utf-8')
+      for (const stmt of sql.split(';').filter((s) => s.trim())) {
+        db.exec(stmt + ';')
+      }
+    }
+    const cols = db.prepare('PRAGMA table_info(arrows)').all() as Array<{
+      name: string
+      dflt_value: string | null
+    }>
+    const bidir = cols.find((c) => c.name === 'bidirectional')
+    expect(bidir).toBeDefined()
+    expect(bidir?.dflt_value).toBe('0')
+
+    db.prepare(
+      "INSERT INTO users (id, email, password_hash, name) VALUES ('u1', 'u1@test.com', 'h', 'U')",
+    ).run()
+    db.prepare("INSERT INTO flows (id, user_id) VALUES ('f1', 'u1')").run()
+    db.prepare(
+      "INSERT INTO lanes (id, flow_id, name, position) VALUES ('l1', 'f1', 'L', 0)",
+    ).run()
+    db.prepare(
+      "INSERT INTO nodes (id, flow_id, lane_id, row_index, order_index) VALUES ('n1', 'f1', 'l1', 0, 0)",
+    ).run()
+    db.prepare(
+      "INSERT INTO nodes (id, flow_id, lane_id, row_index, order_index) VALUES ('n2', 'f1', 'l1', 1, 1)",
+    ).run()
+    db.prepare(
+      "INSERT INTO arrows (id, flow_id, from_node_id, to_node_id) VALUES ('a1', 'f1', 'n1', 'n2')",
+    ).run()
+    const row = db.prepare("SELECT bidirectional FROM arrows WHERE id = 'a1'").get() as {
+      bidirectional: number
+    }
+    expect(row.bidirectional).toBe(0)
+    db.close()
+  })
+
   it('should have created_at and updated_at on all tables', () => {
     db.prepare(
       "INSERT INTO users (id, email, password_hash, name) VALUES ('u1', 'ts@test.com', 'hash', 'Test')",

--- a/tests/db/migration.test.ts
+++ b/tests/db/migration.test.ts
@@ -230,9 +230,7 @@ describe('D1 Migration', () => {
       "INSERT INTO users (id, email, password_hash, name) VALUES ('u1', 'u1@test.com', 'h', 'U')",
     ).run()
     db.prepare("INSERT INTO flows (id, user_id) VALUES ('f1', 'u1')").run()
-    db.prepare(
-      "INSERT INTO lanes (id, flow_id, name, position) VALUES ('l1', 'f1', 'L', 0)",
-    ).run()
+    db.prepare("INSERT INTO lanes (id, flow_id, name, position) VALUES ('l1', 'f1', 'L', 0)").run()
     db.prepare(
       "INSERT INTO nodes (id, flow_id, lane_id, row_index, order_index) VALUES ('n1', 'f1', 'l1', 0, 0)",
     ).run()

--- a/tests/helpers/mock-d1.ts
+++ b/tests/helpers/mock-d1.ts
@@ -16,6 +16,7 @@ export function createTestDb(): ReturnType<typeof Database> {
     '0008_projects.sql',
     '0009_invitation_codes.sql',
     '0010_project_members.sql',
+    '0011_arrow_bidirectional.sql',
   ]
   for (const file of migrationFiles) {
     const sql = readFileSync(resolve(__dirname, '../../migrations/', file), 'utf-8')


### PR DESCRIPTION
## Summary
- 矢印に `bidirectional` フラグを追加（DB / API / UI / Mermaid 出力）
- RightPanel の操作セクションに「⇄ 双方向」トグルボタンを追加。ON 時は「⇄ 方向を逆転」を disabled
- SVG `<path>` に条件付き `markerStart` を追加し、両端に矢じりを描画
- Mermaid エクスポート時、双方向矢印は `<-->` 構文で出力
- Closes #316

## 実装範囲

| 層 | 変更内容 |
|---|---|
| DB | `migrations/0011_arrow_bidirectional.sql` で `arrows.bidirectional INTEGER DEFAULT 0` 追加 |
| 型 | `InternalArrow.bidirectional?: boolean` / `Arrow.bidirectional?: boolean \| null` |
| API | zod schema + `ArrowRow` + `toArrow` + INSERT文（POST/PUT 両方）に `bidirectional` 反映 |
| UI | RightPanel に「⇄ 双方向」ボタン追加。`PanelBtn` に `active` prop 拡張 |
| 描画 | `FlowEditor.tsx` / `SharedFlowViewer.tsx` で `markerStart` を条件レンダリング |
| Mermaid | 双方向矢印は `<-->`、片方向は `-->` |
| i18n | ja: 「⇄ 双方向」 / en: 「⇄ Bidirectional」 |

## Test plan
- [x] DB マイグレーション 0011 のスキーマ・後方互換テスト
- [x] API 永続化 round-trip テスト（POST → GET で `bidirectional` 維持）
- [x] FlowEditor の `marker-start` 描画テスト（双方向 / 片方向）
- [x] SharedFlowViewer の `marker-start` 描画テスト（双方向 / 片方向）
- [x] RightPanel トグルテスト（aria-pressed フリップ + reverse 無効化）
- [x] useArrows: `bidirectional` が `setArrows` を経て保持されることを確認
- [x] Mermaid 出力: `<-->` / `<-->|comment|` / `-->` の3パターンをカバー
- [x] 全体テスト: 1457 passed / 1 skipped
- [x] lint: 0 errors（既存の警告 2 件のみ）
- [x] typecheck: clean
- [x] prettier: clean
- [ ] **実画面検証**: 本セッションでは Playwright MCP が利用不可、Vite dev server の起動確認のみ実施（HTTP 200 OK）。マージ前にブラウザで以下を確認願います:
  - 矢印を選択 → 「⇄ 双方向」をクリック → 両端矢じり表示
  - 双方向 ON 時に「⇄ 方向を逆転」が disabled
  - 保存 → リロードで状態維持
  - 共有ビューでも双方向表示
  - PNG エクスポートに両端矢じり反映
  - LCP 1秒以内

## スコープ外（後続 issue）
- AI 生成プロンプト（`api/lib/ai-prompt.ts`）で双方向矢印を出力できるようにする
- OGP Worker の双方向対応（必要なら）

## 関連ドキュメント
- 設計: `docs/plans/2026-04-29-arrow-bidirectional-design.md`
- 実装計画: `docs/plans/2026-04-29-arrow-bidirectional-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)