### PR TITLE
feat(#331): make memo URLs clickable and reflect newlines

### DIFF
--- a/docs/superpowers/plans/2026-04-30-memo-url-newline-plan.md
+++ b/docs/superpowers/plans/2026-04-30-memo-url-newline-plan.md
@@ -1,0 +1,903 @@
+# Memo URL/Newline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** メモ吹き出し内の `https?://` URL を別タブで開けるリンクに自動変換し、改行をそのまま表示・入力に反映する。
+
+**Architecture:** 表示ロジックは新設の `MemoText` コンポーネントに集約（FlowEditor 通常表示・SharedFlowViewer の 2 か所で使う）。URL 検出は新設の純粋関数 `splitTextWithUrls` に分離。右パネルは既存 `PanelTextarea` を `submitOnEnter` オプション付きに拡張して再利用。永続化形式（`MemoData.text`）と高さ計算（`measureMemoHeight`）は無改修。
+
+**Tech Stack:** React (TypeScript) / Vite / Vitest / @testing-library/react / Playwright / Cloudflare Pages
+
+**Spec:** `docs/superpowers/specs/2026-04-30-memo-url-newline-design.md`
+**Issue:** https://github.com/tomohirof/flowline/issues/331
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `src/features/editor/memo-utils.ts` | Modify | `splitTextWithUrls` と型 `MemoTextSegment` を追加 |
+| `src/features/editor/memo-utils.test.ts` | Modify | `splitTextWithUrls` の単体テストを追加 |
+| `src/features/editor/components/MemoText.tsx` | Create | 改行＋URL クリッカブル化を担うプレゼンテーショナルコンポーネント |
+| `src/features/editor/components/MemoText.test.tsx` | Create | `MemoText` の単体テスト |
+| `src/features/editor/components/PanelParts.tsx` | Modify | `PanelTextarea` に `submitOnEnter` オプション追加 |
+| `src/features/editor/components/PanelParts.test.tsx` | Create | `PanelTextarea` の挙動テスト |
+| `src/features/editor/FlowEditor.tsx` | Modify | 通常表示メモ（3487-3503）を `MemoText` に置換 |
+| `src/features/shared/SharedFlowViewer.tsx` | Modify | 共有ビューのメモ（471-486）を `MemoText` に置換 |
+| `src/features/editor/components/RightPanel.tsx` | Modify | メモ欄の `PanelInput` を `PanelTextarea (submitOnEnter=false)` に置換 |
+| `src/features/editor/FlowEditor.test.tsx` | Modify | 右パネル `<textarea>`／改行表示／URLリンク化の統合テストを追加 |
+
+---
+
+## Pre-flight: Worktree, Cleanup, Issue Label
+
+### Task 0: 作業ブランチ準備
+
+**Files:** （リポジトリ運用のみ）
+
+- [ ] **Step 0-1: 既存プロセスをクリーンアップ**
+
+Run: `pkill -f 'vite|wrangler|esbuild|workerd' 2>/dev/null; true`
+
+- [ ] **Step 0-2: issue に「作業開始」ラベルを付与**
+
+```bash
+gh label list --json name | jq -r '.[].name' | grep -q '^作業開始$' || gh label create "作業開始" --color "E11D48"
+gh issue edit 331 --add-label "作業開始"
+```
+
+- [ ] **Step 0-3: main を最新化（必須・ff-only）**
+
+```bash
+git checkout main
+git fetch origin
+git merge --ff-only origin/main
+```
+
+ff-only が通らなかったら **作業を中断して報告**。
+
+- [ ] **Step 0-4: worktree 作成と .env シンボリックリンク**
+
+```bash
+git worktree add .worktrees/feat-memo-url-newline-331 -b feat/memo-url-newline-331
+cd .worktrees/feat-memo-url-newline-331
+MAIN=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
+for f in "$MAIN"/.env*; do [ -f "$f" ] && ln -sf "$f" .; done
+```
+
+- [ ] **Step 0-5: 依存関係を確認**
+
+Run: `npm ci --no-audit --no-fund` （既に node_modules がリンクされていればスキップ可）
+Expected: 成功して `npm test --silent -- --run --reporter=dot` が動く状態。
+
+- [ ] **Step 0-6: テストルールを読込**
+
+Run: `cat ~/.claude/rules/testing.md`
+Expected: 振る舞いベース／網羅すべきエッジケースのチェックリストが頭に入る。
+
+---
+
+## Task 1: `splitTextWithUrls` の TDD
+
+**Files:**
+- Modify: `src/features/editor/memo-utils.test.ts`（末尾に追記）
+- Modify: `src/features/editor/memo-utils.ts`（末尾に追記）
+
+- [ ] **Step 1-1: 失敗テストを追加**
+
+`src/features/editor/memo-utils.test.ts` の最終行（`MEMO_W` describe の後）に以下を追記:
+
+```ts
+import { splitTextWithUrls } from './memo-utils'
+
+describe('splitTextWithUrls', () => {
+  it('returns single text segment when input has no URLs', () => {
+    expect(splitTextWithUrls('hello world')).toEqual([{ type: 'text', value: 'hello world' }])
+  })
+
+  it('returns empty array for empty string', () => {
+    expect(splitTextWithUrls('')).toEqual([])
+  })
+
+  it('detects a single https URL in the middle of text', () => {
+    expect(splitTextWithUrls('see https://example.com here')).toEqual([
+      { type: 'text', value: 'see ' },
+      { type: 'url', value: 'https://example.com' },
+      { type: 'text', value: ' here' },
+    ])
+  })
+
+  it('detects http and multiple URLs in order', () => {
+    expect(splitTextWithUrls('a http://a.com b https://b.com c')).toEqual([
+      { type: 'text', value: 'a ' },
+      { type: 'url', value: 'http://a.com' },
+      { type: 'text', value: ' b ' },
+      { type: 'url', value: 'https://b.com' },
+      { type: 'text', value: ' c' },
+    ])
+  })
+
+  it('preserves query and fragment', () => {
+    const url = 'https://example.com/path?q=1&r=2#frag'
+    expect(splitTextWithUrls(`x ${url} y`)).toEqual([
+      { type: 'text', value: 'x ' },
+      { type: 'url', value: url },
+      { type: 'text', value: ' y' },
+    ])
+  })
+
+  it('excludes trailing punctuation from the URL', () => {
+    expect(splitTextWithUrls('see https://example.com.')).toEqual([
+      { type: 'text', value: 'see ' },
+      { type: 'url', value: 'https://example.com' },
+      { type: 'text', value: '.' },
+    ])
+    expect(splitTextWithUrls('(https://example.com)')).toEqual([
+      { type: 'text', value: '(' },
+      { type: 'url', value: 'https://example.com' },
+      { type: 'text', value: ')' },
+    ])
+  })
+
+  it('does NOT match dangerous schemes', () => {
+    expect(splitTextWithUrls('javascript:alert(1)')).toEqual([
+      { type: 'text', value: 'javascript:alert(1)' },
+    ])
+    expect(splitTextWithUrls('data:text/html,foo')).toEqual([
+      { type: 'text', value: 'data:text/html,foo' },
+    ])
+    expect(splitTextWithUrls('file:///etc/passwd')).toEqual([
+      { type: 'text', value: 'file:///etc/passwd' },
+    ])
+  })
+
+  it('does not match scheme-only without host', () => {
+    expect(splitTextWithUrls('http://')).toEqual([{ type: 'text', value: 'http://' }])
+  })
+
+  it('does not span URL across newlines', () => {
+    expect(splitTextWithUrls('see https://example.com\nnext line')).toEqual([
+      { type: 'text', value: 'see ' },
+      { type: 'url', value: 'https://example.com' },
+      { type: 'text', value: '\nnext line' },
+    ])
+  })
+
+  it('treats full-width spaces and tabs as separators', () => {
+    expect(splitTextWithUrls('a\thttps://example.com\tb')).toEqual([
+      { type: 'text', value: 'a\t' },
+      { type: 'url', value: 'https://example.com' },
+      { type: 'text', value: '\tb' },
+    ])
+  })
+})
+```
+
+- [ ] **Step 1-2: テストを走らせて失敗を確認**
+
+Run: `npx vitest run src/features/editor/memo-utils.test.ts`
+Expected: `splitTextWithUrls` を export していないため import エラーで失敗する（または `is not a function`）。
+
+- [ ] **Step 1-3: 最小実装**
+
+`src/features/editor/memo-utils.ts` の末尾に以下を追記:
+
+```ts
+export type MemoTextSegment = { type: 'text' | 'url'; value: string }
+
+const URL_REGEX = /\bhttps?:\/\/[^\s<]+[^\s<.,;:!?)\]'"]/g
+
+export function splitTextWithUrls(text: string): MemoTextSegment[] {
+  if (!text) return []
+  const segments: MemoTextSegment[] = []
+  let last = 0
+  for (const match of text.matchAll(URL_REGEX)) {
+    const start = match.index ?? 0
+    if (start > last) {
+      segments.push({ type: 'text', value: text.slice(last, start) })
+    }
+    segments.push({ type: 'url', value: match[0] })
+    last = start + match[0].length
+  }
+  if (last < text.length) {
+    segments.push({ type: 'text', value: text.slice(last) })
+  }
+  return segments
+}
+```
+
+- [ ] **Step 1-4: テストが pass するか確認**
+
+Run: `npx vitest run src/features/editor/memo-utils.test.ts`
+Expected: すべて pass（既存 parseNote / serializeMemo / measureMemoHeight も引き続き pass）。
+
+- [ ] **Step 1-5: コミット**
+
+```bash
+git add src/features/editor/memo-utils.ts src/features/editor/memo-utils.test.ts
+git commit -m "feat(#331): add splitTextWithUrls util for memo URL detection"
+```
+
+---
+
+## Task 2: `MemoText` コンポーネントの TDD
+
+**Files:**
+- Create: `src/features/editor/components/MemoText.tsx`
+- Create: `src/features/editor/components/MemoText.test.tsx`
+
+- [ ] **Step 2-1: 失敗テストを作成**
+
+`src/features/editor/components/MemoText.test.tsx` を新規作成:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { MemoText } from './MemoText'
+
+describe('MemoText', () => {
+  it('renders plain text without anchor when no URL is present', () => {
+    const { container, queryByRole } = render(<MemoText text="just plain text" color="#000" />)
+    expect(queryByRole('link')).toBeNull()
+    expect(container.textContent).toBe('just plain text')
+  })
+
+  it('renders an anchor for an https URL', () => {
+    const { getByRole } = render(<MemoText text="visit https://example.com" color="#000" />)
+    const link = getByRole('link') as HTMLAnchorElement
+    expect(link.getAttribute('href')).toBe('https://example.com')
+  })
+
+  it('sets target=_blank and a strict rel', () => {
+    const { getByRole } = render(<MemoText text="https://example.com" color="#000" />)
+    const link = getByRole('link') as HTMLAnchorElement
+    expect(link.getAttribute('target')).toBe('_blank')
+    const rel = link.getAttribute('rel') ?? ''
+    expect(rel).toContain('noopener')
+    expect(rel).toContain('noreferrer')
+    expect(rel).toContain('nofollow')
+  })
+
+  it('makes the anchor pointer-interactive even though container is non-interactive', () => {
+    const { container, getByRole } = render(<MemoText text="https://example.com" color="#000" />)
+    const root = container.firstChild as HTMLElement
+    expect(root.style.pointerEvents).toBe('none')
+    expect(root.style.userSelect).toBe('none')
+
+    const link = getByRole('link') as HTMLAnchorElement
+    expect(link.style.pointerEvents).toBe('auto')
+    expect(link.style.userSelect).toBe('auto')
+  })
+
+  it('uses pre-wrap whiteSpace so newlines are preserved', () => {
+    const { container } = render(<MemoText text={'line1\nline2'} color="#000" />)
+    const root = container.firstChild as HTMLElement
+    expect(root.style.whiteSpace).toBe('pre-wrap')
+  })
+
+  it('does NOT linkify dangerous schemes', () => {
+    const { queryByRole, container } = render(
+      <MemoText text="javascript:alert(1) data:text/html,x" color="#000" />,
+    )
+    expect(queryByRole('link')).toBeNull()
+    expect(container.textContent).toBe('javascript:alert(1) data:text/html,x')
+  })
+
+  it('stops mousedown and click propagation on the anchor', () => {
+    const onParentMouseDown = vi.fn()
+    const onParentClick = vi.fn()
+    const { getByRole } = render(
+      <div onMouseDown={onParentMouseDown} onClick={onParentClick}>
+        <MemoText text="https://example.com" color="#000" />
+      </div>,
+    )
+    const link = getByRole('link') as HTMLAnchorElement
+    fireEvent.mouseDown(link)
+    fireEvent.click(link)
+    expect(onParentMouseDown).not.toHaveBeenCalled()
+    expect(onParentClick).not.toHaveBeenCalled()
+  })
+
+  it('renders nothing visible for empty text', () => {
+    const { container } = render(<MemoText text="" color="#000" />)
+    expect(container.textContent).toBe('')
+  })
+})
+```
+
+- [ ] **Step 2-2: テスト走らせて失敗を確認**
+
+Run: `npx vitest run src/features/editor/components/MemoText.test.tsx`
+Expected: `MemoText` を import できず失敗。
+
+- [ ] **Step 2-3: 実装を作成**
+
+`src/features/editor/components/MemoText.tsx` を新規作成:
+
+```tsx
+import { Fragment } from 'react'
+import { splitTextWithUrls } from '../memo-utils'
+
+type Props = {
+  text: string
+  color: string
+  linkColor?: string
+}
+
+export function MemoText({ text, color, linkColor }: Props) {
+  const segments = splitTextWithUrls(text)
+  return (
+    <div
+      style={{
+        fontSize: 11,
+        lineHeight: '1.55',
+        color,
+        fontFamily: 'inherit',
+        padding: '5px 8px',
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word',
+        pointerEvents: 'none',
+        userSelect: 'none',
+      }}
+    >
+      {segments.map((seg, i) =>
+        seg.type === 'url' ? (
+          <a
+            key={i}
+            href={seg.value}
+            target="_blank"
+            rel="noopener noreferrer nofollow"
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              color: linkColor ?? color,
+              textDecoration: 'underline',
+              pointerEvents: 'auto',
+              userSelect: 'auto',
+              overflowWrap: 'anywhere',
+            }}
+          >
+            {seg.value}
+          </a>
+        ) : (
+          <Fragment key={i}>{seg.value}</Fragment>
+        ),
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2-4: テストが pass するか確認**
+
+Run: `npx vitest run src/features/editor/components/MemoText.test.tsx`
+Expected: 全テスト pass。
+
+- [ ] **Step 2-5: コミット**
+
+```bash
+git add src/features/editor/components/MemoText.tsx src/features/editor/components/MemoText.test.tsx
+git commit -m "feat(#331): add MemoText component with URL/newline rendering"
+```
+
+---
+
+## Task 3: `PanelTextarea` の `submitOnEnter` 拡張
+
+**Files:**
+- Modify: `src/features/editor/components/PanelParts.tsx`
+- Create: `src/features/editor/components/PanelParts.test.tsx`
+
+- [ ] **Step 3-1: 失敗テストを作成**
+
+`src/features/editor/components/PanelParts.test.tsx` を新規作成:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { PanelTextarea } from './PanelParts'
+
+describe('PanelTextarea', () => {
+  it('blurs on Enter when submitOnEnter is unset (default true)', () => {
+    const onChange = vi.fn()
+    const { container } = render(<PanelTextarea value="" onChange={onChange} />)
+    const ta = container.querySelector('textarea') as HTMLTextAreaElement
+    ta.focus()
+    expect(document.activeElement).toBe(ta)
+    fireEvent.keyDown(ta, { key: 'Enter' })
+    expect(document.activeElement).not.toBe(ta)
+  })
+
+  it('does NOT blur on Enter when submitOnEnter is false', () => {
+    const onChange = vi.fn()
+    const { container } = render(
+      <PanelTextarea value="" onChange={onChange} submitOnEnter={false} />,
+    )
+    const ta = container.querySelector('textarea') as HTMLTextAreaElement
+    ta.focus()
+    expect(document.activeElement).toBe(ta)
+    fireEvent.keyDown(ta, { key: 'Enter' })
+    expect(document.activeElement).toBe(ta)
+  })
+
+  it('does not blur during IME composition even when submitOnEnter is true', () => {
+    const onChange = vi.fn()
+    const { container } = render(<PanelTextarea value="" onChange={onChange} />)
+    const ta = container.querySelector('textarea') as HTMLTextAreaElement
+    ta.focus()
+    fireEvent.keyDown(ta, { key: 'Enter', isComposing: true })
+    expect(document.activeElement).toBe(ta)
+  })
+})
+```
+
+- [ ] **Step 3-2: テスト走らせて失敗を確認**
+
+Run: `npx vitest run src/features/editor/components/PanelParts.test.tsx`
+Expected: 「does NOT blur on Enter when submitOnEnter is false」が失敗（現実装では submitOnEnter プロパティが存在しない＝既定で blur してしまう）。
+
+- [ ] **Step 3-3: `PanelTextarea` を改修**
+
+`src/features/editor/components/PanelParts.tsx` の `PanelTextarea` を以下に置換:
+
+```tsx
+export const PanelTextarea = ({
+  value,
+  onChange,
+  placeholder,
+  rows = 2,
+  submitOnEnter = true,
+}: {
+  value: string
+  onChange: (v: string) => void
+  placeholder?: string
+  rows?: number
+  submitOnEnter?: boolean
+}) => (
+  <textarea
+    value={value}
+    onChange={(e) => onChange(e.target.value)}
+    placeholder={placeholder}
+    rows={rows}
+    className={styles.panelTextarea}
+    onKeyDown={(e) => {
+      if (e.nativeEvent.isComposing) return
+      if (!submitOnEnter) return
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault()
+        ;(e.currentTarget as HTMLTextAreaElement).blur()
+      }
+    }}
+  />
+)
+```
+
+- [ ] **Step 3-4: テストが pass するか確認**
+
+Run: `npx vitest run src/features/editor/components/PanelParts.test.tsx`
+Expected: 全テスト pass。
+
+- [ ] **Step 3-5: コミット**
+
+```bash
+git add src/features/editor/components/PanelParts.tsx src/features/editor/components/PanelParts.test.tsx
+git commit -m "feat(#331): add submitOnEnter option to PanelTextarea"
+```
+
+---
+
+## Task 4: FlowEditor 通常表示を `MemoText` に置換
+
+**Files:**
+- Modify: `src/features/editor/FlowEditor.tsx`（3487-3503）
+
+- [ ] **Step 4-1: 既存メモ表示の `<foreignObject>` ＋ `<div>` を `MemoText` に置換**
+
+`src/features/editor/FlowEditor.tsx` の以下のブロック（line 3487-3503 周辺、`{m.text ? (` の foreignObject 内 `<div>...</div>`）:
+
+```tsx
+{m.text ? (
+  <foreignObject x={mx} y={my} width={MEMO_W} height={mh}>
+    <div
+      style={{
+        fontSize: 11,
+        lineHeight: '1.55',
+        color: T.memoText,
+        fontFamily: 'inherit',
+        padding: '5px 8px',
+        wordBreak: 'break-all' as const,
+        pointerEvents: 'none',
+        userSelect: 'none' as const,
+      }}
+    >
+      {m.text}
+    </div>
+  </foreignObject>
+) : (
+```
+
+を以下に置換:
+
+```tsx
+{m.text ? (
+  <foreignObject x={mx} y={my} width={MEMO_W} height={mh}>
+    <MemoText text={m.text} color={T.memoText} />
+  </foreignObject>
+) : (
+```
+
+- [ ] **Step 4-2: import を追加**
+
+ファイル先頭の import 群（既存 `import` の塊）に以下を追記:
+
+```ts
+import { MemoText } from './components/MemoText'
+```
+
+- [ ] **Step 4-3: 既存 FlowEditor テスト群が pass することを確認**
+
+Run: `npx vitest run src/features/editor/FlowEditor.test.tsx`
+Expected: 全 pass（特に `textarea[placeholder="memoPlaceholder"]` セレクタの既存テスト＝インライン編集 textarea は無改修なので影響なし）。
+
+- [ ] **Step 4-4: コミット**
+
+```bash
+git add src/features/editor/FlowEditor.tsx
+git commit -m "refactor(#331): use MemoText for editor memo display"
+```
+
+---
+
+## Task 5: SharedFlowViewer を `MemoText` に置換
+
+**Files:**
+- Modify: `src/features/shared/SharedFlowViewer.tsx`（471-486）
+
+- [ ] **Step 5-1: 既存メモ表示の `<foreignObject>` ＋ `<div>` を `MemoText` に置換**
+
+`src/features/shared/SharedFlowViewer.tsx` の以下のブロック:
+
+```tsx
+<foreignObject x={mx} y={my} width={MEMO_W} height={mh}>
+  <div
+    style={{
+      fontSize: 11,
+      lineHeight: '1.55',
+      color: T.memoText,
+      fontFamily: 'inherit',
+      padding: '5px 8px',
+      wordBreak: 'break-all',
+      pointerEvents: 'none',
+      userSelect: 'none',
+    }}
+  >
+    {memo.text}
+  </div>
+</foreignObject>
+```
+
+を以下に置換:
+
+```tsx
+<foreignObject x={mx} y={my} width={MEMO_W} height={mh}>
+  <MemoText text={memo.text} color={T.memoText} />
+</foreignObject>
+```
+
+- [ ] **Step 5-2: import を追加**
+
+`SharedFlowViewer.tsx` の先頭 import 群に以下を追記:
+
+```ts
+import { MemoText } from '../editor/components/MemoText'
+```
+
+- [ ] **Step 5-3: 既存テストが pass することを確認**
+
+Run: `npx vitest run src/features/shared`
+Expected: 全 pass。
+
+- [ ] **Step 5-4: コミット**
+
+```bash
+git add src/features/shared/SharedFlowViewer.tsx
+git commit -m "refactor(#331): use MemoText for shared viewer memo display"
+```
+
+---
+
+## Task 6: 右パネルのメモ入力を `PanelTextarea` に置換
+
+**Files:**
+- Modify: `src/features/editor/components/RightPanel.tsx`（368 周辺）
+
+- [ ] **Step 6-1: `PanelInput` を `PanelTextarea(submitOnEnter=false, rows=3)` に置換**
+
+`src/features/editor/components/RightPanel.tsx` の以下のブロック:
+
+```tsx
+<PanelSection label={t('rightPanel.memo')}>
+  <PanelInput
+    value={memos[selTask]?.text || ''}
+    placeholder={t('rightPanel.memoPlaceholder')}
+    onChange={(v: string) =>
+      setMemos((p2) => {
+        if (!v) {
+          const n = { ...p2 }
+          delete n[selTask]
+          return n
+        }
+        return {
+          ...p2,
+          [selTask]: { ...(p2[selTask] || { dx: 50, dy: 46 }), text: v },
+        }
+      })
+    }
+```
+
+を以下に置換（閉じタグの位置は元のまま、`PanelInput` を `PanelTextarea` に変えて `submitOnEnter={false}` `rows={3}` を追加するだけ）:
+
+```tsx
+<PanelSection label={t('rightPanel.memo')}>
+  <PanelTextarea
+    value={memos[selTask]?.text || ''}
+    placeholder={t('rightPanel.memoPlaceholder')}
+    submitOnEnter={false}
+    rows={3}
+    onChange={(v: string) =>
+      setMemos((p2) => {
+        if (!v) {
+          const n = { ...p2 }
+          delete n[selTask]
+          return n
+        }
+        return {
+          ...p2,
+          [selTask]: { ...(p2[selTask] || { dx: 50, dy: 46 }), text: v },
+        }
+      })
+    }
+```
+
+(import 文 5 行目はすでに `PanelTextarea` を含むので追加不要)
+
+- [ ] **Step 6-2: 関連テストが pass することを確認**
+
+Run: `npx vitest run src/features/editor/FlowEditor.test.tsx`
+Expected: 全 pass。
+
+- [ ] **Step 6-3: コミット**
+
+```bash
+git add src/features/editor/components/RightPanel.tsx
+git commit -m "feat(#331): make right panel memo input multi-line"
+```
+
+---
+
+## Task 7: 統合テスト追加（FlowEditor）
+
+**Files:**
+- Modify: `src/features/editor/FlowEditor.test.tsx`
+
+- [ ] **Step 7-1: 統合テストを追加**
+
+`src/features/editor/FlowEditor.test.tsx` 末尾の最後の `describe` ブロック直後（最終 `})` 直前）に以下の `describe` を追加:
+
+```tsx
+describe('memo URL/newline rendering (#331)', () => {
+  function makeFlowWithNode() {
+    const flow = createMinimalFlow()
+    flow.nodes = [
+      { id: 'n1', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+    ]
+    return flow
+  }
+
+  function addMemoText(container: HTMLElement, text: string) {
+    const nodeRects = container.querySelectorAll('rect[rx="10"]')
+    const nodeRect = Array.from(nodeRects).find((r) => r.getAttribute('width') === '152')
+    expect(nodeRect).toBeTruthy()
+    fireEvent.click(nodeRect!)
+
+    const toolbarBtns = container.querySelectorAll('[data-testid="toolbar-btn"]')
+    expect(toolbarBtns.length).toBeGreaterThanOrEqual(2)
+    fireEvent.click(toolbarBtns[1])
+
+    const textarea = container.querySelector('textarea[placeholder="memoPlaceholder"]')
+    expect(textarea).toBeTruthy()
+    fireEvent.change(textarea!, { target: { value: text } })
+    fireEvent.blur(textarea!)
+  }
+
+  it('renders newline in memo text using whiteSpace pre-wrap', () => {
+    const flow = makeFlowWithNode()
+    const { container } = render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+    addMemoText(container, 'line1\nline2')
+
+    // Re-render shows MemoText container with whiteSpace pre-wrap
+    const memoNote = container.querySelector('[data-testid="memo-note"]')!
+    const memoDiv = memoNote.querySelector('foreignObject > div') as HTMLElement
+    expect(memoDiv).toBeTruthy()
+    expect(memoDiv.style.whiteSpace).toBe('pre-wrap')
+    expect(memoDiv.textContent).toContain('line1')
+    expect(memoDiv.textContent).toContain('line2')
+  })
+
+  it('renders an anchor element for https URL inside memo', () => {
+    const flow = makeFlowWithNode()
+    const { container } = render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+    addMemoText(container, 'click https://example.com please')
+
+    const memoNote = container.querySelector('[data-testid="memo-note"]')!
+    const link = memoNote.querySelector('a[href="https://example.com"]') as HTMLAnchorElement
+    expect(link).toBeTruthy()
+    expect(link.getAttribute('target')).toBe('_blank')
+    const rel = link.getAttribute('rel') ?? ''
+    expect(rel).toContain('noopener')
+    expect(rel).toContain('noreferrer')
+  })
+
+  it('right panel memo input is a textarea (multi-line)', () => {
+    const flow = makeFlowWithNode()
+    const { container } = render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+
+    const nodeRects = container.querySelectorAll('rect[rx="10"]')
+    const nodeRect = Array.from(nodeRects).find((r) => r.getAttribute('width') === '152')
+    fireEvent.click(nodeRect!)
+
+    const memoTextarea = container.querySelector(
+      'textarea[placeholder="rightPanel.memoPlaceholder"]',
+    )
+    expect(memoTextarea).toBeTruthy()
+    expect((memoTextarea as HTMLTextAreaElement).tagName).toBe('TEXTAREA')
+  })
+})
+```
+
+- [ ] **Step 7-2: 全テスト走らせて pass を確認**
+
+Run: `npm test -- --run`
+Expected: 全 pass（FAILが1つでもあれば次に進まない）。
+
+- [ ] **Step 7-3: コミット**
+
+```bash
+git add src/features/editor/FlowEditor.test.tsx
+git commit -m "test(#331): add integration tests for memo URL/newline"
+```
+
+---
+
+## Task 8: 全体回帰確認 & 本番ビルド
+
+**Files:** （ビルド／確認のみ）
+
+- [ ] **Step 8-1: lint と型チェック**
+
+Run: `npm run lint && npx tsc --noEmit`
+Expected: エラーなし。エラーが出たら **修正してから次へ**。
+
+- [ ] **Step 8-2: 全テストを最終実行**
+
+Run: `npm test -- --run`
+Expected: 全 pass（FAIL ゼロ）。
+
+- [ ] **Step 8-3: 本番ビルド**
+
+Run: `npm run build`
+Expected: 成功。
+
+- [ ] **Step 8-4: 本番プレビュー（preview skill）**
+
+Skill: `~/.claude/skills/preview/SKILL.md` の手順に従って起動し、以下を Playwright（または手動）で確認:
+
+  - エディタを開く → ノード選択 → 右パネル「メモ」欄に複数行＋URL を入力 → メモ吹き出しに改行とリンクが反映される
+  - リンククリック → 別タブで開く・ドラッグ／編集モードが起動しない
+  - 共有ビュー（公開リンク）でも改行・リンクが表示される
+  - LCP 1 秒以内（preview skill の計測手順に従う）
+
+スクリーンショットは `.screenshots/` に保存。
+
+不具合があれば Task 1〜7 のいずれかに戻り修正。
+
+---
+
+## Task 9: 最新 main 同期 → PR
+
+**Files:** （ブランチ運用のみ）
+
+- [ ] **Step 9-1: 最新 main にリベース**
+
+```bash
+git pull origin main --rebase
+npm test -- --run
+```
+Expected: 全 pass。コンフリクトがあれば解決して再テスト。
+
+- [ ] **Step 9-2: push と PR 作成**
+
+```bash
+git push -u origin feat/memo-url-newline-331
+gh pr create --title "feat(#331): make memo URLs clickable and reflect newlines" --body "$(cat <<'EOF'
+## Summary
+- メモ吹き出し内の `https?://` URL を別タブリンクに自動変換
+- メモの改行が表示・入力に反映されるように
+- 右パネルのメモ欄を複数行入力 (`PanelTextarea(submitOnEnter=false)`) に変更
+
+Closes #331
+
+## Test plan
+- [x] `splitTextWithUrls` の単体テスト（複数 URL／句読点除外／危険スキーム除外／改行）
+- [x] `MemoText` の単体テスト（`<a target=_blank rel=noopener noreferrer nofollow>`／pointer-events／whiteSpace pre-wrap／stopPropagation）
+- [x] `PanelTextarea` の `submitOnEnter` 切替テスト
+- [x] FlowEditor 統合テスト（改行表示・URL リンク化・右パネル textarea）
+- [x] 既存メモ関連テスト全 pass
+- [ ] Playwright 実画面確認（エディタ通常表示・共有ビュー・右パネル入力）
+EOF
+)"
+```
+
+- [ ] **Step 9-3: CI を待機**
+
+Run: `gh pr checks --watch`
+Expected: 全 pass。Fail があれば修正 → push → 再 watch。
+
+- [ ] **Step 9-4: レビュー依頼コメント**
+
+```bash
+gh pr comment --body '@claude PRをレビューして。
+以下の観点で確認すること：
+- バグ・ロジックの問題
+- コードの重複・共通化できる処理
+- 不要な複雑さ
+結果は最終行に [A:要修正] [B:条件つき承認] [C:承認OK] のいずれかで明記。'
+```
+
+- [ ] **Step 9-5: レビュー結果に応じて修正ループ（最大10回）**
+
+CLAUDE.md の Step 9 に従う。**[C:承認OK]** が出るまで `sleep 60` → `gh pr view --json comments` → 修正 → push を繰り返す。
+
+---
+
+## Task 10: Merge & Deploy 確認 & クリーンアップ
+
+**Files:** （Merge ／クリーンアップのみ）
+
+- [ ] **Step 10-1: Merge**
+
+```bash
+gh pr merge --merge
+sleep 30
+MAIN=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
+git -C "$MAIN" fetch origin main
+git -C "$MAIN" merge --ff-only origin/main
+```
+
+- [ ] **Step 10-2: Deploy 確認**
+
+`~/.claude/skills/deploy/SKILL.md` の手順を実行。
+
+- [ ] **Step 10-3: worktree 削除**
+
+```bash
+cd "$MAIN"
+git worktree remove .worktrees/feat-memo-url-newline-331
+git branch -d feat/memo-url-newline-331
+git worktree list
+```
+
+残骸が無いことを確認。
+
+---
+
+## 受け入れ条件（Spec 由来チェックリスト）
+
+- [ ] メモ内の `https?://...` がリンク表示になり、別タブで開く（Task 2/4/5/7 でカバー）
+- [ ] メモ内の改行が表示に反映される（エディタ通常表示・共有ビュー）（Task 2/4/5/7）
+- [ ] リンククリックでドラッグ・編集モードが起動しない（Task 2/8）
+- [ ] 右パネルの「メモ」欄で改行入力できる（Task 3/6/7）
+- [ ] エディタ通常表示・インライン編集後の表示・共有ビューの全てで動作（Task 4/5/8）
+- [ ] `parseNote` / `measureMemoHeight` の既存テストが通る（Task 1 で回帰確認、Task 8 で最終確認）
+- [ ] `MemoText` / `splitTextWithUrls` の単体テストを追加（Task 1/2）

--- a/docs/superpowers/plans/2026-04-30-memo-url-newline-plan.md
+++ b/docs/superpowers/plans/2026-04-30-memo-url-newline-plan.md
@@ -15,18 +15,18 @@
 
 ## File Structure
 
-| Path | Action | Responsibility |
-|---|---|---|
-| `src/features/editor/memo-utils.ts` | Modify | `splitTextWithUrls` と型 `MemoTextSegment` を追加 |
-| `src/features/editor/memo-utils.test.ts` | Modify | `splitTextWithUrls` の単体テストを追加 |
-| `src/features/editor/components/MemoText.tsx` | Create | 改行＋URL クリッカブル化を担うプレゼンテーショナルコンポーネント |
-| `src/features/editor/components/MemoText.test.tsx` | Create | `MemoText` の単体テスト |
-| `src/features/editor/components/PanelParts.tsx` | Modify | `PanelTextarea` に `submitOnEnter` オプション追加 |
-| `src/features/editor/components/PanelParts.test.tsx` | Create | `PanelTextarea` の挙動テスト |
-| `src/features/editor/FlowEditor.tsx` | Modify | 通常表示メモ（3487-3503）を `MemoText` に置換 |
-| `src/features/shared/SharedFlowViewer.tsx` | Modify | 共有ビューのメモ（471-486）を `MemoText` に置換 |
-| `src/features/editor/components/RightPanel.tsx` | Modify | メモ欄の `PanelInput` を `PanelTextarea (submitOnEnter=false)` に置換 |
-| `src/features/editor/FlowEditor.test.tsx` | Modify | 右パネル `<textarea>`／改行表示／URLリンク化の統合テストを追加 |
+| Path                                                 | Action | Responsibility                                                        |
+| ---------------------------------------------------- | ------ | --------------------------------------------------------------------- |
+| `src/features/editor/memo-utils.ts`                  | Modify | `splitTextWithUrls` と型 `MemoTextSegment` を追加                     |
+| `src/features/editor/memo-utils.test.ts`             | Modify | `splitTextWithUrls` の単体テストを追加                                |
+| `src/features/editor/components/MemoText.tsx`        | Create | 改行＋URL クリッカブル化を担うプレゼンテーショナルコンポーネント      |
+| `src/features/editor/components/MemoText.test.tsx`   | Create | `MemoText` の単体テスト                                               |
+| `src/features/editor/components/PanelParts.tsx`      | Modify | `PanelTextarea` に `submitOnEnter` オプション追加                     |
+| `src/features/editor/components/PanelParts.test.tsx` | Create | `PanelTextarea` の挙動テスト                                          |
+| `src/features/editor/FlowEditor.tsx`                 | Modify | 通常表示メモ（3487-3503）を `MemoText` に置換                         |
+| `src/features/shared/SharedFlowViewer.tsx`           | Modify | 共有ビューのメモ（471-486）を `MemoText` に置換                       |
+| `src/features/editor/components/RightPanel.tsx`      | Modify | メモ欄の `PanelInput` を `PanelTextarea (submitOnEnter=false)` に置換 |
+| `src/features/editor/FlowEditor.test.tsx`            | Modify | 右パネル `<textarea>`／改行表示／URLリンク化の統合テストを追加        |
 
 ---
 
@@ -81,6 +81,7 @@ Expected: 振る舞いベース／網羅すべきエッジケースのチェッ�
 ## Task 1: `splitTextWithUrls` の TDD
 
 **Files:**
+
 - Modify: `src/features/editor/memo-utils.test.ts`（末尾に追記）
 - Modify: `src/features/editor/memo-utils.ts`（末尾に追記）
 
@@ -224,6 +225,7 @@ git commit -m "feat(#331): add splitTextWithUrls util for memo URL detection"
 ## Task 2: `MemoText` コンポーネントの TDD
 
 **Files:**
+
 - Create: `src/features/editor/components/MemoText.tsx`
 - Create: `src/features/editor/components/MemoText.test.tsx`
 
@@ -386,6 +388,7 @@ git commit -m "feat(#331): add MemoText component with URL/newline rendering"
 ## Task 3: `PanelTextarea` の `submitOnEnter` 拡張
 
 **Files:**
+
 - Modify: `src/features/editor/components/PanelParts.tsx`
 - Create: `src/features/editor/components/PanelParts.test.tsx`
 
@@ -490,6 +493,7 @@ git commit -m "feat(#331): add submitOnEnter option to PanelTextarea"
 ## Task 4: FlowEditor 通常表示を `MemoText` に置換
 
 **Files:**
+
 - Modify: `src/features/editor/FlowEditor.tsx`（3487-3503）
 
 - [ ] **Step 4-1: 既存メモ表示の `<foreignObject>` ＋ `<div>` を `MemoText` に置換**
@@ -552,6 +556,7 @@ git commit -m "refactor(#331): use MemoText for editor memo display"
 ## Task 5: SharedFlowViewer を `MemoText` に置換
 
 **Files:**
+
 - Modify: `src/features/shared/SharedFlowViewer.tsx`（471-486）
 
 - [ ] **Step 5-1: 既存メモ表示の `<foreignObject>` ＋ `<div>` を `MemoText` に置換**
@@ -610,6 +615,7 @@ git commit -m "refactor(#331): use MemoText for shared viewer memo display"
 ## Task 6: 右パネルのメモ入力を `PanelTextarea` に置換
 
 **Files:**
+
 - Modify: `src/features/editor/components/RightPanel.tsx`（368 周辺）
 
 - [ ] **Step 6-1: `PanelInput` を `PanelTextarea(submitOnEnter=false, rows=3)` に置換**
@@ -679,6 +685,7 @@ git commit -m "feat(#331): make right panel memo input multi-line"
 ## Task 7: 統合テスト追加（FlowEditor）
 
 **Files:**
+
 - Modify: `src/features/editor/FlowEditor.test.tsx`
 
 - [ ] **Step 7-1: 統合テストを追加**
@@ -793,10 +800,10 @@ Expected: 成功。
 
 Skill: `~/.claude/skills/preview/SKILL.md` の手順に従って起動し、以下を Playwright（または手動）で確認:
 
-  - エディタを開く → ノード選択 → 右パネル「メモ」欄に複数行＋URL を入力 → メモ吹き出しに改行とリンクが反映される
-  - リンククリック → 別タブで開く・ドラッグ／編集モードが起動しない
-  - 共有ビュー（公開リンク）でも改行・リンクが表示される
-  - LCP 1 秒以内（preview skill の計測手順に従う）
+- エディタを開く → ノード選択 → 右パネル「メモ」欄に複数行＋URL を入力 → メモ吹き出しに改行とリンクが反映される
+- リンククリック → 別タブで開く・ドラッグ／編集モードが起動しない
+- 共有ビュー（公開リンク）でも改行・リンクが表示される
+- LCP 1 秒以内（preview skill の計測手順に従う）
 
 スクリーンショットは `.screenshots/` に保存。
 
@@ -814,6 +821,7 @@ Skill: `~/.claude/skills/preview/SKILL.md` の手順に従って起動し、以�
 git pull origin main --rebase
 npm test -- --run
 ```
+
 Expected: 全 pass。コンフリクトがあれば解決して再テスト。
 
 - [ ] **Step 9-2: push と PR 作成**

--- a/docs/superpowers/specs/2026-04-30-memo-url-newline-design.md
+++ b/docs/superpowers/specs/2026-04-30-memo-url-newline-design.md
@@ -51,8 +51,8 @@
 ```ts
 type Props = {
   text: string
-  color: string          // T.memoText
-  linkColor?: string     // 既存テーマがあれば流用、なければ color の派生
+  color: string // T.memoText
+  linkColor?: string // 既存テーマがあれば流用、なければ color の派生
 }
 ```
 
@@ -147,13 +147,13 @@ m.text → measureMemoHeight(text, MEMO_W) → mh (foreignObject の height)
 
 React は子要素の文字列を自動エスケープするため、`<MemoText>` の中で文字列をそのまま渡しても DOM injection は発生しない。今回追加されるリスクは `<a href={...}>` の `href` を URL に組み立てる箇所のみ。
 
-| 攻撃ベクタ | 防御 |
-|---|---|
+| 攻撃ベクタ                                       | 防御                                                                                                                                                     |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `javascript:alert(1)` を埋め込んでクリックさせる | 正規表現が `https?://` で始まる文字列のみマッチ。`javascript:` `data:` `file:` `vbscript:` は検出器を通らないため `<a>` にならず、ただのテキストになる。 |
-| 攻撃サイトへの誘導 | `target="_blank"` ＋ `rel="noopener noreferrer nofollow"` を必ず付ける。`opener` 経由のタブハイジャックを防ぐ。 |
-| URL 内に `"` `<` を埋めて属性を破る | React が属性値を自動エスケープするため `dangerouslySetInnerHTML` を使わない限り発生しない。本実装は `<a href={url}>` の JSX のみ。 |
-| 異常に長い URL ／壊れた URL | 正規表現でマッチしなければただのテキスト。マッチしても `<a>` として表示されるだけ。 |
-| 末尾句読点問題 | 正規表現の末尾クラスで `.,;:!?)\]'"` を除外。 |
+| 攻撃サイトへの誘導                               | `target="_blank"` ＋ `rel="noopener noreferrer nofollow"` を必ず付ける。`opener` 経由のタブハイジャックを防ぐ。                                          |
+| URL 内に `"` `<` を埋めて属性を破る              | React が属性値を自動エスケープするため `dangerouslySetInnerHTML` を使わない限り発生しない。本実装は `<a href={url}>` の JSX のみ。                       |
+| 異常に長い URL ／壊れた URL                      | 正規表現でマッチしなければただのテキスト。マッチしても `<a>` として表示されるだけ。                                                                      |
+| 末尾句読点問題                                   | 正規表現の末尾クラスで `.,;:!?)\]'"` を除外。                                                                                                            |
 
 ### イベント伝播の防御
 
@@ -168,12 +168,12 @@ onClick: (e) => e.stopPropagation()
 
 ### 失敗系の挙動
 
-| ケース | 挙動 |
-|---|---|
-| `text` が空文字 | `MemoText` は安全に空フラグメントを返す。呼び出し側は元から空時に `<text>memoClickToEdit</text>` 経路へ分岐済みで `MemoText` は呼ばれない。 |
-| `text` が極端に長い／URL だらけ | 既存の `wordBreak`/`overflowWrap` で折り返し、高さは `measureMemoHeight` がカバー（無改修で動く）。 |
-| `parseNote` が JSON parse 失敗 | 既存の try/catch がプレーンテキスト扱いに fall through（無改修）。 |
-| 右パネル textarea で巨大入力 | 既存 `setMemos` の更新を通るのみ。サイズ上限は今回スコープ外。 |
+| ケース                          | 挙動                                                                                                                                        |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `text` が空文字                 | `MemoText` は安全に空フラグメントを返す。呼び出し側は元から空時に `<text>memoClickToEdit</text>` 経路へ分岐済みで `MemoText` は呼ばれない。 |
+| `text` が極端に長い／URL だらけ | 既存の `wordBreak`/`overflowWrap` で折り返し、高さは `measureMemoHeight` がカバー（無改修で動く）。                                         |
+| `parseNote` が JSON parse 失敗  | 既存の try/catch がプレーンテキスト扱いに fall through（無改修）。                                                                          |
+| 右パネル textarea で巨大入力    | 既存 `setMemos` の更新を通るのみ。サイズ上限は今回スコープ外。                                                                              |
 
 ### 何をしないか
 

--- a/docs/superpowers/specs/2026-04-30-memo-url-newline-design.md
+++ b/docs/superpowers/specs/2026-04-30-memo-url-newline-design.md
@@ -1,0 +1,263 @@
+# メモのURLクリッカブル化と改行表示・入力の対応
+
+- Issue: https://github.com/tomohirof/flowline/issues/331
+- Date: 2026-04-30
+
+## 概要
+
+ノードに付随するメモ（黄色い吹き出し）について、以下3点を改善する。
+
+1. メモ内の URL（`https?://...`）を自動でリンク化し、クリックで新しいタブで開けるようにする
+2. メモ内の改行をそのまま表示に反映する（現状は改行が無視され詰めて表示される）
+3. 右パネルの「メモ」入力欄を複数行入力に変更する（現状は `<input>` のため改行不可）
+
+## 現状
+
+### 表示（3 か所すべて改行・URL 未対応）
+
+- `src/features/editor/FlowEditor.tsx:3487-3503` — エディタ通常表示
+- `src/features/editor/FlowEditor.tsx:3519-3570` — インライン編集 textarea（入力時は改行可）
+- `src/features/shared/SharedFlowViewer.tsx:471-486` — 共有ビュー
+
+すべて `<div>{memo.text}</div>` で出力しており、`whiteSpace` 指定なし＋URL はプレーンテキスト。表示要素は `pointerEvents: 'none'` / `userSelect: 'none'` で全体無効化されている。
+
+### 入力経路
+
+- ノードクリック → inline `<textarea>` → 改行入力 **可能**
+- 右パネル → `PanelInput`（`<input>`, `RightPanel.tsx:369`）→ 改行入力 **不可**
+
+### 高さ計算
+
+`measureMemoHeight()` は既に `\n` をカウント済み（`memo-utils.ts:48-51`）。表示側に `whiteSpace: 'pre-wrap'` を入れても高さは崩れない。
+
+## アーキテクチャ概要
+
+- 表示用ロジックは新設の純粋プレゼンテーショナルコンポーネント `MemoText` に集約。3 か所（FlowEditor 通常表示・FlowEditor インライン編集の **保存後表示**・SharedFlowViewer）はすべて `MemoText` 経由で描画する。
+- URL 検出は表示時のみ実施。永続化フォーマット（`MemoData.text` の文字列）は変更しない。`parseNote` / `serializeMemo` への変更ナシ。
+- 右パネルの単行 `<input>` は、既存 `PanelTextarea` に **`submitOnEnter?: boolean`（default `true`）** オプションを追加し、メモ欄では `submitOnEnter={false}` で利用する（インライン textarea と挙動を揃える）。
+
+### スコープ外（YAGNI）
+
+- マークダウンサポート（`**bold**` 等）
+- 自動 `mailto:` リンク化
+- URL 以外のリンク種別（`ftp://`, `tel:` など）
+
+## コンポーネント設計
+
+### 新設: `MemoText`
+
+配置: `src/features/editor/components/MemoText.tsx`
+
+```ts
+type Props = {
+  text: string
+  color: string          // T.memoText
+  linkColor?: string     // 既存テーマがあれば流用、なければ color の派生
+}
+```
+
+責務: プレーンテキストを受け取り、改行を保持しつつ URL を `<a>` 化した React ノード列を返す。コンテナの style（`fontSize/lineHeight/padding/wordBreak/pointerEvents/userSelect`）は呼び出し側ではなく `MemoText` 内部に集約し、3 か所で同じ見た目を強制する。
+
+実装の要点:
+
+- ルートは `<div style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', pointerEvents: 'none', userSelect: 'none', ... }}>`。
+  - 既存コードは `wordBreak: 'break-all'` だが、URL が意図せず途中改行されるのを避けるため `break-word` に変更。URL は `<a>` 側で `overflowWrap: 'anywhere'` を別途指定する。
+- 文字列は `splitTextWithUrls(text)` で `{ type: 'text' | 'url'; value: string }` の配列に分割。
+- `url` セグメントのみ `<a target="_blank" rel="noopener noreferrer nofollow"` ＋ `style={{ pointerEvents: 'auto', userSelect: 'auto', overflowWrap: 'anywhere' }}` ＋ `onMouseDown` / `onClick` で `e.stopPropagation()`。
+- 改行は `whiteSpace: 'pre-wrap'` で表現（明示的な `<br>` 挿入はしない）。
+
+### 新設: `splitTextWithUrls`
+
+配置: `src/features/editor/memo-utils.ts`（`measureMemoHeight` の隣）
+
+```ts
+export type MemoTextSegment = { type: 'text' | 'url'; value: string }
+export function splitTextWithUrls(text: string): MemoTextSegment[]
+```
+
+URL 検出正規表現の要点:
+
+- `https?://` で始まるもののみ対象（`javascript:` `data:` `file:` `vbscript:` 等は対象外）
+- 末尾の句読点・閉じ括弧 `.,;:!?)\]'"` は URL から除外（よくある「文末の `.` まで含めてしまう」問題対策）
+- 検出パターン: `/\bhttps?:\/\/[^\s<]+[^\s<.,;:!?)\]'"]/g`
+- 同一文字列内に複数 URL が含まれるケースに対応
+
+### 改修: `PanelTextarea`
+
+配置: `src/features/editor/components/PanelParts.tsx`
+
+```ts
+{ submitOnEnter?: boolean = true }   // 追加
+```
+
+- `false` のとき `onKeyDown` の Enter blur 処理をスキップ（IME 中は従来どおり処理しない）。
+- 既存呼び出し（説明欄ほか）はデフォルト `true` で挙動不変。
+
+### 改修: 3 か所の表示
+
+- `FlowEditor.tsx:3487-3503` → `<MemoText text={m.text} color={T.memoText} />` に置換
+- `SharedFlowViewer.tsx:471-486` → 同上
+- `FlowEditor.tsx:3519-3570`（インライン編集中） → textarea のまま改修なし（編集中はリンク化しない）
+
+### 改修: 右パネル
+
+- `RightPanel.tsx:368-` の `<PanelInput>` を `<PanelTextarea ... submitOnEnter={false} rows={3}>` に置換。
+
+## データフロー
+
+### 読み出し（DB → 画面）
+
+```
+notes(json text) → parseNote → MemoData{ text, dx, dy } → setMemos
+                                                        ↓
+                                           (a) FlowEditor 通常表示    → MemoText
+                                           (b) FlowEditor インライン編集 → <textarea>（無改修）
+                                           (c) SharedFlowViewer       → MemoText
+```
+
+`MemoText` は `text: string` のみを入力に取り、`splitTextWithUrls(text)` でセグメント分割→React ノード列に写像する純粋関数的なレンダリング。永続化される文字列は **生のままのプレーンテキスト**（URL は `https://...` の文字列のまま）。
+
+### 書き込み（画面 → DB）
+
+```
+(a) ノードクリック inline <textarea>  ─┐
+                                       ├→ setMemos({ text }) → serializeMemo → notes(json)
+(b) 右パネル <PanelTextarea>          ─┘
+```
+
+両入力経路ともに `MemoData.text` に **改行を含む素のユーザ入力文字列** を書き込むだけ。`serializeMemo` は `JSON.stringify` するため、改行（`\n`）は JSON 仕様で `\\n` として安全にエスケープされ、ラウンドトリップで失われない（既存挙動）。
+
+### 高さ計算（読み出し時の派生）
+
+```
+m.text → measureMemoHeight(text, MEMO_W) → mh (foreignObject の height)
+```
+
+`measureMemoHeight` は既に `\n` を split して行数加算しているため、改行が増えても表示が切れない。今回 `whiteSpace: 'pre-wrap'` を導入しても改行は `\n` の数だけ既に勘定済み、URL リンク化は文字列長を変えない（`<a>` でラップするだけ）→ **既存高さ計算は無改修で正しく動く**。
+
+### 入力時の Enter 挙動
+
+- `PanelTextarea(submitOnEnter={false})` は Enter で何もせず、textarea のデフォルトの「改行挿入」が走る。
+- 確定タイミング: textarea の `onBlur`（外側クリック・別フィールドへの移動）。
+- IME 変換中の Enter は、A 案では submit を行わないため特別ハンドリング不要（`isComposing` 判定は `submitOnEnter=true` 経路のみ意味を持つ）。
+
+## エラーハンドリング・セキュリティ
+
+### URL 検出の XSS 耐性
+
+React は子要素の文字列を自動エスケープするため、`<MemoText>` の中で文字列をそのまま渡しても DOM injection は発生しない。今回追加されるリスクは `<a href={...}>` の `href` を URL に組み立てる箇所のみ。
+
+| 攻撃ベクタ | 防御 |
+|---|---|
+| `javascript:alert(1)` を埋め込んでクリックさせる | 正規表現が `https?://` で始まる文字列のみマッチ。`javascript:` `data:` `file:` `vbscript:` は検出器を通らないため `<a>` にならず、ただのテキストになる。 |
+| 攻撃サイトへの誘導 | `target="_blank"` ＋ `rel="noopener noreferrer nofollow"` を必ず付ける。`opener` 経由のタブハイジャックを防ぐ。 |
+| URL 内に `"` `<` を埋めて属性を破る | React が属性値を自動エスケープするため `dangerouslySetInnerHTML` を使わない限り発生しない。本実装は `<a href={url}>` の JSX のみ。 |
+| 異常に長い URL ／壊れた URL | 正規表現でマッチしなければただのテキスト。マッチしても `<a>` として表示されるだけ。 |
+| 末尾句読点問題 | 正規表現の末尾クラスで `.,;:!?)\]'"` を除外。 |
+
+### イベント伝播の防御
+
+`MemoText` の `<a>` は次のハンドラを持つ:
+
+```ts
+onMouseDown: (e) => e.stopPropagation()
+onClick: (e) => e.stopPropagation()
+```
+
+これにより、メモ用 `<g>` の親に登録されたドラッグ開始・編集モード起動・選択解除等の SVG イベントがバブルアップしない。`pointerEvents: 'none'` を親に持つ表示でも、`<a>` だけ `pointerEvents: 'auto'` を上書きしているのでクリック自体は `<a>` で受ける。
+
+### 失敗系の挙動
+
+| ケース | 挙動 |
+|---|---|
+| `text` が空文字 | `MemoText` は安全に空フラグメントを返す。呼び出し側は元から空時に `<text>memoClickToEdit</text>` 経路へ分岐済みで `MemoText` は呼ばれない。 |
+| `text` が極端に長い／URL だらけ | 既存の `wordBreak`/`overflowWrap` で折り返し、高さは `measureMemoHeight` がカバー（無改修で動く）。 |
+| `parseNote` が JSON parse 失敗 | 既存の try/catch がプレーンテキスト扱いに fall through（無改修）。 |
+| 右パネル textarea で巨大入力 | 既存 `setMemos` の更新を通るのみ。サイズ上限は今回スコープ外。 |
+
+### 何をしないか
+
+- URL の妥当性チェック（DNS や到達性）
+- リンクのプレビュー／OGP 取得
+- `mailto:` / `tel:` の自動リンク化
+- マークダウンリンク `[text](url)` 構文サポート
+
+## テスト戦略
+
+### 単体テスト（vitest）
+
+#### `src/features/editor/memo-utils.test.ts`（既存ファイルに追記）
+
+`splitTextWithUrls`:
+
+- URL なしの素テキスト → `[{ type: 'text', value: 入力 }]`
+- 単一 URL → `text` / `url` セグメントに分割される
+- 文中に複数 URL → 順番に正しく交互分割される
+- 連続 URL（`https://a.com https://b.com`）も両方検出される
+- URL 末尾の `.` `,` `)` などはリンクに含まれない（句読点除外）
+- `https://example.com/path?q=1&r=2#frag` のクエリ・フラグメントを保持
+- `javascript:alert(1)` / `data:text/html,...` / `file:///etc/passwd` は URL 扱いしない
+- スキームのみ（`http://` 単独）はマッチさせない／ホスト 1 文字以上を要求
+- 改行を含む文字列でも改行をまたいで URL を誤検出しない（`\s` で停止）
+- 全角空白・タブを区切りとして扱う
+- 空文字 `""` の挙動を実装に合わせて assert する
+
+#### `src/features/editor/components/MemoText.test.tsx`（新規）
+
+`@testing-library/react` で DOM を検証:
+
+- プレーンテキストのみ → `<a>` が出現せず、テキストがそのまま入る
+- URL を含む → `<a href={url}>` が生成される
+- `<a>` に `target="_blank"` と `rel` に `noopener noreferrer nofollow` がすべて含まれる
+- `<a>` の `style.pointerEvents === 'auto'`、`userSelect === 'auto'`
+- `javascript:` 等の危険スキームは `<a>` にならずテキストのまま
+- 改行を含む `text` でルートの `style.whiteSpace === 'pre-wrap'`
+- `<a>` を `mouseDown` / `click` した際に `stopPropagation` が呼ばれる
+
+#### `PanelTextarea`（既存テスト or 新規 `PanelParts.test.tsx`）
+
+- `submitOnEnter` 未指定（既定 `true`）で Enter キー → blur 発火（既存挙動）
+- `submitOnEnter={false}` で Enter キー → blur せず、`onChange` で改行が入る
+
+### 統合テスト
+
+#### `src/features/editor/FlowEditor.test.tsx`（既存に追記）
+
+- 右パネルのメモ欄が `<textarea>` でレンダリングされる（`PanelTextarea` への変更確認）
+- 右パネルで複数行入力 → エディタ通常表示にも改行が反映される（`whiteSpace: pre-wrap` のスタイル確認 or 行高さ確認）
+- メモテキストに `https://` を含むと `<a>` 要素がエディタ通常表示に出現する
+
+#### `SharedFlowViewer.test.tsx`（存在する場合は追記）
+
+- 共有ビューでも URL が `<a target="_blank">` 化される
+
+### 既存テストの非破壊確認
+
+- `parseNote` / `serializeMemo` テスト全通過（無改修）
+- `measureMemoHeight` テスト全通過（無改修）
+- 既存 `FlowEditor.test.tsx` の `textarea[placeholder="memoPlaceholder"]` セレクタ（`FlowEditor.test.tsx:3033`）が依然マッチすることを確認
+
+### Playwright（実画面検証 — 実装後 Step6）
+
+- 右パネルメモ欄に複数行＋URL 入力 → メモ吹き出しに改行とリンクが表示
+- リンククリック → 新しいタブで開く、ノードの編集モード起動・ドラッグ開始しない
+- 共有ビュー（公開リンク）でも同様にリンク・改行表示
+- エディタ通常表示・インライン編集後の表示・共有ビューの 3 か所すべてで動作
+
+### TDD 順序
+
+1. `splitTextWithUrls` の test を Red → 実装
+2. `MemoText` の test を Red → 実装
+3. `PanelTextarea` の `submitOnEnter` 拡張 test を Red → 実装
+4. 3 か所差し替え＋右パネル差し替え（既存テスト Green 維持）
+5. FlowEditor 統合テスト追加 → 確認
+
+## 受け入れ条件
+
+- [ ] メモ内の `https?://...` がリンク表示になり、別タブで開く
+- [ ] メモ内の改行が表示に反映される（エディタ通常表示・共有ビュー）
+- [ ] リンククリックでドラッグ・編集モードが起動しない
+- [ ] 右パネルの「メモ」欄で改行入力できる
+- [ ] エディタ通常表示・インライン編集後の表示・共有ビューの全てで動作
+- [ ] `parseNote` / `measureMemoHeight` の既存テストが通る
+- [ ] `MemoText` / `splitTextWithUrls` の単体テストを追加（URL 検出、複数 URL、改行、危険スキーム除外）

--- a/src/features/editor/FlowEditor.test.tsx
+++ b/src/features/editor/FlowEditor.test.tsx
@@ -3245,3 +3245,71 @@ describe('bidirectional arrow toggle (RightPanel)', () => {
     expect(bodyArrows.length).toBe(0)
   })
 })
+
+describe('memo URL/newline rendering (#331)', () => {
+  function makeFlowWithNode() {
+    const flow = createMinimalFlow()
+    flow.nodes = [
+      { id: 'n1', laneId: 'lane-1', rowIndex: 0, label: 'A', note: null, orderIndex: 0 },
+    ]
+    return flow
+  }
+
+  function addMemoText(container: HTMLElement, text: string) {
+    const nodeRects = container.querySelectorAll('rect[rx="10"]')
+    const nodeRect = Array.from(nodeRects).find((r) => r.getAttribute('width') === '152')
+    expect(nodeRect).toBeTruthy()
+    fireEvent.click(nodeRect!)
+
+    const toolbarBtns = container.querySelectorAll('[data-testid="toolbar-btn"]')
+    expect(toolbarBtns.length).toBeGreaterThanOrEqual(2)
+    fireEvent.click(toolbarBtns[1])
+
+    const textarea = container.querySelector('textarea[placeholder="memoPlaceholder"]')
+    expect(textarea).toBeTruthy()
+    fireEvent.change(textarea!, { target: { value: text } })
+    fireEvent.blur(textarea!)
+  }
+
+  it('renders newline in memo text using whiteSpace pre-wrap', () => {
+    const flow = makeFlowWithNode()
+    const { container } = render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+    addMemoText(container, 'line1\nline2')
+
+    const memoNote = container.querySelector('[data-testid="memo-note"]')!
+    const memoDiv = memoNote.querySelector('foreignObject > div') as HTMLElement
+    expect(memoDiv).toBeTruthy()
+    expect(memoDiv.style.whiteSpace).toBe('pre-wrap')
+    expect(memoDiv.textContent).toContain('line1')
+    expect(memoDiv.textContent).toContain('line2')
+  })
+
+  it('renders an anchor element for https URL inside memo', () => {
+    const flow = makeFlowWithNode()
+    const { container } = render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+    addMemoText(container, 'click https://example.com please')
+
+    const memoNote = container.querySelector('[data-testid="memo-note"]')!
+    const link = memoNote.querySelector('a[href="https://example.com"]') as HTMLAnchorElement
+    expect(link).toBeTruthy()
+    expect(link.getAttribute('target')).toBe('_blank')
+    const rel = link.getAttribute('rel') ?? ''
+    expect(rel).toContain('noopener')
+    expect(rel).toContain('noreferrer')
+  })
+
+  it('right panel memo input is a textarea (multi-line)', () => {
+    const flow = makeFlowWithNode()
+    const { container } = render(<FlowEditor flow={flow} onSave={vi.fn()} saveStatus="saved" />)
+
+    const nodeRects = container.querySelectorAll('rect[rx="10"]')
+    const nodeRect = Array.from(nodeRects).find((r) => r.getAttribute('width') === '152')
+    fireEvent.click(nodeRect!)
+
+    const memoTextarea = container.querySelector(
+      'textarea[placeholder="rightPanel.memoPlaceholder"]',
+    )
+    expect(memoTextarea).toBeTruthy()
+    expect((memoTextarea as HTMLTextAreaElement).tagName).toBe('TEXTAREA')
+  })
+})

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -39,6 +39,7 @@ import { DS, collectObstacles, type Bbox, type ObstacleNode } from '../../lib/ar
 import { useToast } from './hooks/useToast'
 import { ToastList } from './components/Toast'
 import { I, Ico } from './components/EditorIcons'
+import { MemoText } from './components/MemoText'
 import { RightPanel } from './components/RightPanel'
 import { useArrows } from './hooks/useArrows'
 import { useMoveAutoRepair } from './hooks/useMoveAutoRepair'
@@ -3486,20 +3487,7 @@ export default function FlowEditor({
                       )}
                       {m.text ? (
                         <foreignObject x={mx} y={my} width={MEMO_W} height={mh}>
-                          <div
-                            style={{
-                              fontSize: 11,
-                              lineHeight: '1.55',
-                              color: T.memoText,
-                              fontFamily: 'inherit',
-                              padding: '5px 8px',
-                              wordBreak: 'break-all' as const,
-                              pointerEvents: 'none',
-                              userSelect: 'none' as const,
-                            }}
-                          >
-                            {m.text}
-                          </div>
+                          <MemoText text={m.text} color={T.memoText} />
                         </foreignObject>
                       ) : (
                         <text

--- a/src/features/editor/components/MemoText.test.tsx
+++ b/src/features/editor/components/MemoText.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, fireEvent, cleanup } from '@testing-library/react'
+import { MemoText } from './MemoText'
+
+afterEach(() => cleanup())
+
+describe('MemoText', () => {
+  it('renders plain text without anchor when no URL is present', () => {
+    const { container, queryByRole } = render(<MemoText text="just plain text" color="#000" />)
+    expect(queryByRole('link')).toBeNull()
+    expect(container.textContent).toBe('just plain text')
+  })
+
+  it('renders an anchor for an https URL', () => {
+    const { getByRole } = render(<MemoText text="visit https://example.com" color="#000" />)
+    const link = getByRole('link') as HTMLAnchorElement
+    expect(link.getAttribute('href')).toBe('https://example.com')
+  })
+
+  it('sets target=_blank and a strict rel', () => {
+    const { getByRole } = render(<MemoText text="https://example.com" color="#000" />)
+    const link = getByRole('link') as HTMLAnchorElement
+    expect(link.getAttribute('target')).toBe('_blank')
+    const rel = link.getAttribute('rel') ?? ''
+    expect(rel).toContain('noopener')
+    expect(rel).toContain('noreferrer')
+    expect(rel).toContain('nofollow')
+  })
+
+  it('makes the anchor pointer-interactive even though container is non-interactive', () => {
+    const { container, getByRole } = render(<MemoText text="https://example.com" color="#000" />)
+    const root = container.firstChild as HTMLElement
+    expect(root.style.pointerEvents).toBe('none')
+    expect(root.style.userSelect).toBe('none')
+
+    const link = getByRole('link') as HTMLAnchorElement
+    expect(link.style.pointerEvents).toBe('auto')
+    expect(link.style.userSelect).toBe('auto')
+  })
+
+  it('uses pre-wrap whiteSpace so newlines are preserved', () => {
+    const { container } = render(<MemoText text={'line1\nline2'} color="#000" />)
+    const root = container.firstChild as HTMLElement
+    expect(root.style.whiteSpace).toBe('pre-wrap')
+  })
+
+  it('does NOT linkify dangerous schemes', () => {
+    const { queryByRole, container } = render(
+      <MemoText text="javascript:alert(1) data:text/html,x" color="#000" />,
+    )
+    expect(queryByRole('link')).toBeNull()
+    expect(container.textContent).toBe('javascript:alert(1) data:text/html,x')
+  })
+
+  it('stops mousedown and click propagation on the anchor', () => {
+    const onParentMouseDown = vi.fn()
+    const onParentClick = vi.fn()
+    const { getByRole } = render(
+      <div onMouseDown={onParentMouseDown} onClick={onParentClick}>
+        <MemoText text="https://example.com" color="#000" />
+      </div>,
+    )
+    const link = getByRole('link') as HTMLAnchorElement
+    fireEvent.mouseDown(link)
+    fireEvent.click(link)
+    expect(onParentMouseDown).not.toHaveBeenCalled()
+    expect(onParentClick).not.toHaveBeenCalled()
+  })
+
+  it('renders nothing visible for empty text', () => {
+    const { container } = render(<MemoText text="" color="#000" />)
+    expect(container.textContent).toBe('')
+  })
+})

--- a/src/features/editor/components/MemoText.tsx
+++ b/src/features/editor/components/MemoText.tsx
@@ -1,0 +1,51 @@
+import { Fragment } from 'react'
+import { splitTextWithUrls } from '../memo-utils'
+
+type Props = {
+  text: string
+  color: string
+  linkColor?: string
+}
+
+export function MemoText({ text, color, linkColor }: Props) {
+  const segments = splitTextWithUrls(text)
+  return (
+    <div
+      style={{
+        fontSize: 11,
+        lineHeight: '1.55',
+        color,
+        fontFamily: 'inherit',
+        padding: '5px 8px',
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word',
+        pointerEvents: 'none',
+        userSelect: 'none',
+      }}
+    >
+      {segments.map((seg, i) =>
+        seg.type === 'url' ? (
+          <a
+            key={i}
+            href={seg.value}
+            target="_blank"
+            rel="noopener noreferrer nofollow"
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              color: linkColor ?? color,
+              textDecoration: 'underline',
+              pointerEvents: 'auto',
+              userSelect: 'auto',
+              overflowWrap: 'anywhere',
+            }}
+          >
+            {seg.value}
+          </a>
+        ) : (
+          <Fragment key={i}>{seg.value}</Fragment>
+        ),
+      )}
+    </div>
+  )
+}

--- a/src/features/editor/components/MemoText.tsx
+++ b/src/features/editor/components/MemoText.tsx
@@ -4,10 +4,9 @@ import { splitTextWithUrls } from '../memo-utils'
 type Props = {
   text: string
   color: string
-  linkColor?: string
 }
 
-export function MemoText({ text, color, linkColor }: Props) {
+export function MemoText({ text, color }: Props) {
   const segments = splitTextWithUrls(text)
   return (
     <div
@@ -33,7 +32,7 @@ export function MemoText({ text, color, linkColor }: Props) {
             onMouseDown={(e) => e.stopPropagation()}
             onClick={(e) => e.stopPropagation()}
             style={{
-              color: linkColor ?? color,
+              color,
               textDecoration: 'underline',
               pointerEvents: 'auto',
               userSelect: 'auto',

--- a/src/features/editor/components/PanelParts.test.tsx
+++ b/src/features/editor/components/PanelParts.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, fireEvent, cleanup } from '@testing-library/react'
+import { PanelTextarea } from './PanelParts'
+
+afterEach(() => cleanup())
+
+describe('PanelTextarea', () => {
+  it('blurs on Enter when submitOnEnter is unset (default true)', () => {
+    const onChange = vi.fn()
+    const { container } = render(<PanelTextarea value="" onChange={onChange} />)
+    const ta = container.querySelector('textarea') as HTMLTextAreaElement
+    ta.focus()
+    expect(document.activeElement).toBe(ta)
+    fireEvent.keyDown(ta, { key: 'Enter' })
+    expect(document.activeElement).not.toBe(ta)
+  })
+
+  it('does NOT blur on Enter when submitOnEnter is false', () => {
+    const onChange = vi.fn()
+    const { container } = render(
+      <PanelTextarea value="" onChange={onChange} submitOnEnter={false} />,
+    )
+    const ta = container.querySelector('textarea') as HTMLTextAreaElement
+    ta.focus()
+    expect(document.activeElement).toBe(ta)
+    fireEvent.keyDown(ta, { key: 'Enter' })
+    expect(document.activeElement).toBe(ta)
+  })
+
+  it('does not blur during IME composition even when submitOnEnter is true', () => {
+    const onChange = vi.fn()
+    const { container } = render(<PanelTextarea value="" onChange={onChange} />)
+    const ta = container.querySelector('textarea') as HTMLTextAreaElement
+    ta.focus()
+    fireEvent.keyDown(ta, { key: 'Enter', isComposing: true })
+    expect(document.activeElement).toBe(ta)
+  })
+})

--- a/src/features/editor/components/PanelParts.tsx
+++ b/src/features/editor/components/PanelParts.tsx
@@ -37,11 +37,13 @@ export const PanelTextarea = ({
   onChange,
   placeholder,
   rows = 2,
+  submitOnEnter = true,
 }: {
   value: string
   onChange: (v: string) => void
   placeholder?: string
   rows?: number
+  submitOnEnter?: boolean
 }) => (
   <textarea
     value={value}
@@ -51,6 +53,7 @@ export const PanelTextarea = ({
     className={styles.panelTextarea}
     onKeyDown={(e) => {
       if (e.nativeEvent.isComposing) return
+      if (!submitOnEnter) return
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault()
         ;(e.currentTarget as HTMLTextAreaElement).blur()

--- a/src/features/editor/components/RightPanel.tsx
+++ b/src/features/editor/components/RightPanel.tsx
@@ -366,9 +366,11 @@ export const RightPanel = ({
           </div>
         </PanelSection>
         <PanelSection label={t('rightPanel.memo')}>
-          <PanelInput
+          <PanelTextarea
             value={memos[selTask]?.text || ''}
             placeholder={t('rightPanel.memoPlaceholder')}
+            submitOnEnter={false}
+            rows={3}
             onChange={(v: string) =>
               setMemos((p2) => {
                 if (!v) {

--- a/src/features/editor/memo-utils.test.ts
+++ b/src/features/editor/memo-utils.test.ts
@@ -89,3 +89,87 @@ describe('MEMO_W', () => {
     expect(MEMO_W).toBe(152)
   })
 })
+
+import { splitTextWithUrls } from './memo-utils'
+
+describe('splitTextWithUrls', () => {
+  it('returns single text segment when input has no URLs', () => {
+    expect(splitTextWithUrls('hello world')).toEqual([{ type: 'text', value: 'hello world' }])
+  })
+
+  it('returns empty array for empty string', () => {
+    expect(splitTextWithUrls('')).toEqual([])
+  })
+
+  it('detects a single https URL in the middle of text', () => {
+    expect(splitTextWithUrls('see https://example.com here')).toEqual([
+      { type: 'text', value: 'see ' },
+      { type: 'url', value: 'https://example.com' },
+      { type: 'text', value: ' here' },
+    ])
+  })
+
+  it('detects http and multiple URLs in order', () => {
+    expect(splitTextWithUrls('a http://a.com b https://b.com c')).toEqual([
+      { type: 'text', value: 'a ' },
+      { type: 'url', value: 'http://a.com' },
+      { type: 'text', value: ' b ' },
+      { type: 'url', value: 'https://b.com' },
+      { type: 'text', value: ' c' },
+    ])
+  })
+
+  it('preserves query and fragment', () => {
+    const url = 'https://example.com/path?q=1&r=2#frag'
+    expect(splitTextWithUrls(`x ${url} y`)).toEqual([
+      { type: 'text', value: 'x ' },
+      { type: 'url', value: url },
+      { type: 'text', value: ' y' },
+    ])
+  })
+
+  it('excludes trailing punctuation from the URL', () => {
+    expect(splitTextWithUrls('see https://example.com.')).toEqual([
+      { type: 'text', value: 'see ' },
+      { type: 'url', value: 'https://example.com' },
+      { type: 'text', value: '.' },
+    ])
+    expect(splitTextWithUrls('(https://example.com)')).toEqual([
+      { type: 'text', value: '(' },
+      { type: 'url', value: 'https://example.com' },
+      { type: 'text', value: ')' },
+    ])
+  })
+
+  it('does NOT match dangerous schemes', () => {
+    expect(splitTextWithUrls('javascript:alert(1)')).toEqual([
+      { type: 'text', value: 'javascript:alert(1)' },
+    ])
+    expect(splitTextWithUrls('data:text/html,foo')).toEqual([
+      { type: 'text', value: 'data:text/html,foo' },
+    ])
+    expect(splitTextWithUrls('file:///etc/passwd')).toEqual([
+      { type: 'text', value: 'file:///etc/passwd' },
+    ])
+  })
+
+  it('does not match scheme-only without host', () => {
+    expect(splitTextWithUrls('http://')).toEqual([{ type: 'text', value: 'http://' }])
+  })
+
+  it('does not span URL across newlines', () => {
+    expect(splitTextWithUrls('see https://example.com\nnext line')).toEqual([
+      { type: 'text', value: 'see ' },
+      { type: 'url', value: 'https://example.com' },
+      { type: 'text', value: '\nnext line' },
+    ])
+  })
+
+  it('treats full-width spaces and tabs as separators', () => {
+    expect(splitTextWithUrls('a\thttps://example.com\tb')).toEqual([
+      { type: 'text', value: 'a\t' },
+      { type: 'url', value: 'https://example.com' },
+      { type: 'text', value: '\tb' },
+    ])
+  })
+})

--- a/src/features/editor/memo-utils.test.ts
+++ b/src/features/editor/memo-utils.test.ts
@@ -169,6 +169,36 @@ describe('splitTextWithUrls', () => {
     ])
   })
 
+  it('keeps balanced parentheses inside the URL (Wikipedia-style)', () => {
+    const url = 'https://en.wikipedia.org/wiki/Python_(programming_language)'
+    expect(splitTextWithUrls(`see ${url} here`)).toEqual([
+      { type: 'text', value: 'see ' },
+      { type: 'url', value: url },
+      { type: 'text', value: ' here' },
+    ])
+  })
+
+  it('strips only unbalanced trailing close parens from a URL', () => {
+    // Outer parens around URL — trailing ) is unbalanced relative to the URL's content
+    expect(splitTextWithUrls('see (https://example.com) here')).toEqual([
+      { type: 'text', value: 'see (' },
+      { type: 'url', value: 'https://example.com' },
+      { type: 'text', value: ') here' },
+    ])
+    // URL ends with ) AND has matching ( inside — keep the )
+    expect(splitTextWithUrls('see https://en.wikipedia.org/wiki/Brace_(punctuation) here')).toEqual([
+      { type: 'text', value: 'see ' },
+      { type: 'url', value: 'https://en.wikipedia.org/wiki/Brace_(punctuation)' },
+      { type: 'text', value: ' here' },
+    ])
+    // Outer parens around a Wikipedia URL — only the OUTER ) is unbalanced
+    expect(splitTextWithUrls('(https://en.wikipedia.org/wiki/Python_(programming_language))')).toEqual([
+      { type: 'text', value: '(' },
+      { type: 'url', value: 'https://en.wikipedia.org/wiki/Python_(programming_language)' },
+      { type: 'text', value: ')' },
+    ])
+  })
+
   it('treats full-width spaces and tabs as separators', () => {
     expect(splitTextWithUrls('a\thttps://example.com\tb')).toEqual([
       { type: 'text', value: 'a\t' },

--- a/src/features/editor/memo-utils.test.ts
+++ b/src/features/editor/memo-utils.test.ts
@@ -186,13 +186,17 @@ describe('splitTextWithUrls', () => {
       { type: 'text', value: ') here' },
     ])
     // URL ends with ) AND has matching ( inside — keep the )
-    expect(splitTextWithUrls('see https://en.wikipedia.org/wiki/Brace_(punctuation) here')).toEqual([
-      { type: 'text', value: 'see ' },
-      { type: 'url', value: 'https://en.wikipedia.org/wiki/Brace_(punctuation)' },
-      { type: 'text', value: ' here' },
-    ])
+    expect(splitTextWithUrls('see https://en.wikipedia.org/wiki/Brace_(punctuation) here')).toEqual(
+      [
+        { type: 'text', value: 'see ' },
+        { type: 'url', value: 'https://en.wikipedia.org/wiki/Brace_(punctuation)' },
+        { type: 'text', value: ' here' },
+      ],
+    )
     // Outer parens around a Wikipedia URL — only the OUTER ) is unbalanced
-    expect(splitTextWithUrls('(https://en.wikipedia.org/wiki/Python_(programming_language))')).toEqual([
+    expect(
+      splitTextWithUrls('(https://en.wikipedia.org/wiki/Python_(programming_language))'),
+    ).toEqual([
       { type: 'text', value: '(' },
       { type: 'url', value: 'https://en.wikipedia.org/wiki/Python_(programming_language)' },
       { type: 'text', value: ')' },

--- a/src/features/editor/memo-utils.test.ts
+++ b/src/features/editor/memo-utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { parseNote, serializeMemo, measureMemoHeight, MEMO_W } from './memo-utils'
+import {
+  parseNote,
+  serializeMemo,
+  measureMemoHeight,
+  MEMO_W,
+  splitTextWithUrls,
+} from './memo-utils'
 import type { MemoData } from './types'
 
 describe('parseNote', () => {
@@ -90,8 +96,6 @@ describe('MEMO_W', () => {
   })
 })
 
-import { splitTextWithUrls } from './memo-utils'
-
 describe('splitTextWithUrls', () => {
   it('returns single text segment when input has no URLs', () => {
     expect(splitTextWithUrls('hello world')).toEqual([{ type: 'text', value: 'hello world' }])
@@ -170,6 +174,11 @@ describe('splitTextWithUrls', () => {
       { type: 'text', value: 'a\t' },
       { type: 'url', value: 'https://example.com' },
       { type: 'text', value: '\tb' },
+    ])
+    expect(splitTextWithUrls('a　https://example.com　b')).toEqual([
+      { type: 'text', value: 'a　' },
+      { type: 'url', value: 'https://example.com' },
+      { type: 'text', value: '　b' },
     ])
   })
 })

--- a/src/features/editor/memo-utils.ts
+++ b/src/features/editor/memo-utils.ts
@@ -50,3 +50,25 @@ export function measureMemoHeight(text: string, width: number): number {
     .reduce((a, l) => a + Math.max(1, Math.ceil((estimateTextWidth(l) || 1) / cpl)), 0)
   return Math.max(30, lines * 17 + 14)
 }
+
+export type MemoTextSegment = { type: 'text' | 'url'; value: string }
+
+const URL_REGEX = /\bhttps?:\/\/[^\s<]+[^\s<.,;:!?)\]'"]/g
+
+export function splitTextWithUrls(text: string): MemoTextSegment[] {
+  if (!text) return []
+  const segments: MemoTextSegment[] = []
+  let last = 0
+  for (const match of text.matchAll(URL_REGEX)) {
+    const start = match.index ?? 0
+    if (start > last) {
+      segments.push({ type: 'text', value: text.slice(last, start) })
+    }
+    segments.push({ type: 'url', value: match[0] })
+    last = start + match[0].length
+  }
+  if (last < text.length) {
+    segments.push({ type: 'text', value: text.slice(last) })
+  }
+  return segments
+}

--- a/src/features/editor/memo-utils.ts
+++ b/src/features/editor/memo-utils.ts
@@ -53,7 +53,18 @@ export function measureMemoHeight(text: string, width: number): number {
 
 type MemoTextSegment = { type: 'text' | 'url'; value: string }
 
-const URL_REGEX = /\bhttps?:\/\/[^\s<]+[^\s<.,;:!?)\]'"]/g
+const URL_REGEX = /\bhttps?:\/\/[^\s<]+[^\s<.,;:!?\]'"]/g
+
+function trimUnbalancedTrailingParens(url: string): string {
+  let trimmed = url
+  while (trimmed.endsWith(')')) {
+    const opens = (trimmed.match(/\(/g) ?? []).length
+    const closes = (trimmed.match(/\)/g) ?? []).length
+    if (closes <= opens) break
+    trimmed = trimmed.slice(0, -1)
+  }
+  return trimmed
+}
 
 export function splitTextWithUrls(text: string): MemoTextSegment[] {
   if (!text) return []
@@ -61,11 +72,12 @@ export function splitTextWithUrls(text: string): MemoTextSegment[] {
   let last = 0
   for (const match of text.matchAll(URL_REGEX)) {
     const start = match.index ?? 0
+    const url = trimUnbalancedTrailingParens(match[0])
     if (start > last) {
       segments.push({ type: 'text', value: text.slice(last, start) })
     }
-    segments.push({ type: 'url', value: match[0] })
-    last = start + match[0].length
+    segments.push({ type: 'url', value: url })
+    last = start + url.length
   }
   if (last < text.length) {
     segments.push({ type: 'text', value: text.slice(last) })

--- a/src/features/editor/memo-utils.ts
+++ b/src/features/editor/memo-utils.ts
@@ -51,7 +51,7 @@ export function measureMemoHeight(text: string, width: number): number {
   return Math.max(30, lines * 17 + 14)
 }
 
-export type MemoTextSegment = { type: 'text' | 'url'; value: string }
+type MemoTextSegment = { type: 'text' | 'url'; value: string }
 
 const URL_REGEX = /\bhttps?:\/\/[^\s<]+[^\s<.,;:!?)\]'"]/g
 

--- a/src/features/shared/SharedFlowViewer.tsx
+++ b/src/features/shared/SharedFlowViewer.tsx
@@ -20,6 +20,7 @@ import {
 import { formatRelativeTime } from '../../lib/relative-time'
 import { isGroupSub, isGroupParent, getGroupWidth } from '../../lib/lane-group-utils'
 import { parseNote, measureMemoHeight, MEMO_W } from '../editor/memo-utils'
+import { MemoText } from '../editor/components/MemoText'
 import { TeaserModal } from './TeaserModal'
 import { BottomCTABar } from './BottomCTABar'
 
@@ -469,20 +470,7 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
                           style={{ filter: 'drop-shadow(0 1px 3px rgba(180,160,0,0.08))' }}
                         />
                         <foreignObject x={mx} y={my} width={MEMO_W} height={mh}>
-                          <div
-                            style={{
-                              fontSize: 11,
-                              lineHeight: '1.55',
-                              color: T.memoText,
-                              fontFamily: 'inherit',
-                              padding: '5px 8px',
-                              wordBreak: 'break-all',
-                              pointerEvents: 'none',
-                              userSelect: 'none',
-                            }}
-                          >
-                            {memo.text}
-                          </div>
+                          <MemoText text={memo.text} color={T.memoText} />
                         </foreignObject>
                       </g>
                     )


### PR DESCRIPTION
## Summary
- メモ吹き出し内の `https?://` URL を別タブリンクに自動変換（XSS対策込み: `https?://` のみ、`rel="noopener noreferrer nofollow"`、`target="_blank"`）
- メモの改行が表示・入力に反映される（`whiteSpace: pre-wrap`）
- 右パネルのメモ欄を複数行入力 `<PanelTextarea submitOnEnter={false} rows={3}>` に変更
- 表示ロジックは新設の `MemoText` コンポーネントに集約。FlowEditor通常表示と SharedFlowViewer の2か所で共通化
- 永続化フォーマット（`MemoData.text`）と高さ計算（`measureMemoHeight`）は無改修

Closes #331

## Implementation
- 新設: `splitTextWithUrls` 純粋関数（`memo-utils.ts`）— `javascript:`/`data:`/`file:` などの危険スキーム除外、末尾句読点除外
- 新設: `MemoText` コンポーネント — `<a>` のみ `pointerEvents:auto`、親イベントを `stopPropagation` でブロック
- 拡張: `PanelTextarea` に `submitOnEnter?: boolean = true` オプション追加（既存呼び出し挙動は不変）

## Test plan
- [x] `splitTextWithUrls` の単体テスト（11件: 複数URL／句読点除外／危険スキーム除外／改行をまたがない／全角空白・タブ）
- [x] `MemoText` の単体テスト（8件: `<a target=_blank rel=noopener noreferrer nofollow>`／pointer-events／whiteSpace pre-wrap／stopPropagation／空文字）
- [x] `PanelTextarea` の `submitOnEnter` 切替テスト（3件: 既定blur／false非blur／IME中blur抑止）
- [x] FlowEditor 統合テスト（3件: 改行表示／URL リンク化／右パネル textarea）
- [x] 既存メモ関連テスト全 pass（`parseNote` / `serializeMemo` / `measureMemoHeight` 無改修）
- [x] フルテスト 1517 pass / 1 skip
- [x] `npx tsc --noEmit` 緑
- [x] `npm run build` 成功

## Manual verification (PR レビュー時)
- [ ] 右パネルメモ欄に複数行＋URL を入力 → メモ吹き出しに改行とリンクが反映される
- [ ] リンククリック → 新しいタブで開く、ノードのドラッグ／編集モードが起動しない
- [ ] 共有ビュー（公開リンク）でも改行・リンクが表示される
- [ ] LCP 1秒以内

🤖 Generated with [Claude Code](https://claude.com/claude-code)