### PR TITLE
fix(#323): add horizontal depart to detour path start (5→6 segments)

### DIFF
--- a/src/features/shared/SharedFlowViewer.test.tsx
+++ b/src/features/shared/SharedFlowViewer.test.tsx
@@ -483,10 +483,10 @@ describe('SharedFlowViewer', () => {
     )
     expect(paths.length).toBeGreaterThanOrEqual(1)
     const d = paths[0].getAttribute('d')!
-    // 迂回パスは 5 セグメント（M L L L L）。直線パスは M L のみなので区別可能。
-    // 5 セグメント目は target 側面への水平進入。
+    // 迂回パスは 6 セグメント（M L L L L L）。直線パスは M L のみなので区別可能。
+    // 1 セグメント目は始点側の水平 depart、6 セグメント目は target 側面への水平進入。
     const segmentCount = d.match(/[ML]/g)?.length ?? 0
-    expect(segmentCount).toBe(5)
+    expect(segmentCount).toBe(6)
   })
 
   it('同一行で隣接レーン（間にノードなし）の矢印は直線パス', () => {

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -23,8 +23,8 @@ describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
   it('同一行・障害1個・上下空き → 下迂回パス（detourY = 障害下端 + 14）', () => {
     const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
     const r = buildArrowPath(s, e, fc, tc, [B])
-    // approachX = 524 - 14 = 510
-    expect(r.d).toBe('M276,200 L276,242 L510,242 L510,200 L524,200')
+    // departX = 276 + 14 = 290, approachX = 524 - 14 = 510
+    expect(r.d).toBe('M276,200 L290,200 L290,242 L510,242 L510,200 L524,200')
     expect(r.mx).toBe(400)
     expect(r.my).toBe(242)
   })
@@ -33,7 +33,7 @@ describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
     const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
     const D: Bbox = { x: 400, y: 284, w: 152, h: 56 }
     const r = buildArrowPath(s, e, fc, tc, [B, D])
-    expect(r.d).toBe('M276,200 L276,158 L510,158 L510,200 L524,200')
+    expect(r.d).toBe('M276,200 L290,200 L290,158 L510,158 L510,200 L524,200')
     expect(r.my).toBe(158)
   })
 
@@ -52,8 +52,8 @@ describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
     const eExt = { x: 624, y: 200 }
     const r = buildArrowPath(sExt, eExt, { x: 200, y: 200 }, { x: 700, y: 200 }, [B, C2])
     expect(r.my).toBe(254)
-    // approachX = 624 - 14 = 610
-    expect(r.d).toBe('M276,200 L276,254 L610,254 L610,200 L624,200')
+    // departX = 276 + 14 = 290, approachX = 624 - 14 = 610
+    expect(r.d).toBe('M276,200 L290,200 L290,254 L610,254 L610,200 L624,200')
   })
 
   it('同一行・障害2個・1つだけ直下塞がり → 上迂回', () => {
@@ -108,19 +108,27 @@ describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
     const tcR = { x: 200, y: 200 }
     const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
     const r = buildArrowPath(sR, eR, fcR, tcR, [B])
-    // detourY = 200 + 28 + 14 = 242。左右が反転したミラーパス（approachX = 276 + 14 = 290）
-    expect(r.d).toBe('M524,200 L524,242 L290,242 L290,200 L276,200')
+    // detourY = 200 + 28 + 14 = 242。左右が反転したミラーパス
+    // departX = 524 - 14 = 510, approachX = 276 + 14 = 290
+    expect(r.d).toBe('M524,200 L510,200 L510,242 L290,242 L290,200 L276,200')
     expect(r.mx).toBe(400)
     expect(r.my).toBe(242)
   })
 
-  describe('水平進入（最終セグメント水平）', () => {
-    it('下迂回パスは 5 セグメントで最終セグメントが水平', () => {
+  describe('水平進入＋水平 depart（始終点とも水平）', () => {
+    it('下迂回パスは 6 セグメントで最初と最終セグメントが水平', () => {
       const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
       const r = buildArrowPath(s, e, fc, tc, [B])
       const segments = r.d.match(/[ML][^ML]+/g) ?? []
-      expect(segments).toHaveLength(5)
-      // 最終セグメントは水平（前のセグメントの終点と最終終点が同じ Y）
+      expect(segments).toHaveLength(6)
+      // 最初のセグメント（M→L）は水平: M の Y と次の L の Y が同じ
+      const first = segments[0]
+      const second = segments[1]
+      const firstY = Number(first.split(',')[1])
+      const secondY = Number(second.split(',')[1])
+      expect(firstY).toBe(secondY)
+      expect(firstY).toBe(s.y)
+      // 最終セグメントは水平
       const last = segments[segments.length - 1]
       const prev = segments[segments.length - 2]
       const lastY = Number(last.split(',')[1])
@@ -129,8 +137,8 @@ describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
       expect(lastY).toBe(e.y)
     })
 
-    it('水平距離が APPROACH_GAP*2 未満の場合 approachX は s.x を越えない（clamp 動作）', () => {
-      // 水平距離=20, APPROACH_GAP=14。Math.min(14, 10) で 10 に clamp される
+    it('水平距離が DEPART_GAP*2 未満の場合 departX/approachX は中央で接合し自己交差しない', () => {
+      // 水平距離=20, DEPART_GAP=APPROACH_GAP=14。Math.min(14, 10) で 10 に clamp される
       // s=(100,200), e=(120,200) で間に B (110,200) を置いて迂回を強制
       const sN = { x: 100, y: 200 }
       const eN = { x: 120, y: 200 }
@@ -138,8 +146,10 @@ describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
       const tcN = { x: 140, y: 200 }
       const B: Bbox = { x: 110, y: 200, w: 16, h: 56 }
       const r = buildArrowPath(sN, eN, fcN, tcN, [B])
-      // approachX = 120 - 1 * Math.min(14, 10) = 110。s.x(=100) を越えていない
-      expect(r.d).toBe('M100,200 L100,242 L110,242 L110,200 L120,200')
+      // departX = 100 + 1 * Math.min(14, 10) = 110
+      // approachX = 120 - 1 * Math.min(14, 10) = 110
+      // → 中央 (110) で接合。departX も approachX も s.x/e.x を越えない
+      expect(r.d).toBe('M100,200 L110,200 L110,242 L110,242 L110,200 L120,200')
     })
   })
 })

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -163,8 +163,7 @@ export const buildArrowPath = (
       // |e.x - s.x| / 2 で clamp。ノード幅が縮小しても departX/approachX が反対側を越えて
       // パスが自己交差するのを防ぐ防御コード（detectDetour で水平距離は保証されるが、レイアウト
       // 変更時の silent breakage 回避用）。DEPART_GAP/APPROACH_GAP が同値（対称設計）の場合、
-      // clamp が効くと中央で接合する。
-      const dx = e.x - s.x
+      // clamp が効くと中央で接合する（縮退ケースでは中央水平セグメントがゼロ長になる）。
       const sign = Math.sign(dx)
       const halfDx = Math.abs(dx) / 2
       const departX = s.x + sign * Math.min(DEPART_GAP, halfDx)

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -15,6 +15,9 @@ const DETOUR_MARGIN = 14
 // 最終セグメントを水平にすることで矢印先端が target 側面に水平進入する。
 // 値は DETOUR_MARGIN と同値だが意図が異なる（迂回 Y オフセット vs 水平進入 X オフセット）ため別定数とする。
 const APPROACH_GAP = 14
+// 迂回パスの始点直後で水平に出てから垂直に折れる距離。
+// APPROACH_GAP と対称設計（同値）で、始点側もノード端から少し横に進んでから下降させる。
+const DEPART_GAP = 14
 
 function detectDetour(s: Point, e: Point, obstacles: Bbox[]): { detourY: number } | null {
   // 水平直線でなければ迂回しない
@@ -157,13 +160,18 @@ export const buildArrowPath = (
     const detour = detectDetour(s, e, obstacles)
     if (detour) {
       const { detourY } = detour
-      // |e.x - s.x| / 2 で clamp。ノード幅が縮小しても approachX が s.x 側を越えてパスが
-      // 自己交差するのを防ぐ防御コード（detectDetour で水平距離は保証されるが、レイアウト
-      // 変更時の silent breakage 回避用）。
+      // |e.x - s.x| / 2 で clamp。ノード幅が縮小しても departX/approachX が反対側を越えて
+      // パスが自己交差するのを防ぐ防御コード（detectDetour で水平距離は保証されるが、レイアウト
+      // 変更時の silent breakage 回避用）。DEPART_GAP/APPROACH_GAP が同値（対称設計）の場合、
+      // clamp が効くと中央で接合する。
       const dx = e.x - s.x
-      const approachX = e.x - Math.sign(dx) * Math.min(APPROACH_GAP, Math.abs(dx) / 2)
-      // 5 セグメント: M → 垂直(detourY まで) → 水平(approachX まで) → 垂直(e.y まで) → 水平(e.x へ進入)
-      const d = `M${s.x},${s.y} L${s.x},${detourY} L${approachX},${detourY} L${approachX},${e.y} L${e.x},${e.y}`
+      const sign = Math.sign(dx)
+      const halfDx = Math.abs(dx) / 2
+      const departX = s.x + sign * Math.min(DEPART_GAP, halfDx)
+      const approachX = e.x - sign * Math.min(APPROACH_GAP, halfDx)
+      // 6 セグメント: M → 水平(departX まで) → 垂直(detourY まで) → 水平(approachX まで)
+      //               → 垂直(e.y まで) → 水平(e.x へ進入)
+      const d = `M${s.x},${s.y} L${departX},${s.y} L${departX},${detourY} L${approachX},${detourY} L${approachX},${e.y} L${e.x},${e.y}`
       return { d, mx: (s.x + e.x) / 2, my: detourY }
     }
   }

--- a/src/lib/flow-engine.test.ts
+++ b/src/lib/flow-engine.test.ts
@@ -228,8 +228,8 @@ describe('calcArrowPath', () => {
     )
     expect(r).not.toBeNull()
     // exitPt: dx=400 横出口 {276,200}, entryPt: 横入口 {524,200}
-    // 迂回: detourY = 228 + 14 = 242, approachX = 524 - 14 = 510
-    expect(r.d).toBe('M276,200 L276,242 L510,242 L510,200 L524,200')
+    // 迂回: detourY = 228 + 14 = 242, departX = 276 + 14 = 290, approachX = 524 - 14 = 510
+    expect(r.d).toBe('M276,200 L290,200 L290,242 L510,242 L510,200 L524,200')
     expect(r.mx).toBe(400)
     expect(r.my).toBe(242)
   })


### PR DESCRIPTION
## 概要
同一行迂回パスの target 側だけ水平進入（#318/#319）が効いており、始点側は
依然としてノード端から直接垂直に下降していた。target 側と対称に、始点側
にも 14px の水平 depart を挟むことでパスを 6 セグメント化する。

Closes #323

## 変更内容

### 新しいパス構造（6 セグメント）
\`\`\`
M(s.x, s.y) L(departX, s.y) L(departX, detourY) L(approachX, detourY)
            L(approachX, e.y) L(e.x, e.y)
\`\`\`

### 追加定数
- \`DEPART_GAP = 14\`（\`APPROACH_GAP\` と同値、対称設計）

### clamp 動作
\`\`\`ts
const sign = Math.sign(dx)
const halfDx = Math.abs(dx) / 2
const departX = s.x + sign * Math.min(DEPART_GAP, halfDx)
const approachX = e.x - sign * Math.min(APPROACH_GAP, halfDx)
\`\`\`
\`|dx|\` が \`DEPART_GAP*2\` 未満の場合、両者とも \`|dx|/2\` で clamp され
中央で接合する → 自己交差しない。

## スコープ外（issue 仕様通り）
- 上下塞がり判定ロジック（DOWN 優先 / 直下塞がりなら UP / 両塞がりは DOWN）
- 同一行以外の Z字 / L字パス
- \`exitPt\` / \`entryPt\` の出口入口計算
- ラベル位置 \`mx, my\`

## 影響範囲
- \`src/lib/arrow-routing.ts\`（パス生成 + \`DEPART_GAP\` 追加）
- \`src/lib/arrow-routing.test.ts\`（5→6 セグ更新、clamp テスト調整）
- \`src/lib/flow-engine.test.ts\`（path 文字列更新）
- \`src/features/shared/SharedFlowViewer.test.tsx\`（segmentCount 5→6）

## Test plan
- [x] \`buildArrowPath\` 全テストが新 6 セグパスで通過（左右両方向、上下迂回）
- [x] clamp テスト: 水平距離 20px (DEPART_GAP*2 未満) で departX/approachX が中央接合
- [x] \`SharedFlowViewer\` の迂回パスが 6 セグメントになっていることを検証
- [x] \`flow-engine\` の \`calcArrowPath\` 経由でも 6 セグパスを生成
- [x] 全 1469 テスト pass
- [x] OLD/NEW パスをブラウザで並べて目視確認 (\`.screenshots/detour-comparison-323.png\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)