### PR TITLE
fix(#324): shrink arrow marker from 9x8 to 7x6

### DIFF
--- a/src/constants/arrowMarker.ts
+++ b/src/constants/arrowMarker.ts
@@ -1,0 +1,7 @@
+export const ARROW_MARKER = {
+  width: 7,
+  height: 6,
+  refX: 6,
+  refY: 3,
+  points: '0 0.5, 7 3, 0 5.5',
+} as const

--- a/src/features/editor/FlowEditor.test.tsx
+++ b/src/features/editor/FlowEditor.test.tsx
@@ -178,7 +178,33 @@ describe('visual constants (#44, #45)', () => {
     const arrowPath = document.querySelector('path[marker-end]')
     expect(arrowPath?.getAttribute('stroke-width')).toBe('2')
     const marker = document.querySelector('marker')
-    expect(marker?.getAttribute('markerWidth')).toBe('9')
+    expect(marker?.getAttribute('markerWidth')).toBe('7')
+    expect(marker?.getAttribute('markerHeight')).toBe('6')
+    expect(marker?.getAttribute('refX')).toBe('6')
+    expect(marker?.getAttribute('refY')).toBe('3')
+    const polygon = marker?.querySelector('polygon')
+    expect(polygon?.getAttribute('points')).toBe('0 0.5, 7 3, 0 5.5')
+  })
+
+  it('should render bidirectional marker-start with shrunk size 7x6', () => {
+    const flow = createMinimalFlow()
+    flow.nodes = [
+      { id: 'n1', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+      { id: 'n2', laneId: 'lane-1', rowIndex: 1, label: 'B', note: null, orderIndex: 1 },
+    ]
+    flow.arrows = [
+      { id: 'bidir-1', fromNodeId: 'n1', toNodeId: 'n2', comment: null, bidirectional: true },
+    ]
+    const { container } = render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+    const startMarker = container.querySelector('marker#m-start-bidir-1')
+    expect(startMarker?.getAttribute('markerWidth')).toBe('7')
+    expect(startMarker?.getAttribute('markerHeight')).toBe('6')
+    expect(startMarker?.getAttribute('refX')).toBe('6')
+    expect(startMarker?.getAttribute('refY')).toBe('3')
+    expect(startMarker?.getAttribute('orient')).toBe('auto-start-reverse')
+    const polygon = startMarker?.querySelector('polygon')
+    expect(polygon?.getAttribute('points')).toBe('0 0.5, 7 3, 0 5.5')
+    cleanup()
   })
 
   it('should render comment label with fontSize 12 and height 24', () => {

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -2722,28 +2722,28 @@ export default function FlowEditor({
                   <defs>
                     <marker
                       id={`m-${arrow.id}`}
-                      markerWidth="9"
-                      markerHeight="8"
-                      refX="8"
-                      refY="4"
+                      markerWidth="7"
+                      markerHeight="6"
+                      refX="6"
+                      refY="3"
                       orient="auto"
                     >
                       <polygon
-                        points="0 0.5, 9 4, 0 7.5"
+                        points="0 0.5, 7 3, 0 5.5"
                         fill={isSel ? arrow.color || T.accent : ac}
                       />
                     </marker>
                     {arrow.bidirectional && (
                       <marker
                         id={`m-start-${arrow.id}`}
-                        markerWidth="9"
-                        markerHeight="8"
-                        refX="8"
-                        refY="4"
+                        markerWidth="7"
+                        markerHeight="6"
+                        refX="6"
+                        refY="3"
                         orient="auto-start-reverse"
                       >
                         <polygon
-                          points="0 0.5, 9 4, 0 7.5"
+                          points="0 0.5, 7 3, 0 5.5"
                           fill={isSel ? arrow.color || T.accent : ac}
                         />
                       </marker>
@@ -2949,13 +2949,13 @@ export default function FlowEditor({
               <defs key={`repair-preview-def-${i}`}>
                 <marker
                   id={`m-preview-${i}`}
-                  markerWidth="9"
-                  markerHeight="8"
-                  refX="8"
-                  refY="4"
+                  markerWidth="7"
+                  markerHeight="6"
+                  refX="6"
+                  refY="3"
                   orient="auto"
                 >
-                  <polygon points="0 0.5, 9 4, 0 7.5" fill={T.accent} opacity={0.6} />
+                  <polygon points="0 0.5, 7 3, 0 5.5" fill={T.accent} opacity={0.6} />
                 </marker>
               </defs>
             ))}

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BRAND } from '../../constants/brand'
+import { ARROW_MARKER } from '../../constants/arrowMarker'
 import { useNavigate, Link } from 'react-router-dom'
 import { ShareDialog } from './components/ShareDialog'
 import { AiAssistant } from './components/AiAssistant'
@@ -2722,28 +2723,28 @@ export default function FlowEditor({
                   <defs>
                     <marker
                       id={`m-${arrow.id}`}
-                      markerWidth="7"
-                      markerHeight="6"
-                      refX="6"
-                      refY="3"
+                      markerWidth={ARROW_MARKER.width}
+                      markerHeight={ARROW_MARKER.height}
+                      refX={ARROW_MARKER.refX}
+                      refY={ARROW_MARKER.refY}
                       orient="auto"
                     >
                       <polygon
-                        points="0 0.5, 7 3, 0 5.5"
+                        points={ARROW_MARKER.points}
                         fill={isSel ? arrow.color || T.accent : ac}
                       />
                     </marker>
                     {arrow.bidirectional && (
                       <marker
                         id={`m-start-${arrow.id}`}
-                        markerWidth="7"
-                        markerHeight="6"
-                        refX="6"
-                        refY="3"
+                        markerWidth={ARROW_MARKER.width}
+                        markerHeight={ARROW_MARKER.height}
+                        refX={ARROW_MARKER.refX}
+                        refY={ARROW_MARKER.refY}
                         orient="auto-start-reverse"
                       >
                         <polygon
-                          points="0 0.5, 7 3, 0 5.5"
+                          points={ARROW_MARKER.points}
                           fill={isSel ? arrow.color || T.accent : ac}
                         />
                       </marker>
@@ -2949,13 +2950,13 @@ export default function FlowEditor({
               <defs key={`repair-preview-def-${i}`}>
                 <marker
                   id={`m-preview-${i}`}
-                  markerWidth="7"
-                  markerHeight="6"
-                  refX="6"
-                  refY="3"
+                  markerWidth={ARROW_MARKER.width}
+                  markerHeight={ARROW_MARKER.height}
+                  refX={ARROW_MARKER.refX}
+                  refY={ARROW_MARKER.refY}
                   orient="auto"
                 >
-                  <polygon points="0 0.5, 7 3, 0 5.5" fill={T.accent} opacity={0.6} />
+                  <polygon points={ARROW_MARKER.points} fill={T.accent} opacity={0.6} />
                 </marker>
               </defs>
             ))}

--- a/src/features/shared/SharedFlowViewer.test.tsx
+++ b/src/features/shared/SharedFlowViewer.test.tsx
@@ -332,6 +332,41 @@ describe('SharedFlowViewer', () => {
       const polygon = document.querySelector('polygon[fill="#ff0000"]')
       expect(polygon).not.toBeNull()
     })
+
+    it('should render arrow marker with shrunk size 7x6', () => {
+      render(<SharedFlowViewer flow={flowWithArrow({})} />)
+      const marker = document.querySelector('marker#sm-arrow-1')
+      expect(marker?.getAttribute('markerWidth')).toBe('7')
+      expect(marker?.getAttribute('markerHeight')).toBe('6')
+      expect(marker?.getAttribute('refX')).toBe('6')
+      expect(marker?.getAttribute('refY')).toBe('3')
+      const polygon = marker?.querySelector('polygon')
+      expect(polygon?.getAttribute('points')).toBe('0 0.5, 7 3, 0 5.5')
+    })
+
+    it('should render bidirectional marker-start with shrunk size 7x6', () => {
+      const flow = {
+        ...flowWithArrow({}),
+        arrows: [
+          {
+            id: 'arrow-1',
+            fromNodeId: 'node-1',
+            toNodeId: 'node-2',
+            comment: null,
+            bidirectional: true,
+          },
+        ],
+      }
+      render(<SharedFlowViewer flow={flow} />)
+      const startMarker = document.querySelector('marker#sm-start-arrow-1')
+      expect(startMarker?.getAttribute('markerWidth')).toBe('7')
+      expect(startMarker?.getAttribute('markerHeight')).toBe('6')
+      expect(startMarker?.getAttribute('refX')).toBe('6')
+      expect(startMarker?.getAttribute('refY')).toBe('3')
+      expect(startMarker?.getAttribute('orient')).toBe('auto-start-reverse')
+      const polygon = startMarker?.querySelector('polygon')
+      expect(polygon?.getAttribute('points')).toBe('0 0.5, 7 3, 0 5.5')
+    })
   })
 
   describe('rect node custom styles', () => {

--- a/src/features/shared/SharedFlowViewer.tsx
+++ b/src/features/shared/SharedFlowViewer.tsx
@@ -491,24 +491,24 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
                 <defs>
                   <marker
                     id={`sm-${arrow.id}`}
-                    markerWidth="9"
-                    markerHeight="8"
-                    refX="8"
-                    refY="4"
+                    markerWidth="7"
+                    markerHeight="6"
+                    refX="6"
+                    refY="3"
                     orient="auto"
                   >
-                    <polygon points="0 0.5, 9 4, 0 7.5" fill={ac} />
+                    <polygon points="0 0.5, 7 3, 0 5.5" fill={ac} />
                   </marker>
                   {arrow.bidirectional && (
                     <marker
                       id={`sm-start-${arrow.id}`}
-                      markerWidth="9"
-                      markerHeight="8"
-                      refX="8"
-                      refY="4"
+                      markerWidth="7"
+                      markerHeight="6"
+                      refX="6"
+                      refY="3"
                       orient="auto-start-reverse"
                     >
-                      <polygon points="0 0.5, 9 4, 0 7.5" fill={ac} />
+                      <polygon points="0 0.5, 7 3, 0 5.5" fill={ac} />
                     </marker>
                   )}
                 </defs>

--- a/src/features/shared/SharedFlowViewer.tsx
+++ b/src/features/shared/SharedFlowViewer.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { Flow, ThemeId, Node as FlowNode, Arrow } from '../editor/types'
 import { BRAND } from '../../constants/brand'
+import { ARROW_MARKER } from '../../constants/arrowMarker'
 import { PALETTES, THEMES } from '../editor/theme-constants'
 import styles from './SharedFlowViewer.module.css'
 import { NodeLabelText } from './NodeLabelText'
@@ -491,24 +492,24 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
                 <defs>
                   <marker
                     id={`sm-${arrow.id}`}
-                    markerWidth="7"
-                    markerHeight="6"
-                    refX="6"
-                    refY="3"
+                    markerWidth={ARROW_MARKER.width}
+                    markerHeight={ARROW_MARKER.height}
+                    refX={ARROW_MARKER.refX}
+                    refY={ARROW_MARKER.refY}
                     orient="auto"
                   >
-                    <polygon points="0 0.5, 7 3, 0 5.5" fill={ac} />
+                    <polygon points={ARROW_MARKER.points} fill={ac} />
                   </marker>
                   {arrow.bidirectional && (
                     <marker
                       id={`sm-start-${arrow.id}`}
-                      markerWidth="7"
-                      markerHeight="6"
-                      refX="6"
-                      refY="3"
+                      markerWidth={ARROW_MARKER.width}
+                      markerHeight={ARROW_MARKER.height}
+                      refX={ARROW_MARKER.refX}
+                      refY={ARROW_MARKER.refY}
                       orient="auto-start-reverse"
                     >
-                      <polygon points="0 0.5, 7 3, 0 5.5" fill={ac} />
+                      <polygon points={ARROW_MARKER.points} fill={ac} />
                     </marker>
                   )}
                 </defs>


### PR DESCRIPTION
## 概要
矢印先端マーカーを 9×8 → 7×6（約 78%）に縮小し、ノード間の余白を確保する。

Closes #324

## 変更内容
- `markerWidth` 9 → 7
- `markerHeight` 8 → 6
- `refX` 8 → 6
- `refY` 4 → 3
- `polygon points` `0 0.5, 9 4, 0 7.5` → `0 0.5, 7 3, 0 5.5`

### 変更箇所（計 5 箇所）
- `src/features/editor/FlowEditor.tsx`
  - 通常矢印マーカー（`m-{arrow.id}`）
  - 双方向矢印 marker-start（`m-start-{arrow.id}`、`auto-start-reverse` 維持）
  - 修復プレビューマーカー（`m-preview-{i}`）
- `src/features/shared/SharedFlowViewer.tsx`
  - 通常矢印マーカー（`sm-{arrow.id}`）
  - 双方向矢印 marker-start（`sm-start-{arrow.id}`）

`strokeWidth` は通常 2 / 選択時 2.5 を維持。パスのルーティングや出口/入口計算には変更なし。

## Test plan
- [x] FlowEditor.test.tsx: 通常矢印マーカー属性とポリゴン points を 7×6 で検証
- [x] FlowEditor.test.tsx: 双方向 marker-start を 7×6 で検証（追加）
- [x] SharedFlowViewer.test.tsx: 通常矢印マーカーを 7×6 で検証（追加）
- [x] SharedFlowViewer.test.tsx: 双方向 marker-start を 7×6 で検証（追加）
- [x] 全 1469 テスト pass
- [x] ブラウザで OLD 9×8 / NEW 7×6 を並べた SVG 比較で目視確認 (`.screenshots/marker-comparison-324.png`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)