### PR TITLE
feat(#333): vertical (same-lane) arrow detour

### DIFF
--- a/docs/superpowers/plans/2026-04-30-vertical-arrow-detour-plan.md
+++ b/docs/superpowers/plans/2026-04-30-vertical-arrow-detour-plan.md
@@ -43,18 +43,19 @@ cat ~/.claude/rules/testing.md
 
 ## File Structure
 
-| ファイル | 役割 | 変更種別 |
-|---|---|---|
-| `src/lib/arrow-routing.ts` | 矢印パス計算ロジック | Modify (追加: `detectVerticalDetour`, `collectVerticalObstacles`, `buildArrowPath` dispatch) |
-| `src/lib/arrow-routing.test.ts` | ユニットテスト | Modify (追加: 縦方向テスト 14 件 + collectVerticalObstacles テスト 4 件) |
-| `src/features/editor/FlowEditor.tsx` | エディタ本体 | Modify (`aPath` の obstacles 組み立て) |
-| `src/features/shared/SharedFlowViewer.tsx` | 共有ビューア | Modify (`computeArrowPath` の obstacles 組み立て) |
+| ファイル                                   | 役割                 | 変更種別                                                                                     |
+| ------------------------------------------ | -------------------- | -------------------------------------------------------------------------------------------- |
+| `src/lib/arrow-routing.ts`                 | 矢印パス計算ロジック | Modify (追加: `detectVerticalDetour`, `collectVerticalObstacles`, `buildArrowPath` dispatch) |
+| `src/lib/arrow-routing.test.ts`            | ユニットテスト       | Modify (追加: 縦方向テスト 14 件 + collectVerticalObstacles テスト 4 件)                     |
+| `src/features/editor/FlowEditor.tsx`       | エディタ本体         | Modify (`aPath` の obstacles 組み立て)                                                       |
+| `src/features/shared/SharedFlowViewer.tsx` | 共有ビューア         | Modify (`computeArrowPath` の obstacles 組み立て)                                            |
 
 ---
 
 ## Task 1: detectVerticalDetour 基本ロジック（TDD）
 
 **Files:**
+
 - Test: `src/lib/arrow-routing.test.ts` (末尾に新 describe を追加)
 - Modify: `src/lib/arrow-routing.ts`
 
@@ -108,11 +109,7 @@ npm test -- arrow-routing.test
 `src/lib/arrow-routing.ts` の `detectDetour` 関数の **直後** に追加:
 
 ```ts
-function detectVerticalDetour(
-  s: Point,
-  e: Point,
-  obstacles: Bbox[],
-): { detourX: number } | null {
+function detectVerticalDetour(s: Point, e: Point, obstacles: Bbox[]): { detourX: number } | null {
   // 垂直直線でなければ迂回しない
   if (Math.abs(e.x - s.x) >= 2) return null
 
@@ -157,32 +154,32 @@ function detectVerticalDetour(
 `src/lib/arrow-routing.ts` の `buildArrowPath` 内、既存の水平迂回ブロック直後に追加。具体的には、既存の `if (obstacles && obstacles.length > 0)` ブロック内で、水平 detour が null だったら垂直 detour を試す形にする:
 
 ```ts
-  // 迂回モード: 同一行/同一レーンで経路上に障害ノードがある場合
-  if (obstacles && obstacles.length > 0) {
-    const detour = detectDetour(s, e, obstacles)
-    if (detour) {
-      const { detourY } = detour
-      const sign = Math.sign(dx)
-      const halfDx = Math.abs(dx) / 2
-      const departX = s.x + sign * Math.min(DEPART_GAP, halfDx)
-      const approachX = e.x - sign * Math.min(APPROACH_GAP, halfDx)
-      const d = `M${s.x},${s.y} L${departX},${s.y} L${departX},${detourY} L${approachX},${detourY} L${approachX},${e.y} L${e.x},${e.y}`
-      return { d, mx: (s.x + e.x) / 2, my: detourY }
-    }
-    const vDetour = detectVerticalDetour(s, e, obstacles)
-    if (vDetour) {
-      const { detourX } = vDetour
-      // |e.y - s.y| / 2 で clamp（横版と対称な防御コード）
-      const sign = Math.sign(dy)
-      const halfDy = Math.abs(dy) / 2
-      const departY = s.y + sign * Math.min(DEPART_GAP, halfDy)
-      const approachY = e.y - sign * Math.min(APPROACH_GAP, halfDy)
-      // 6 セグメント: M → 垂直(departY まで) → 水平(detourX まで) → 垂直(approachY まで)
-      //               → 水平(e.x まで=s.x なので戻る) → 垂直(e.y へ進入)
-      const d = `M${s.x},${s.y} L${s.x},${departY} L${detourX},${departY} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
-      return { d, mx: detourX, my: (s.y + e.y) / 2 }
-    }
+// 迂回モード: 同一行/同一レーンで経路上に障害ノードがある場合
+if (obstacles && obstacles.length > 0) {
+  const detour = detectDetour(s, e, obstacles)
+  if (detour) {
+    const { detourY } = detour
+    const sign = Math.sign(dx)
+    const halfDx = Math.abs(dx) / 2
+    const departX = s.x + sign * Math.min(DEPART_GAP, halfDx)
+    const approachX = e.x - sign * Math.min(APPROACH_GAP, halfDx)
+    const d = `M${s.x},${s.y} L${departX},${s.y} L${departX},${detourY} L${approachX},${detourY} L${approachX},${e.y} L${e.x},${e.y}`
+    return { d, mx: (s.x + e.x) / 2, my: detourY }
   }
+  const vDetour = detectVerticalDetour(s, e, obstacles)
+  if (vDetour) {
+    const { detourX } = vDetour
+    // |e.y - s.y| / 2 で clamp（横版と対称な防御コード）
+    const sign = Math.sign(dy)
+    const halfDy = Math.abs(dy) / 2
+    const departY = s.y + sign * Math.min(DEPART_GAP, halfDy)
+    const approachY = e.y - sign * Math.min(APPROACH_GAP, halfDy)
+    // 6 セグメント: M → 垂直(departY まで) → 水平(detourX まで) → 垂直(approachY まで)
+    //               → 水平(e.x まで=s.x なので戻る) → 垂直(e.y へ進入)
+    const d = `M${s.x},${s.y} L${s.x},${departY} L${detourX},${departY} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
+    return { d, mx: detourX, my: (s.y + e.y) / 2 }
+  }
+}
 ```
 
 - [ ] **Step 5: テスト pass を確認**
@@ -216,6 +213,7 @@ EOF
 直右にノードがあるとき左迂回、両塞がりで右優先になることを検証。
 
 **Files:**
+
 - Test: `src/lib/arrow-routing.test.ts`
 
 - [ ] **Step 1: 失敗テストを追加**
@@ -223,22 +221,22 @@ EOF
 Task 1 で追加した `describe('buildArrowPath - 縦方向迂回（同一レーン）', () => {...})` の中に追加:
 
 ```ts
-  it('同一列・障害1個・直右塞がり → 左迂回（detourX = 障害左端 - 14）', () => {
-    const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
-    const Bright: Bbox = { x: 284, y: 400, w: 152, h: 56 }
-    const r = buildArrowPath(s, e, fc, tc, [B, Bright])
-    // detourX = 200 - 76 - 14 = 110
-    expect(r.d).toBe('M200,228 L200,242 L110,242 L110,558 L200,558 L200,572')
-    expect(r.mx).toBe(110)
-  })
+it('同一列・障害1個・直右塞がり → 左迂回（detourX = 障害左端 - 14）', () => {
+  const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+  const Bright: Bbox = { x: 284, y: 400, w: 152, h: 56 }
+  const r = buildArrowPath(s, e, fc, tc, [B, Bright])
+  // detourX = 200 - 76 - 14 = 110
+  expect(r.d).toBe('M200,228 L200,242 L110,242 L110,558 L200,558 L200,572')
+  expect(r.mx).toBe(110)
+})
 
-  it('同一列・障害1個・両塞がり → 右優先で右迂回', () => {
-    const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
-    const Bright: Bbox = { x: 284, y: 400, w: 152, h: 56 }
-    const Bleft: Bbox = { x: 116, y: 400, w: 152, h: 56 }
-    const r = buildArrowPath(s, e, fc, tc, [B, Bright, Bleft])
-    expect(r.mx).toBe(290)
-  })
+it('同一列・障害1個・両塞がり → 右優先で右迂回', () => {
+  const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+  const Bright: Bbox = { x: 284, y: 400, w: 152, h: 56 }
+  const Bleft: Bbox = { x: 116, y: 400, w: 152, h: 56 }
+  const r = buildArrowPath(s, e, fc, tc, [B, Bright, Bleft])
+  expect(r.mx).toBe(290)
+})
 ```
 
 - [ ] **Step 2: テストを実行して PASS を確認**
@@ -266,6 +264,7 @@ EOF
 ## Task 3: detectVerticalDetour 複数障害・方向・エッジ（TDD）
 
 **Files:**
+
 - Test: `src/lib/arrow-routing.test.ts`
 
 - [ ] **Step 1: 残りのテストケースを追加**
@@ -273,75 +272,75 @@ EOF
 Task 1 で追加した describe 内に以下を追加:
 
 ```ts
-  it('同一列・障害2個・右空き → まとめて右迂回（detourX は最右端の最大）', () => {
-    const B: Bbox = { x: 200, y: 380, w: 152, h: 56 }
-    const C2: Bbox = { x: 200, y: 480, w: 200, h: 56 }
-    const sExt = { x: 200, y: 228 }
-    const eExt = { x: 200, y: 624 }
-    const r = buildArrowPath(sExt, eExt, { x: 200, y: 200 }, { x: 200, y: 700 }, [B, C2])
-    // 最右端: max(200+76, 200+100) = 300, +14 = 314
-    expect(r.mx).toBe(314)
-    expect(r.d).toBe('M200,228 L200,242 L314,242 L314,610 L200,610 L200,624')
-  })
+it('同一列・障害2個・右空き → まとめて右迂回（detourX は最右端の最大）', () => {
+  const B: Bbox = { x: 200, y: 380, w: 152, h: 56 }
+  const C2: Bbox = { x: 200, y: 480, w: 200, h: 56 }
+  const sExt = { x: 200, y: 228 }
+  const eExt = { x: 200, y: 624 }
+  const r = buildArrowPath(sExt, eExt, { x: 200, y: 200 }, { x: 200, y: 700 }, [B, C2])
+  // 最右端: max(200+76, 200+100) = 300, +14 = 314
+  expect(r.mx).toBe(314)
+  expect(r.d).toBe('M200,228 L200,242 L314,242 L314,610 L200,610 L200,624')
+})
 
-  it('同一列・障害2個・1つだけ直右塞がり → 左迂回', () => {
-    const B: Bbox = { x: 200, y: 380, w: 152, h: 56 }
-    const C2: Bbox = { x: 200, y: 480, w: 152, h: 56 }
-    const Bright: Bbox = { x: 284, y: 380, w: 152, h: 56 }
-    const sExt = { x: 200, y: 228 }
-    const eExt = { x: 200, y: 624 }
-    const r = buildArrowPath(sExt, eExt, { x: 200, y: 200 }, { x: 200, y: 700 }, [B, C2, Bright])
-    // 最左端: min(200-76, 200-76) = 124, -14 = 110
-    expect(r.mx).toBe(110)
-  })
+it('同一列・障害2個・1つだけ直右塞がり → 左迂回', () => {
+  const B: Bbox = { x: 200, y: 380, w: 152, h: 56 }
+  const C2: Bbox = { x: 200, y: 480, w: 152, h: 56 }
+  const Bright: Bbox = { x: 284, y: 380, w: 152, h: 56 }
+  const sExt = { x: 200, y: 228 }
+  const eExt = { x: 200, y: 624 }
+  const r = buildArrowPath(sExt, eExt, { x: 200, y: 200 }, { x: 200, y: 700 }, [B, C2, Bright])
+  // 最左端: min(200-76, 200-76) = 124, -14 = 110
+  expect(r.mx).toBe(110)
+})
 
-  it('同一列・障害なし（経路上に bbox がない）→ 直線', () => {
-    const farUp: Bbox = { x: 200, y: 100, w: 152, h: 56 }
-    const farDown: Bbox = { x: 200, y: 700, w: 152, h: 56 }
-    const r = buildArrowPath(s, e, fc, tc, [farUp, farDown])
-    expect(r.d).toBe('M200,228 L200,572')
-  })
+it('同一列・障害なし（経路上に bbox がない）→ 直線', () => {
+  const farUp: Bbox = { x: 200, y: 100, w: 152, h: 56 }
+  const farDown: Bbox = { x: 200, y: 700, w: 152, h: 56 }
+  const r = buildArrowPath(s, e, fc, tc, [farUp, farDown])
+  expect(r.d).toBe('M200,228 L200,572')
+})
 
-  it('斜め方向（dx >= 2）→ 既存の Z/L 字ロジック（縦迂回しない）', () => {
-    const sDiag = { x: 200, y: 228 }
-    const eDiag = { x: 300, y: 572 }
-    const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
-    const r = buildArrowPath(sDiag, eDiag, { x: 200, y: 200 }, { x: 300, y: 600 }, [B])
-    // 縦迂回特有のセグメント L${detourX},242 等が出ないことを確認
-    expect(r.d).not.toContain('L290,242')
-  })
+it('斜め方向（dx >= 2）→ 既存の Z/L 字ロジック（縦迂回しない）', () => {
+  const sDiag = { x: 200, y: 228 }
+  const eDiag = { x: 300, y: 572 }
+  const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+  const r = buildArrowPath(sDiag, eDiag, { x: 200, y: 200 }, { x: 300, y: 600 }, [B])
+  // 縦迂回特有のセグメント L${detourX},242 等が出ないことを確認
+  expect(r.d).not.toContain('L290,242')
+})
 
-  it('始終点が同じ Y（自己参照） → inCol 空 → 直線', () => {
-    const B: Bbox = { x: 200, y: 200, w: 152, h: 56 }
-    const r = buildArrowPath(
-      { x: 200, y: 200 },
-      { x: 200, y: 200 },
-      { x: 200, y: 200 },
-      { x: 200, y: 200 },
-      [B],
-    )
-    expect(r.d).toBe('M200,200 L200,200')
-  })
+it('始終点が同じ Y（自己参照） → inCol 空 → 直線', () => {
+  const B: Bbox = { x: 200, y: 200, w: 152, h: 56 }
+  const r = buildArrowPath(
+    { x: 200, y: 200 },
+    { x: 200, y: 200 },
+    { x: 200, y: 200 },
+    { x: 200, y: 200 },
+    [B],
+  )
+  expect(r.d).toBe('M200,200 L200,200')
+})
 
-  it('from/to 自身の bbox が混入しても Y±1 マージンで除外される', () => {
-    const fromSelfBbox: Bbox = { x: 200, y: 200, w: 152, h: 56 }
-    const toSelfBbox: Bbox = { x: 200, y: 600, w: 152, h: 56 }
-    const r = buildArrowPath(s, e, fc, tc, [fromSelfBbox, toSelfBbox])
-    expect(r.d).toBe('M200,228 L200,572')
-  })
+it('from/to 自身の bbox が混入しても Y±1 マージンで除外される', () => {
+  const fromSelfBbox: Bbox = { x: 200, y: 200, w: 152, h: 56 }
+  const toSelfBbox: Bbox = { x: 200, y: 600, w: 152, h: 56 }
+  const r = buildArrowPath(s, e, fc, tc, [fromSelfBbox, toSelfBbox])
+  expect(r.d).toBe('M200,228 L200,572')
+})
 
-  it('同一列・下→上方向でも右迂回する（s.y > e.y）', () => {
-    // s と e を逆転
-    const sR = { x: 200, y: 572 }
-    const eR = { x: 200, y: 228 }
-    const fcR = { x: 200, y: 600 }
-    const tcR = { x: 200, y: 200 }
-    const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
-    const r = buildArrowPath(sR, eR, fcR, tcR, [B])
-    // sign=-1, departY=572-14=558, approachY=228+14=242
-    expect(r.d).toBe('M200,572 L200,558 L290,558 L290,242 L200,242 L200,228')
-    expect(r.mx).toBe(290)
-  })
+it('同一列・下→上方向でも右迂回する（s.y > e.y）', () => {
+  // s と e を逆転
+  const sR = { x: 200, y: 572 }
+  const eR = { x: 200, y: 228 }
+  const fcR = { x: 200, y: 600 }
+  const tcR = { x: 200, y: 200 }
+  const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+  const r = buildArrowPath(sR, eR, fcR, tcR, [B])
+  // sign=-1, departY=572-14=558, approachY=228+14=242
+  expect(r.d).toBe('M200,572 L200,558 L290,558 L290,242 L200,242 L200,228')
+  expect(r.mx).toBe(290)
+})
 ```
 
 - [ ] **Step 2: テストを実行して PASS を確認**
@@ -369,6 +368,7 @@ EOF
 ## Task 4: 6 セグメント形状＋自己交差防止 clamp（TDD）
 
 **Files:**
+
 - Test: `src/lib/arrow-routing.test.ts`
 
 - [ ] **Step 1: テスト追加**
@@ -376,43 +376,43 @@ EOF
 Task 1 の describe ブロックの末尾に追加:
 
 ```ts
-  describe('垂直進入＋垂直 depart（始終点とも垂直）', () => {
-    it('右迂回パスは 6 セグメントで最初と最終セグメントが垂直', () => {
-      const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
-      const r = buildArrowPath(s, e, fc, tc, [B])
-      const segments = r.d.match(/[ML][^ML]+/g) ?? []
-      expect(segments).toHaveLength(6)
-      // 最初のセグメント（M→L）は垂直: M の X と次の L の X が同じ
-      const first = segments[0]
-      const second = segments[1]
-      const firstX = Number(first.slice(1).split(',')[0])
-      const secondX = Number(second.slice(1).split(',')[0])
-      expect(firstX).toBe(secondX)
-      expect(firstX).toBe(s.x)
-      // 最終セグメントは垂直
-      const last = segments[segments.length - 1]
-      const prev = segments[segments.length - 2]
-      const lastX = Number(last.slice(1).split(',')[0])
-      const prevX = Number(prev.slice(1).split(',')[0])
-      expect(lastX).toBe(prevX)
-      expect(lastX).toBe(e.x)
-    })
-
-    it('垂直距離が DEPART_GAP*2 未満の場合 departY/approachY は中央で接合し自己交差しない', () => {
-      // 垂直距離=20, DEPART_GAP=APPROACH_GAP=14。Math.min(14, 10) で 10 に clamp される
-      // s=(200,100), e=(200,120) で間に B (200,110) を置いて迂回を強制
-      const sN = { x: 200, y: 100 }
-      const eN = { x: 200, y: 120 }
-      const fcN = { x: 200, y: 80 }
-      const tcN = { x: 200, y: 140 }
-      const B: Bbox = { x: 200, y: 110, w: 152, h: 16 }
-      const r = buildArrowPath(sN, eN, fcN, tcN, [B])
-      // departY = 100 + 1 * Math.min(14, 10) = 110
-      // approachY = 120 - 1 * Math.min(14, 10) = 110
-      // detourX = 200 + 76 + 14 = 290
-      expect(r.d).toBe('M200,100 L200,110 L290,110 L290,110 L200,110 L200,120')
-    })
+describe('垂直進入＋垂直 depart（始終点とも垂直）', () => {
+  it('右迂回パスは 6 セグメントで最初と最終セグメントが垂直', () => {
+    const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B])
+    const segments = r.d.match(/[ML][^ML]+/g) ?? []
+    expect(segments).toHaveLength(6)
+    // 最初のセグメント（M→L）は垂直: M の X と次の L の X が同じ
+    const first = segments[0]
+    const second = segments[1]
+    const firstX = Number(first.slice(1).split(',')[0])
+    const secondX = Number(second.slice(1).split(',')[0])
+    expect(firstX).toBe(secondX)
+    expect(firstX).toBe(s.x)
+    // 最終セグメントは垂直
+    const last = segments[segments.length - 1]
+    const prev = segments[segments.length - 2]
+    const lastX = Number(last.slice(1).split(',')[0])
+    const prevX = Number(prev.slice(1).split(',')[0])
+    expect(lastX).toBe(prevX)
+    expect(lastX).toBe(e.x)
   })
+
+  it('垂直距離が DEPART_GAP*2 未満の場合 departY/approachY は中央で接合し自己交差しない', () => {
+    // 垂直距離=20, DEPART_GAP=APPROACH_GAP=14。Math.min(14, 10) で 10 に clamp される
+    // s=(200,100), e=(200,120) で間に B (200,110) を置いて迂回を強制
+    const sN = { x: 200, y: 100 }
+    const eN = { x: 200, y: 120 }
+    const fcN = { x: 200, y: 80 }
+    const tcN = { x: 200, y: 140 }
+    const B: Bbox = { x: 200, y: 110, w: 152, h: 16 }
+    const r = buildArrowPath(sN, eN, fcN, tcN, [B])
+    // departY = 100 + 1 * Math.min(14, 10) = 110
+    // approachY = 120 - 1 * Math.min(14, 10) = 110
+    // detourX = 200 + 76 + 14 = 290
+    expect(r.d).toBe('M200,100 L200,110 L290,110 L290,110 L200,110 L200,120')
+  })
+})
 ```
 
 - [ ] **Step 2: テストを実行**
@@ -440,6 +440,7 @@ EOF
 ## Task 5: collectVerticalObstacles ヘルパー（TDD）
 
 **Files:**
+
 - Test: `src/lib/arrow-routing.test.ts`
 - Modify: `src/lib/arrow-routing.ts`
 
@@ -642,6 +643,7 @@ EOF
 ## Task 6: FlowEditor.aPath を縦方向対応
 
 **Files:**
+
 - Modify: `src/features/editor/FlowEditor.tsx`
 
 - [ ] **Step 1: import 文を更新**
@@ -663,33 +665,33 @@ import {
 `src/features/editor/FlowEditor.tsx` の `aPath` 関数内（line 1384-1398 付近）を以下に置き換え:
 
 ```ts
-    // 同一行/同一レーンのときに obstacles を組み立てる（迂回判定用）
-    let obstacles: Bbox[] | undefined
-    if (fri === tri) {
-      obstacles = collectObstacles({
-        nodes: obstacleNodes,
-        fromKey: arrow.from,
-        toKey: arrow.to,
-        fromCx: from.x,
-        toCx: to.x,
-        rowY: from.y,
-        rowH: RH,
-        bboxW: TW,
-        bboxH: TH,
-      })
-    } else if (fli === tli) {
-      obstacles = collectVerticalObstacles({
-        nodes: obstacleNodes,
-        fromKey: arrow.from,
-        toKey: arrow.to,
-        fromCy: from.y,
-        toCy: to.y,
-        colX: from.x,
-        colW: LW + G,
-        bboxW: TW,
-        bboxH: TH,
-      })
-    }
+// 同一行/同一レーンのときに obstacles を組み立てる（迂回判定用）
+let obstacles: Bbox[] | undefined
+if (fri === tri) {
+  obstacles = collectObstacles({
+    nodes: obstacleNodes,
+    fromKey: arrow.from,
+    toKey: arrow.to,
+    fromCx: from.x,
+    toCx: to.x,
+    rowY: from.y,
+    rowH: RH,
+    bboxW: TW,
+    bboxH: TH,
+  })
+} else if (fli === tli) {
+  obstacles = collectVerticalObstacles({
+    nodes: obstacleNodes,
+    fromKey: arrow.from,
+    toKey: arrow.to,
+    fromCy: from.y,
+    toCy: to.y,
+    colX: from.x,
+    colW: LW + G,
+    bboxW: TW,
+    bboxH: TH,
+  })
+}
 ```
 
 `LW` と `G` はこのスコープで利用可能（line 678: `const LW = ...`, line 677: `G = T.laneGap`）。
@@ -722,6 +724,7 @@ EOF
 ## Task 7: SharedFlowViewer.computeArrowPath を縦方向対応
 
 **Files:**
+
 - Modify: `src/features/shared/SharedFlowViewer.tsx`
 
 - [ ] **Step 1: import 文を更新**
@@ -747,33 +750,33 @@ import {
 line 131-145 付近の `if (fromNode.rowIndex === toNode.rowIndex) { ... }` ブロックを以下に置き換え:
 
 ```ts
-    // 同一行/同一レーンのときに obstacles を組み立てる（迂回判定用）
-    let obstacles: Bbox[] | undefined
-    if (fromNode.rowIndex === toNode.rowIndex) {
-      obstacles = collectObstacles({
-        nodes: obstacleNodes,
-        fromKey: fromNode.id,
-        toKey: toNode.id,
-        fromCx: f.x,
-        toCx: t.x,
-        rowY: f.y,
-        rowH: RH,
-        bboxW: TW,
-        bboxH: TH,
-      })
-    } else if (fromNode.laneId === toNode.laneId) {
-      obstacles = collectVerticalObstacles({
-        nodes: obstacleNodes,
-        fromKey: fromNode.id,
-        toKey: toNode.id,
-        fromCy: f.y,
-        toCy: t.y,
-        colX: f.x,
-        colW: LW + G,
-        bboxW: TW,
-        bboxH: TH,
-      })
-    }
+// 同一行/同一レーンのときに obstacles を組み立てる（迂回判定用）
+let obstacles: Bbox[] | undefined
+if (fromNode.rowIndex === toNode.rowIndex) {
+  obstacles = collectObstacles({
+    nodes: obstacleNodes,
+    fromKey: fromNode.id,
+    toKey: toNode.id,
+    fromCx: f.x,
+    toCx: t.x,
+    rowY: f.y,
+    rowH: RH,
+    bboxW: TW,
+    bboxH: TH,
+  })
+} else if (fromNode.laneId === toNode.laneId) {
+  obstacles = collectVerticalObstacles({
+    nodes: obstacleNodes,
+    fromKey: fromNode.id,
+    toKey: toNode.id,
+    fromCy: f.y,
+    toCy: t.y,
+    colX: f.x,
+    colW: LW + G,
+    bboxW: TW,
+    bboxH: TH,
+  })
+}
 ```
 
 `LW` と `G` はこのスコープで利用可能（line 81 付近: `const LW = ...`, `G = T.laneGap` 相当）。確認のため line 70-90 を読み、利用可能な変数名と一致するよう調整。

--- a/docs/superpowers/plans/2026-04-30-vertical-arrow-detour-plan.md
+++ b/docs/superpowers/plans/2026-04-30-vertical-arrow-detour-plan.md
@@ -1,0 +1,917 @@
+# 縦方向（同一レーン）の矢印迂回 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 同一レーン（縦方向）で A→C の直線パス上に他ノードがあるとき、右優先で迂回するロジックを実装する（issue #333、#314 の対称版）。
+
+**Architecture:** 既存の横方向迂回ロジック (`detectDetour`, `collectObstacles`) の対称コピー。`arrow-routing.ts` に `detectVerticalDetour` と `collectVerticalObstacles` を追加し、`buildArrowPath` で水平/垂直直線を判別して dispatch。呼び出し側 (`FlowEditor.aPath`, `SharedFlowViewer.computeArrowPath`) は同一行/同一レーンで分岐。
+
+**Tech Stack:** TypeScript / React / Vitest / Playwright。CSS Modules。
+
+**Spec:** `docs/superpowers/specs/2026-04-30-vertical-arrow-detour-design.md`
+
+**Branch:** `feat/vertical-arrow-detour-333`
+
+---
+
+## 事前準備（Workflow Step 0-1）
+
+```bash
+# main 最新化（必須。失敗したら中断して人間に報告）
+git checkout main
+git fetch origin
+git merge --ff-only origin/main
+
+# issue ラベル
+gh issue edit 333 --add-label "作業開始"
+
+# worktree 作成
+git worktree add .worktrees/feat-vertical-arrow-detour-333 -b feat/vertical-arrow-detour-333
+cd .worktrees/feat-vertical-arrow-detour-333
+
+# .env シンボリックリンク
+MAIN=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
+for f in "$MAIN"/.env*; do [ -f "$f" ] && ln -sf "$f" .; done
+
+# テストルール再読込
+cat ~/.claude/rules/testing.md
+```
+
+以降の全タスクはこの worktree 内で実行する。
+
+---
+
+## File Structure
+
+| ファイル | 役割 | 変更種別 |
+|---|---|---|
+| `src/lib/arrow-routing.ts` | 矢印パス計算ロジック | Modify (追加: `detectVerticalDetour`, `collectVerticalObstacles`, `buildArrowPath` dispatch) |
+| `src/lib/arrow-routing.test.ts` | ユニットテスト | Modify (追加: 縦方向テスト 14 件 + collectVerticalObstacles テスト 4 件) |
+| `src/features/editor/FlowEditor.tsx` | エディタ本体 | Modify (`aPath` の obstacles 組み立て) |
+| `src/features/shared/SharedFlowViewer.tsx` | 共有ビューア | Modify (`computeArrowPath` の obstacles 組み立て) |
+
+---
+
+## Task 1: detectVerticalDetour 基本ロジック（TDD）
+
+**Files:**
+- Test: `src/lib/arrow-routing.test.ts` (末尾に新 describe を追加)
+- Modify: `src/lib/arrow-routing.ts`
+
+縦方向の障害なし／障害あり（右迂回）の最小ケースから始める。
+
+- [ ] **Step 1: 失敗テストを追加**
+
+`src/lib/arrow-routing.test.ts` の末尾に以下の新 describe ブロックを追加:
+
+```ts
+describe('buildArrowPath - 縦方向迂回（同一レーン）', () => {
+  // 共通の始終点（A→C 同一レーン、A=(200,200), C=(200,600) のときの exitPt/entryPt 後の値）
+  // ノード TW=152, TH=56 → hh=28, exit Y=200+28=228, entry Y=600-28=572
+  const s = { x: 200, y: 228 }
+  const e = { x: 200, y: 572 }
+  const fc = { x: 200, y: 200 }
+  const tc = { x: 200, y: 600 }
+
+  it('obstacles 省略 → 既存の直線パスを返す（垂直直線）', () => {
+    const r = buildArrowPath(s, e, fc, tc)
+    expect(r.d).toBe('M200,228 L200,572')
+  })
+
+  it('obstacles が空配列 → 既存の直線パスを返す', () => {
+    const r = buildArrowPath(s, e, fc, tc, [])
+    expect(r.d).toBe('M200,228 L200,572')
+  })
+
+  it('同一列・障害1個・左右空き → 右迂回パス（detourX = 障害右端 + 14）', () => {
+    const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B])
+    // detourX = 200 + 76 + 14 = 290
+    // sign=+1, halfDy=172, departY=228+14=242, approachY=572-14=558
+    expect(r.d).toBe('M200,228 L200,242 L290,242 L290,558 L200,558 L200,572')
+    expect(r.mx).toBe(290)
+    expect(r.my).toBe(400)
+  })
+})
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+```bash
+npm test -- arrow-routing.test
+```
+
+期待: 「障害1個・左右空き → 右迂回パス」が FAIL（直線パスが返るため）。最初の 2 件（直線ケース）は既存ロジックで PASS する可能性あり、それは想定どおり。
+
+- [ ] **Step 3: detectVerticalDetour を実装**
+
+`src/lib/arrow-routing.ts` の `detectDetour` 関数の **直後** に追加:
+
+```ts
+function detectVerticalDetour(
+  s: Point,
+  e: Point,
+  obstacles: Bbox[],
+): { detourX: number } | null {
+  // 垂直直線でなければ迂回しない
+  if (Math.abs(e.x - s.x) >= 2) return null
+
+  const yLow = Math.min(s.y, e.y)
+  const yHigh = Math.max(s.y, e.y)
+  const colX = s.x
+
+  // 垂直移動がなければ迂回対象なし
+  if (yLow >= yHigh - 1) return null
+
+  // 経路上の障害ノード = 同一列（colX と X が重なる）かつ Y が始終点の間
+  const inCol = obstacles.filter(
+    (b) =>
+      Math.abs(b.x - colX) < b.w / 2 + 2 && b.y - b.h / 2 < yHigh - 1 && b.y + b.h / 2 > yLow + 1,
+  )
+  if (inCol.length === 0) return null
+
+  // 左右塞がり判定（Y 重なりするノードが直左/直右に存在するか）
+  // 前提: obstacles 配列には呼び出し側で「同一列＋直左列＋直右列のみ」をフィルタ済み
+  const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
+  const rightBlocked = inCol.some((obs) =>
+    obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
+  )
+  const leftBlocked = inCol.some((obs) =>
+    obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
+  )
+
+  // 方向決定: 右空きなら右、右塞がり＆左空きなら左、両塞がりは右優先
+  const goRight = !rightBlocked || leftBlocked
+
+  // detourX: 障害ノード群の最右端 + マージン or 最左端 - マージン
+  const detourX = goRight
+    ? Math.max(...inCol.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+    : Math.min(...inCol.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+
+  return { detourX }
+}
+```
+
+- [ ] **Step 4: buildArrowPath に dispatch を追加**
+
+`src/lib/arrow-routing.ts` の `buildArrowPath` 内、既存の水平迂回ブロック直後に追加。具体的には、既存の `if (obstacles && obstacles.length > 0)` ブロック内で、水平 detour が null だったら垂直 detour を試す形にする:
+
+```ts
+  // 迂回モード: 同一行/同一レーンで経路上に障害ノードがある場合
+  if (obstacles && obstacles.length > 0) {
+    const detour = detectDetour(s, e, obstacles)
+    if (detour) {
+      const { detourY } = detour
+      const sign = Math.sign(dx)
+      const halfDx = Math.abs(dx) / 2
+      const departX = s.x + sign * Math.min(DEPART_GAP, halfDx)
+      const approachX = e.x - sign * Math.min(APPROACH_GAP, halfDx)
+      const d = `M${s.x},${s.y} L${departX},${s.y} L${departX},${detourY} L${approachX},${detourY} L${approachX},${e.y} L${e.x},${e.y}`
+      return { d, mx: (s.x + e.x) / 2, my: detourY }
+    }
+    const vDetour = detectVerticalDetour(s, e, obstacles)
+    if (vDetour) {
+      const { detourX } = vDetour
+      // |e.y - s.y| / 2 で clamp（横版と対称な防御コード）
+      const sign = Math.sign(dy)
+      const halfDy = Math.abs(dy) / 2
+      const departY = s.y + sign * Math.min(DEPART_GAP, halfDy)
+      const approachY = e.y - sign * Math.min(APPROACH_GAP, halfDy)
+      // 6 セグメント: M → 垂直(departY まで) → 水平(detourX まで) → 垂直(approachY まで)
+      //               → 水平(e.x まで=s.x なので戻る) → 垂直(e.y へ進入)
+      const d = `M${s.x},${s.y} L${s.x},${departY} L${detourX},${departY} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
+      return { d, mx: detourX, my: (s.y + e.y) / 2 }
+    }
+  }
+```
+
+- [ ] **Step 5: テスト pass を確認**
+
+```bash
+npm test -- arrow-routing.test
+```
+
+期待: 新規 3 件 + 既存全件 PASS。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts
+git commit -m "$(cat <<'EOF'
+feat(#333): add detectVerticalDetour for same-lane arrow routing
+
+Mirror of detectDetour for vertical straight lines. buildArrowPath
+dispatches to vertical detour when e.x ≈ s.x and obstacles are present.
+Right-priority by default (symmetric to horizontal's down-priority).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: detectVerticalDetour 塞がり判定（TDD）
+
+直右にノードがあるとき左迂回、両塞がりで右優先になることを検証。
+
+**Files:**
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: 失敗テストを追加**
+
+Task 1 で追加した `describe('buildArrowPath - 縦方向迂回（同一レーン）', () => {...})` の中に追加:
+
+```ts
+  it('同一列・障害1個・直右塞がり → 左迂回（detourX = 障害左端 - 14）', () => {
+    const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+    const Bright: Bbox = { x: 284, y: 400, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B, Bright])
+    // detourX = 200 - 76 - 14 = 110
+    expect(r.d).toBe('M200,228 L200,242 L110,242 L110,558 L200,558 L200,572')
+    expect(r.mx).toBe(110)
+  })
+
+  it('同一列・障害1個・両塞がり → 右優先で右迂回', () => {
+    const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+    const Bright: Bbox = { x: 284, y: 400, w: 152, h: 56 }
+    const Bleft: Bbox = { x: 116, y: 400, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B, Bright, Bleft])
+    expect(r.mx).toBe(290)
+  })
+```
+
+- [ ] **Step 2: テストを実行して PASS を確認**
+
+```bash
+npm test -- arrow-routing.test
+```
+
+期待: Task 1 で実装したロジックで PASS（実装変更不要）。FAIL する場合はロジック誤り — `rightBlocked` / `leftBlocked` の判定式を確認。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src/lib/arrow-routing.test.ts
+git commit -m "$(cat <<'EOF'
+test(#333): add blocked-direction tests for vertical detour
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: detectVerticalDetour 複数障害・方向・エッジ（TDD）
+
+**Files:**
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: 残りのテストケースを追加**
+
+Task 1 で追加した describe 内に以下を追加:
+
+```ts
+  it('同一列・障害2個・右空き → まとめて右迂回（detourX は最右端の最大）', () => {
+    const B: Bbox = { x: 200, y: 380, w: 152, h: 56 }
+    const C2: Bbox = { x: 200, y: 480, w: 200, h: 56 }
+    const sExt = { x: 200, y: 228 }
+    const eExt = { x: 200, y: 624 }
+    const r = buildArrowPath(sExt, eExt, { x: 200, y: 200 }, { x: 200, y: 700 }, [B, C2])
+    // 最右端: max(200+76, 200+100) = 300, +14 = 314
+    expect(r.mx).toBe(314)
+    expect(r.d).toBe('M200,228 L200,242 L314,242 L314,610 L200,610 L200,624')
+  })
+
+  it('同一列・障害2個・1つだけ直右塞がり → 左迂回', () => {
+    const B: Bbox = { x: 200, y: 380, w: 152, h: 56 }
+    const C2: Bbox = { x: 200, y: 480, w: 152, h: 56 }
+    const Bright: Bbox = { x: 284, y: 380, w: 152, h: 56 }
+    const sExt = { x: 200, y: 228 }
+    const eExt = { x: 200, y: 624 }
+    const r = buildArrowPath(sExt, eExt, { x: 200, y: 200 }, { x: 200, y: 700 }, [B, C2, Bright])
+    // 最左端: min(200-76, 200-76) = 124, -14 = 110
+    expect(r.mx).toBe(110)
+  })
+
+  it('同一列・障害なし（経路上に bbox がない）→ 直線', () => {
+    const farUp: Bbox = { x: 200, y: 100, w: 152, h: 56 }
+    const farDown: Bbox = { x: 200, y: 700, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [farUp, farDown])
+    expect(r.d).toBe('M200,228 L200,572')
+  })
+
+  it('斜め方向（dx >= 2）→ 既存の Z/L 字ロジック（縦迂回しない）', () => {
+    const sDiag = { x: 200, y: 228 }
+    const eDiag = { x: 300, y: 572 }
+    const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+    const r = buildArrowPath(sDiag, eDiag, { x: 200, y: 200 }, { x: 300, y: 600 }, [B])
+    // 縦迂回特有のセグメント L${detourX},242 等が出ないことを確認
+    expect(r.d).not.toContain('L290,242')
+  })
+
+  it('始終点が同じ Y（自己参照） → inCol 空 → 直線', () => {
+    const B: Bbox = { x: 200, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(
+      { x: 200, y: 200 },
+      { x: 200, y: 200 },
+      { x: 200, y: 200 },
+      { x: 200, y: 200 },
+      [B],
+    )
+    expect(r.d).toBe('M200,200 L200,200')
+  })
+
+  it('from/to 自身の bbox が混入しても Y±1 マージンで除外される', () => {
+    const fromSelfBbox: Bbox = { x: 200, y: 200, w: 152, h: 56 }
+    const toSelfBbox: Bbox = { x: 200, y: 600, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [fromSelfBbox, toSelfBbox])
+    expect(r.d).toBe('M200,228 L200,572')
+  })
+
+  it('同一列・下→上方向でも右迂回する（s.y > e.y）', () => {
+    // s と e を逆転
+    const sR = { x: 200, y: 572 }
+    const eR = { x: 200, y: 228 }
+    const fcR = { x: 200, y: 600 }
+    const tcR = { x: 200, y: 200 }
+    const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+    const r = buildArrowPath(sR, eR, fcR, tcR, [B])
+    // sign=-1, departY=572-14=558, approachY=228+14=242
+    expect(r.d).toBe('M200,572 L200,558 L290,558 L290,242 L200,242 L200,228')
+    expect(r.mx).toBe(290)
+  })
+```
+
+- [ ] **Step 2: テストを実行して PASS を確認**
+
+```bash
+npm test -- arrow-routing.test
+```
+
+期待: 全 PASS。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src/lib/arrow-routing.test.ts
+git commit -m "$(cat <<'EOF'
+test(#333): add multi-obstacle and direction tests for vertical detour
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: 6 セグメント形状＋自己交差防止 clamp（TDD）
+
+**Files:**
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: テスト追加**
+
+Task 1 の describe ブロックの末尾に追加:
+
+```ts
+  describe('垂直進入＋垂直 depart（始終点とも垂直）', () => {
+    it('右迂回パスは 6 セグメントで最初と最終セグメントが垂直', () => {
+      const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+      const r = buildArrowPath(s, e, fc, tc, [B])
+      const segments = r.d.match(/[ML][^ML]+/g) ?? []
+      expect(segments).toHaveLength(6)
+      // 最初のセグメント（M→L）は垂直: M の X と次の L の X が同じ
+      const first = segments[0]
+      const second = segments[1]
+      const firstX = Number(first.slice(1).split(',')[0])
+      const secondX = Number(second.slice(1).split(',')[0])
+      expect(firstX).toBe(secondX)
+      expect(firstX).toBe(s.x)
+      // 最終セグメントは垂直
+      const last = segments[segments.length - 1]
+      const prev = segments[segments.length - 2]
+      const lastX = Number(last.slice(1).split(',')[0])
+      const prevX = Number(prev.slice(1).split(',')[0])
+      expect(lastX).toBe(prevX)
+      expect(lastX).toBe(e.x)
+    })
+
+    it('垂直距離が DEPART_GAP*2 未満の場合 departY/approachY は中央で接合し自己交差しない', () => {
+      // 垂直距離=20, DEPART_GAP=APPROACH_GAP=14。Math.min(14, 10) で 10 に clamp される
+      // s=(200,100), e=(200,120) で間に B (200,110) を置いて迂回を強制
+      const sN = { x: 200, y: 100 }
+      const eN = { x: 200, y: 120 }
+      const fcN = { x: 200, y: 80 }
+      const tcN = { x: 200, y: 140 }
+      const B: Bbox = { x: 200, y: 110, w: 152, h: 16 }
+      const r = buildArrowPath(sN, eN, fcN, tcN, [B])
+      // departY = 100 + 1 * Math.min(14, 10) = 110
+      // approachY = 120 - 1 * Math.min(14, 10) = 110
+      // detourX = 200 + 76 + 14 = 290
+      expect(r.d).toBe('M200,100 L200,110 L290,110 L290,110 L200,110 L200,120')
+    })
+  })
+```
+
+- [ ] **Step 2: テストを実行**
+
+```bash
+npm test -- arrow-routing.test
+```
+
+期待: PASS。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src/lib/arrow-routing.test.ts
+git commit -m "$(cat <<'EOF'
+test(#333): verify 6-segment shape and clamp for vertical detour
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: collectVerticalObstacles ヘルパー（TDD）
+
+**Files:**
+- Test: `src/lib/arrow-routing.test.ts`
+- Modify: `src/lib/arrow-routing.ts`
+
+- [ ] **Step 1: 失敗テストを追加**
+
+`src/lib/arrow-routing.test.ts` の末尾（`describe('collectObstacles', ...)` の **後** ）に追加。インポート行も必要なら更新:
+
+```ts
+import {
+  buildArrowPath,
+  collectObstacles,
+  collectVerticalObstacles,
+  type Bbox,
+  type ObstacleNode,
+} from './arrow-routing'
+```
+
+新 describe 追加:
+
+```ts
+describe('collectVerticalObstacles', () => {
+  // A=(200,200), B=(200,400), C=(200,600) 同一レーン (colX=200)
+  // D=(284,400) B 直右列, E=(116,400) B 直左列 (colW=84 → adjacent threshold)
+  // F=(368,400) 2列右（除外対象）
+  // 注: ここではテストしやすい colW=84 を使用。実際の運用では LW + G を渡す。
+  const TW = 152,
+    TH = 56,
+    LANE_W = 84
+
+  const baseNodes: ObstacleNode[] = [
+    { key: 'A', cx: 200, cy: 200 },
+    { key: 'B', cx: 200, cy: 400 },
+    { key: 'C', cx: 200, cy: 600 },
+    { key: 'D', cx: 284, cy: 400 },
+    { key: 'E', cx: 116, cy: 400 },
+    { key: 'F', cx: 368, cy: 400 },
+  ]
+
+  it('A→C: 同一列の B（from-to 間）と直左 E・直右 D を集める。F（2列右）は除外', () => {
+    const result = collectVerticalObstacles({
+      nodes: baseNodes,
+      fromKey: 'A',
+      toKey: 'C',
+      fromCy: 200,
+      toCy: 600,
+      colX: 200,
+      colW: LANE_W,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    // B (同一列・間), D (直右), E (直左) が含まれる
+    expect(result).toHaveLength(3)
+    const cxs = result.map((b) => b.x).sort((a, b) => a - b)
+    expect(cxs).toEqual([116, 200, 284])
+    // F (cx=368) は除外
+    expect(result.every((b) => b.x !== 368)).toBe(true)
+  })
+
+  it('from/to 自身は除外される', () => {
+    const result = collectVerticalObstacles({
+      nodes: baseNodes,
+      fromKey: 'A',
+      toKey: 'C',
+      fromCy: 200,
+      toCy: 600,
+      colX: 200,
+      colW: LANE_W,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    const xys = result.map((b) => `${b.x},${b.y}`)
+    expect(xys).not.toContain('200,200') // A
+    expect(xys).not.toContain('200,600') // C
+  })
+
+  it('A→B（隣接、間にノードなし）: 同一列は from-to 間限定なので空、直左/直右列は Y 制限なしで含む', () => {
+    const result = collectVerticalObstacles({
+      nodes: baseNodes,
+      fromKey: 'A',
+      toKey: 'B',
+      fromCy: 200,
+      toCy: 400,
+      colX: 200,
+      colW: LANE_W,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    // 同一列: A=200, B=400 が from/to で除外。C=600 は Y 範囲外で除外。→ 0件
+    // 直左/直右列: D, E のみ（F は 2列右で除外）。Y 制限なしなので cy=400 が含まれる
+    expect(result).toHaveLength(2)
+    const cxs = result.map((b) => b.x).sort((a, b) => a - b)
+    expect(cxs).toEqual([116, 284])
+  })
+
+  it('下→上方向（fromCy > toCy）でも同一列・隣接列を正しく抽出', () => {
+    const result = collectVerticalObstacles({
+      nodes: baseNodes,
+      fromKey: 'C',
+      toKey: 'A',
+      fromCy: 600,
+      toCy: 200,
+      colX: 200,
+      colW: LANE_W,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    expect(result).toHaveLength(3)
+    const cxs = result.map((b) => b.x).sort((a, b) => a - b)
+    expect(cxs).toEqual([116, 200, 284])
+  })
+})
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+```bash
+npm test -- arrow-routing.test
+```
+
+期待: collectVerticalObstacles が undefined のためインポートエラー or "is not a function"。
+
+- [ ] **Step 3: collectVerticalObstacles を実装**
+
+`src/lib/arrow-routing.ts` の末尾（既存 `collectObstacles` の後）に追加:
+
+```ts
+interface CollectVerticalObstaclesArgs {
+  nodes: ObstacleNode[]
+  fromKey: string
+  toKey: string
+  fromCy: number // 始点 Y
+  toCy: number // 終点 Y
+  colX: number // 同一列 X（始点・終点共通）
+  colW: number // 列ピッチ（FlowEditor の LW + G を渡す）
+  bboxW: number
+  bboxH: number
+}
+
+/**
+ * 矢印の同一列・直左列・直右列にあるノードを bbox 配列に変換する（縦版）。
+ * 同一列は from-to 間レンジに限定。直左/直右列は Y 制限なしで含める（左右塞がり判定用）。
+ * from/to 自身および 2 列以上離れたノードは除外する。
+ *
+ * 呼び出し側は同一レーン（fromLane === toLane）のときのみ本関数を呼ぶ想定。
+ * colX には fromNode の X 座標を渡すこと（同一レーンなので toNode.x と等価）。
+ *
+ * collectObstacles の対称版。横版の rowH に相当するのが colW（レーンピッチ）。
+ */
+export function collectVerticalObstacles(args: CollectVerticalObstaclesArgs): Bbox[] {
+  const { nodes, fromKey, toKey, fromCy, toCy, colX, colW, bboxW, bboxH } = args
+  const yLow = Math.min(fromCy, toCy)
+  const yHigh = Math.max(fromCy, toCy)
+  const result: Bbox[] = []
+  for (const n of nodes) {
+    if (n.key === fromKey || n.key === toKey) continue
+    const dx = Math.abs(n.cx - colX)
+    const onCol = dx < bboxW / 2 + 2
+    // 直左/直右列のみを採用（dx が colW に近い）。2列以上離れたノードは除外。
+    const onAdjacentCol = !onCol && dx > colW - bboxW / 2 && dx < colW + bboxW / 2
+    if (onCol) {
+      // 同一列: from-to 間レンジに限定（始終点 Y は除外）
+      if (n.cy > yLow + 1 && n.cy < yHigh - 1) {
+        result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+      }
+    } else if (onAdjacentCol) {
+      // 直左/直右列: 左右塞がり判定用に Y 制限なしで含める
+      result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+    }
+  }
+  return result
+}
+```
+
+- [ ] **Step 4: テスト pass を確認**
+
+```bash
+npm test -- arrow-routing.test
+```
+
+期待: 全 PASS。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts
+git commit -m "$(cat <<'EOF'
+feat(#333): add collectVerticalObstacles helper
+
+Mirror of collectObstacles for vertical (same-lane) routing. Filters
+nodes to same-column (from-to range) and adjacent columns (no Y limit).
+colW takes lane pitch (LW + G).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: FlowEditor.aPath を縦方向対応
+
+**Files:**
+- Modify: `src/features/editor/FlowEditor.tsx`
+
+- [ ] **Step 1: import 文を更新**
+
+`src/features/editor/FlowEditor.tsx` の line 38 付近のインポートを更新:
+
+```ts
+import {
+  DS,
+  collectObstacles,
+  collectVerticalObstacles,
+  type Bbox,
+  type ObstacleNode,
+} from '../../lib/arrow-routing'
+```
+
+- [ ] **Step 2: aPath の obstacles 組み立てロジックを変更**
+
+`src/features/editor/FlowEditor.tsx` の `aPath` 関数内（line 1384-1398 付近）を以下に置き換え:
+
+```ts
+    // 同一行/同一レーンのときに obstacles を組み立てる（迂回判定用）
+    let obstacles: Bbox[] | undefined
+    if (fri === tri) {
+      obstacles = collectObstacles({
+        nodes: obstacleNodes,
+        fromKey: arrow.from,
+        toKey: arrow.to,
+        fromCx: from.x,
+        toCx: to.x,
+        rowY: from.y,
+        rowH: RH,
+        bboxW: TW,
+        bboxH: TH,
+      })
+    } else if (fli === tli) {
+      obstacles = collectVerticalObstacles({
+        nodes: obstacleNodes,
+        fromKey: arrow.from,
+        toKey: arrow.to,
+        fromCy: from.y,
+        toCy: to.y,
+        colX: from.x,
+        colW: LW + G,
+        bboxW: TW,
+        bboxH: TH,
+      })
+    }
+```
+
+`LW` と `G` はこのスコープで利用可能（line 678: `const LW = ...`, line 677: `G = T.laneGap`）。
+
+- [ ] **Step 3: 全テストを実行**
+
+```bash
+npm test
+```
+
+期待: 全 PASS（既存テストに regression なし）。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/features/editor/FlowEditor.tsx
+git commit -m "$(cat <<'EOF'
+feat(#333): wire FlowEditor aPath for vertical detour
+
+Build vertical obstacles when from/to are in the same lane (fli === tli).
+Lane pitch is LW + G (uniform).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: SharedFlowViewer.computeArrowPath を縦方向対応
+
+**Files:**
+- Modify: `src/features/shared/SharedFlowViewer.tsx`
+
+- [ ] **Step 1: import 文を更新**
+
+`src/features/shared/SharedFlowViewer.tsx` の line 14 付近を更新:
+
+```ts
+import {
+  buildArrowPath,
+  collectObstacles,
+  collectVerticalObstacles,
+  exitPt,
+  entryPt,
+  type Bbox,
+  type ObstacleNode,
+} from '../../lib/arrow-routing'
+```
+
+（注: 実際のインポート構造に合わせて調整。元の順番・他のインポートは維持）
+
+- [ ] **Step 2: computeArrowPath の obstacles 組み立てを変更**
+
+line 131-145 付近の `if (fromNode.rowIndex === toNode.rowIndex) { ... }` ブロックを以下に置き換え:
+
+```ts
+    // 同一行/同一レーンのときに obstacles を組み立てる（迂回判定用）
+    let obstacles: Bbox[] | undefined
+    if (fromNode.rowIndex === toNode.rowIndex) {
+      obstacles = collectObstacles({
+        nodes: obstacleNodes,
+        fromKey: fromNode.id,
+        toKey: toNode.id,
+        fromCx: f.x,
+        toCx: t.x,
+        rowY: f.y,
+        rowH: RH,
+        bboxW: TW,
+        bboxH: TH,
+      })
+    } else if (fromNode.laneId === toNode.laneId) {
+      obstacles = collectVerticalObstacles({
+        nodes: obstacleNodes,
+        fromKey: fromNode.id,
+        toKey: toNode.id,
+        fromCy: f.y,
+        toCy: t.y,
+        colX: f.x,
+        colW: LW + G,
+        bboxW: TW,
+        bboxH: TH,
+      })
+    }
+```
+
+`LW` と `G` はこのスコープで利用可能（line 81 付近: `const LW = ...`, `G = T.laneGap` 相当）。確認のため line 70-90 を読み、利用可能な変数名と一致するよう調整。
+
+- [ ] **Step 3: 全テストを実行**
+
+```bash
+npm test
+```
+
+期待: 全 PASS。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/features/shared/SharedFlowViewer.tsx
+git commit -m "$(cat <<'EOF'
+feat(#333): wire SharedFlowViewer for vertical detour
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: ブラウザ目視確認（Playwright + 本番ビルド）
+
+**Files:** なし（確認のみ）
+
+- [ ] **Step 1: dev サーバー起動と Playwright でエディタ確認**
+
+`E2E_USER_EMAIL` / `E2E_USER_PASSWORD` でログインし、新規 flow を作成:
+
+1. 同一レーン（縦並び）に A、B、C の 3 ノードを置く
+2. A → C の矢印を引く
+3. 矢印が B を **右へ迂回** することをスクリーンショットで確認 (`.screenshots/333-vertical-detour-right.png`)
+
+- [ ] **Step 2: 直右ノードがある場合の左迂回確認**
+
+1. 上記の B の **直右**（隣接レーン）にもう 1 ノード D を置く
+2. A → C の矢印が **左へ迂回** に切り替わることを確認 (`.screenshots/333-vertical-detour-left.png`)
+
+- [ ] **Step 3: Diamond ノード混在確認**
+
+1. B を Diamond に変更
+2. A → C 迂回が崩れないことを確認 (`.screenshots/333-vertical-detour-diamond.png`)
+
+- [ ] **Step 4: 横方向 regression なし確認**
+
+1. 同一行で A→C の間に B を置く（横方向）
+2. 既存の下迂回挙動が維持されていることを確認 (`.screenshots/333-horizontal-regression.png`)
+
+- [ ] **Step 5: 共有ビューアで同じ挙動を確認**
+
+1. 上記 flow を共有 URL で開く
+2. 同じ迂回挙動になっていることを確認 (`.screenshots/333-shared-viewer.png`)
+
+- [ ] **Step 6: LCP 1秒以内を確認**
+
+Chrome DevTools Performance タブで Largest Contentful Paint を測定。1 秒超過ならパフォーマンス改善してから再 commit。
+
+問題があれば該当タスク（5/6/7）に戻って修正。
+
+---
+
+## Task 9: 最新 main 同期 → push → PR 作成
+
+- [ ] **Step 1: main 最新化と全テスト**
+
+```bash
+git pull origin main --rebase
+npm test
+```
+
+全 PASS 必須。
+
+- [ ] **Step 2: 本番ビルド確認**
+
+`~/.claude/skills/preview/SKILL.md` の手順で本番ビルドをローカル起動して目視確認。
+
+- [ ] **Step 3: push & PR 作成**
+
+```bash
+git push -u origin feat/vertical-arrow-detour-333
+gh pr create --title "feat(#333): vertical (same-lane) arrow detour" --body "$(cat <<'EOF'
+## Summary
+- 同一レーン（縦方向）で A→C の間に B があるとき迂回するロジックを追加（issue #333）
+- 横方向の迂回（#314）の対称版。右優先（横の下優先と対称）
+- `arrow-routing.ts` に `detectVerticalDetour` と `collectVerticalObstacles` を追加
+- `FlowEditor.aPath` と `SharedFlowViewer.computeArrowPath` で同一レーン時に dispatch
+
+## Test plan
+- [x] 縦方向迂回ユニットテスト 14 件追加
+- [x] `collectVerticalObstacles` ユニットテスト 4 件追加
+- [x] 既存横方向テスト全 PASS（regression なし）
+- [x] エディタで A→C 迂回確認（右迂回・左迂回・Diamond）
+- [x] 共有ビューアで同じ挙動確認
+- [x] LCP 1秒以内
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: CI watch**
+
+```bash
+gh pr checks --watch
+```
+
+全 PASS まで待機。FAIL 時は修正→push→再 watch。
+
+- [ ] **Step 5: レビュー依頼**
+
+```bash
+gh pr comment --body '@claude PRをレビューして。
+以下の観点で確認すること：
+- バグ・ロジックの問題
+- コードの重複・共通化できる処理
+- 不要な複雑さ
+結果は最終行に [A:要修正] [B:条件つき承認] [C:承認OK] のいずれかで明記。'
+```
+
+- [ ] **Step 6: review-loop**
+
+Workflow Step 9 のレビューループを実行（最大 10 回）。
+
+- [ ] **Step 7: Merge & Deploy 確認**
+
+`gh pr merge --merge` 後、`~/.claude/skills/deploy/SKILL.md` を参照して deploy 確認。
+
+- [ ] **Step 8: Worktree cleanup**
+
+```bash
+MAIN=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
+cd "$MAIN"
+git worktree remove .worktrees/feat-vertical-arrow-detour-333
+git branch -d feat/vertical-arrow-detour-333
+git worktree list
+```

--- a/docs/superpowers/specs/2026-04-30-vertical-arrow-detour-design.md
+++ b/docs/superpowers/specs/2026-04-30-vertical-arrow-detour-design.md
@@ -1,0 +1,272 @@
+# 縦方向（同一レーン）の矢印迂回ロジック
+
+- 関連 issue: [#333](https://github.com/tomohirof/flowline/issues/333)
+- 前段 issue: [#314](https://github.com/tomohirof/flowline/issues/314)（横方向の迂回）
+- 関連懸念: [#328](https://github.com/tomohirof/flowline/issues/328)（depart 脚クリアランス）
+
+## 背景と目的
+
+issue #314 で「同一行（横方向）で A→C の間に B があるとき迂回」する処理を実装したが、対象外としていた **同一レーン（縦方向）** で同じ問題が残っている。
+
+例: 同一レーン (`lid` 同じ) で `rowIndex` が離れた A→C の矢印が、間にあるノード B を貫通する。
+
+本仕様では、横方向の迂回ロジックを **完全な対称形** で縦方向にも適用し、両方向の迂回を提供する。
+
+## 受け入れ基準（issue 抜粋）
+
+- 同一レーン（`fli === tli`）で A→C の直線パス上に他ノードがあるとき、それらを避けて迂回する
+- 迂回方向は **右優先**。直右にもノードがあれば左へ迂回。両方塞がっていれば右優先（横方向の「下優先」と対称）
+- 障害が無ければ従来どおりの垂直直線
+- 横方向の挙動（issue #314）は従来通り（regression なし）
+- Diamond ノードを始点/終点/障害として含む縦方向迂回でも崩れない
+- エディタ (`FlowEditor`) と共有ビューア (`SharedFlowViewer`) 両方で同じ挙動
+
+## スコープ外
+
+- 斜め配置（同一行でも同一レーンでもない）でパス上にノードがある場合の迂回（issue #314 と同方針で従来 L 字/Z 字 パスのまま）
+- depart 脚クリアランス問題の根本対応（#328 で別途対応。本 issue では縦版でも同じ単純 GAP 定数を採用し、regression リスクを横版と同等に揃える）
+
+## 設計
+
+### アプローチ概要
+
+横方向ロジックの **対称コピー** として縦方向ロジックを追加する。共通化（軸抽象化）は行わず、変数名の可読性と既存テストのコードパス保護を優先する。
+
+具体的には:
+
+1. `arrow-routing.ts` に `detectVerticalDetour` を追加
+2. `arrow-routing.ts` に `collectVerticalObstacles` を追加（既存 `collectObstacles` は無変更）
+3. `buildArrowPath` で水平直線/垂直直線を判別して dispatch
+4. 呼び出し側 (`FlowEditor.aPath`, `SharedFlowViewer.computeArrowPath`) は `fri === tri` のとき `collectObstacles`、`fli === tli` のとき `collectVerticalObstacles` を呼ぶ
+
+### `arrow-routing.ts` の変更
+
+#### 定数
+
+横版と同値・対称設計なので **同一定数を共有** する（命名追加なし）:
+
+- `DETOUR_MARGIN = 14` — 迂回方向（横版: Y / 縦版: X）のオフセット
+- `APPROACH_GAP = 14` — 終点側の最終セグメント長
+- `DEPART_GAP = 14` — 始点側の初動セグメント長
+
+#### `detectVerticalDetour`
+
+横版 `detectDetour` を Y↔X 入れ替えで対称化する:
+
+```ts
+function detectVerticalDetour(
+  s: Point, e: Point, obstacles: Bbox[]
+): { detourX: number } | null {
+  // 垂直直線でなければ迂回しない
+  if (Math.abs(e.x - s.x) >= 2) return null
+
+  const yLow = Math.min(s.y, e.y)
+  const yHigh = Math.max(s.y, e.y)
+  const colX = s.x
+
+  // 垂直移動がなければ迂回対象なし
+  if (yLow >= yHigh - 1) return null
+
+  // 経路上の障害ノード = 同一列（colX と X が重なる）かつ Y が始終点の間
+  const inCol = obstacles.filter(
+    (b) =>
+      Math.abs(b.x - colX) < b.w / 2 + 2 &&
+      b.y - b.h / 2 < yHigh - 1 &&
+      b.y + b.h / 2 > yLow + 1,
+  )
+  if (inCol.length === 0) return null
+
+  // 左右塞がり判定（Y 重なりするノードが直左/直右に存在するか）
+  // 前提: obstacles 配列には呼び出し側で「同一列＋直左列＋直右列のみ」をフィルタ済み
+  const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
+  const rightBlocked = inCol.some((obs) =>
+    obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
+  )
+  const leftBlocked = inCol.some((obs) =>
+    obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
+  )
+
+  // 方向決定: 右空きなら右、右塞がり＆左空きなら左、両塞がりは右優先
+  const goRight = !rightBlocked || leftBlocked
+
+  // detourX: 障害ノード群の最右端 + マージン or 最左端 - マージン
+  const detourX = goRight
+    ? Math.max(...inCol.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+    : Math.min(...inCol.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+
+  return { detourX }
+}
+```
+
+#### `buildArrowPath` の dispatch
+
+横版の早期 return（`Math.abs(e.y - s.y) >= 2`）と縦版の早期 return（`Math.abs(e.x - s.x) >= 2`）は排他的なので、**両方を順に試す** 形で良い:
+
+```ts
+if (obstacles && obstacles.length > 0) {
+  const hDetour = detectDetour(s, e, obstacles)         // 水平直線のとき
+  if (hDetour) {
+    // 既存の 6 セグメント水平迂回パス
+  }
+  const vDetour = detectVerticalDetour(s, e, obstacles) // 垂直直線のとき
+  if (vDetour) {
+    // 6 セグメント垂直迂回パス（下記）
+  }
+}
+```
+
+#### 縦方向 6 セグメントパス
+
+```
+M(s.x, s.y)
+L(s.x, departY)         // 短い垂直 depart
+L(detourX, departY)     // 水平に迂回 X へ
+L(detourX, approachY)   // 垂直で目的 Y 近傍まで降下/上昇
+L(s.x, approachY)       // 水平に戻す（s.x === e.x なので）
+L(e.x, e.y)             // 最終垂直
+```
+
+横版 clamp と対称に、`Math.abs(dy) / 2` で `DEPART_GAP` / `APPROACH_GAP` を clamp して自己交差を防ぐ:
+
+```ts
+const sign = Math.sign(dy)
+const halfDy = Math.abs(dy) / 2
+const departY = s.y + sign * Math.min(DEPART_GAP, halfDy)
+const approachY = e.y - sign * Math.min(APPROACH_GAP, halfDy)
+const d = `M${s.x},${s.y} L${s.x},${departY} L${detourX},${departY} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
+return { d, mx: detourX, my: (s.y + e.y) / 2 }
+```
+
+### `collectVerticalObstacles` の新設
+
+既存 `collectObstacles` は **無変更**（横方向専用として保持）。縦方向用に対称な API を新設する:
+
+```ts
+interface CollectVerticalObstaclesArgs {
+  nodes: ObstacleNode[]
+  fromKey: string
+  toKey: string
+  fromCy: number     // 始点 Y
+  toCy: number       // 終点 Y
+  colX: number       // 同一列 X（始点・終点共通）
+  colW: number       // 列ピッチ（FlowEditor の LW + G を渡す）
+  bboxW: number
+  bboxH: number
+}
+
+export function collectVerticalObstacles(args: CollectVerticalObstaclesArgs): Bbox[] {
+  const { nodes, fromKey, toKey, fromCy, toCy, colX, colW, bboxW, bboxH } = args
+  const yLow = Math.min(fromCy, toCy)
+  const yHigh = Math.max(fromCy, toCy)
+  const result: Bbox[] = []
+  for (const n of nodes) {
+    if (n.key === fromKey || n.key === toKey) continue
+    const dx = Math.abs(n.cx - colX)
+    const onCol = dx < bboxW / 2 + 2
+    const onAdjacentCol = !onCol && dx > colW - bboxW / 2 && dx < colW + bboxW / 2
+    if (onCol) {
+      // 同一列: from-to 間レンジに限定（始終点 Y は除外）
+      if (n.cy > yLow + 1 && n.cy < yHigh - 1) {
+        result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+      }
+    } else if (onAdjacentCol) {
+      // 直左/直右列: 左右塞がり判定用に Y 制限なしで含める
+      result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+    }
+  }
+  return result
+}
+```
+
+代案として両関数を `mode` 引数で統一することも検討したが、API 引数の半分が「未使用」になる awkward さが避けられないため、対称な 2 関数構成を採用。共通化が必要になった時点で内部リファクタリングは可能。
+
+### 呼び出し側の変更
+
+#### `FlowEditor.aPath` (src/features/editor/FlowEditor.tsx 行 1386)
+
+```ts
+let obstacles: Bbox[] | undefined
+if (fri === tri) {
+  obstacles = collectObstacles({
+    nodes: obstacleNodes,
+    fromKey: arrow.from, toKey: arrow.to,
+    fromCx: from.x, toCx: to.x,
+    rowY: from.y, rowH: RH,
+    bboxW: TW, bboxH: TH,
+  })
+} else if (fli === tli) {
+  obstacles = collectVerticalObstacles({
+    nodes: obstacleNodes,
+    fromKey: arrow.from, toKey: arrow.to,
+    fromCy: from.y, toCy: to.y,
+    colX: from.x, colW: LW + G,
+    bboxW: TW, bboxH: TH,
+  })
+}
+```
+
+`LW + G` がレーンピッチ（`laneX(li) = LM + li * (LW + G)` より）。グループ親レーンの幅 (`getGroupWidth`) は header 表示のみで、ノードの実 X 位置はすべて uniform pitch なのでこの値で正しい。
+
+#### `SharedFlowViewer.computeArrowPath` (src/features/shared/SharedFlowViewer.tsx 行 133)
+
+`FlowEditor` と同様に `fromNode.rowIndex === toNode.rowIndex` / `fromNode.laneId === toNode.laneId` で `mode` を切り替え。`LW + G` を `colW` に渡す。
+
+## テスト
+
+### 単体テスト（`arrow-routing.test.ts`）
+
+横方向テストの **完全な鏡像** を縦方向で追加:
+
+1. `obstacles 省略 → 既存の直線パス（垂直直線）`
+2. `obstacles が空配列 → 既存の直線パス`
+3. `同一列・障害1個・左右空き → 右迂回パス（detourX = 障害右端 + 14）`
+4. `同一列・障害1個・直右塞がり → 左迂回（detourX = 障害左端 - 14）`
+5. `同一列・障害1個・両塞がり → 右優先で右迂回`
+6. `同一列・障害2個・右空き → まとめて右迂回（detourX は最右端の最大）`
+7. `同一列・障害2個・1つだけ直右塞がり → 左迂回`
+8. `同一列・障害なし → 直線`
+9. `斜め方向（dx >= 2）→ 既存の Z/L 字ロジック（迂回しない）`
+10. `始終点が同じ Y（自己参照） → inCol 空 → 直線`
+11. `from/to 自身の bbox が混入しても Y±1 マージンで除外される`
+12. `同一列・下→上方向でも右迂回する（s.y > e.y）`
+13. `垂直 depart＋垂直 approach（始終点とも垂直）の 6 セグメント形状確認`
+14. `垂直距離が DEPART_GAP*2 未満の場合 departY/approachY は中央で接合し自己交差しない`
+
+`collectVerticalObstacles` のテスト:
+
+15. `A→C: 同一列の B と直左/直右列を集める。2列離れたノードは除外`
+16. `from/to 自身は除外される`
+17. `A→B（隣接、間にノードなし）: 同一列は from-to 間限定なので空、直左/直右列は Y 制限なしで含む`
+18. `下→上方向でも正しく抽出（fromCy > toCy）`
+
+回帰テスト: 既存の横方向テスト 17 件が全 pass であることを確認。
+
+### Playwright 目視確認
+
+エディタと共有ビューア両方で:
+
+- 同一レーンで A→C の間に B を置き、矢印が右迂回することを確認
+- B の直右に別ノードを置き、左迂回に切り替わることを確認
+- Diamond ノードを始点/終点/障害に含む組み合わせで崩れないことを確認
+- 横方向の迂回（既存）に regression がないことを確認
+
+## 影響範囲
+
+| ファイル | 変更内容 |
+|---|---|
+| `src/lib/arrow-routing.ts` | `detectVerticalDetour` 追加、`buildArrowPath` で dispatch、`collectVerticalObstacles` 新設 |
+| `src/lib/arrow-routing.test.ts` | 縦方向迂回テスト 14 件 + `collectVerticalObstacles` テスト 4 件追加 |
+| `src/features/editor/FlowEditor.tsx` | `aPath` の `obstacles` 組み立て条件を `fri === tri || fli === tli` に拡張、`mode` で呼び分け |
+| `src/features/shared/SharedFlowViewer.tsx` | `computeArrowPath` を同様に拡張 |
+
+## 既知の懸念と対応
+
+### A. レーン幅が一定か（issue 既出）
+
+**確認済み**: `laneX(li) = LM + li * (LW + G)` で uniform pitch。グループ親レーンの幅 (`getGroupWidth`) は header 表示のみで、ノードの実 X 位置には影響しない。`LW + G` を `colW` として渡せばよい。
+
+### B. depart 脚クリアランス問題（#328 の縦版）
+
+縦版でも `DEPART_GAP` の短い垂直 depart を入れるため、密レイアウトで「s.y → departY 区間が直近の障害物を貫通」する同じ regression が起こりうる。
+
+**対応**: 本 issue は横版と同じ単純な定数 GAP で実装する。縦版の clamp は #328 のスコープを「両方向」に拡張して別途解決する（本 issue ではテストで明示的にスコープ外としてコメント記載）。

--- a/docs/superpowers/specs/2026-04-30-vertical-arrow-detour-design.md
+++ b/docs/superpowers/specs/2026-04-30-vertical-arrow-detour-design.md
@@ -54,9 +54,7 @@ issue #314 で「同一行（横方向）で A→C の間に B があるとき�
 横版 `detectDetour` を Y↔X 入れ替えで対称化する:
 
 ```ts
-function detectVerticalDetour(
-  s: Point, e: Point, obstacles: Bbox[]
-): { detourX: number } | null {
+function detectVerticalDetour(s: Point, e: Point, obstacles: Bbox[]): { detourX: number } | null {
   // 垂直直線でなければ迂回しない
   if (Math.abs(e.x - s.x) >= 2) return null
 
@@ -70,9 +68,7 @@ function detectVerticalDetour(
   // 経路上の障害ノード = 同一列（colX と X が重なる）かつ Y が始終点の間
   const inCol = obstacles.filter(
     (b) =>
-      Math.abs(b.x - colX) < b.w / 2 + 2 &&
-      b.y - b.h / 2 < yHigh - 1 &&
-      b.y + b.h / 2 > yLow + 1,
+      Math.abs(b.x - colX) < b.w / 2 + 2 && b.y - b.h / 2 < yHigh - 1 && b.y + b.h / 2 > yLow + 1,
   )
   if (inCol.length === 0) return null
 
@@ -104,7 +100,7 @@ function detectVerticalDetour(
 
 ```ts
 if (obstacles && obstacles.length > 0) {
-  const hDetour = detectDetour(s, e, obstacles)         // 水平直線のとき
+  const hDetour = detectDetour(s, e, obstacles) // 水平直線のとき
   if (hDetour) {
     // 既存の 6 セグメント水平迂回パス
   }
@@ -146,10 +142,10 @@ interface CollectVerticalObstaclesArgs {
   nodes: ObstacleNode[]
   fromKey: string
   toKey: string
-  fromCy: number     // 始点 Y
-  toCy: number       // 終点 Y
-  colX: number       // 同一列 X（始点・終点共通）
-  colW: number       // 列ピッチ（FlowEditor の LW + G を渡す）
+  fromCy: number // 始点 Y
+  toCy: number // 終点 Y
+  colX: number // 同一列 X（始点・終点共通）
+  colW: number // 列ピッチ（FlowEditor の LW + G を渡す）
   bboxW: number
   bboxH: number
 }
@@ -189,18 +185,26 @@ let obstacles: Bbox[] | undefined
 if (fri === tri) {
   obstacles = collectObstacles({
     nodes: obstacleNodes,
-    fromKey: arrow.from, toKey: arrow.to,
-    fromCx: from.x, toCx: to.x,
-    rowY: from.y, rowH: RH,
-    bboxW: TW, bboxH: TH,
+    fromKey: arrow.from,
+    toKey: arrow.to,
+    fromCx: from.x,
+    toCx: to.x,
+    rowY: from.y,
+    rowH: RH,
+    bboxW: TW,
+    bboxH: TH,
   })
 } else if (fli === tli) {
   obstacles = collectVerticalObstacles({
     nodes: obstacleNodes,
-    fromKey: arrow.from, toKey: arrow.to,
-    fromCy: from.y, toCy: to.y,
-    colX: from.x, colW: LW + G,
-    bboxW: TW, bboxH: TH,
+    fromKey: arrow.from,
+    toKey: arrow.to,
+    fromCy: from.y,
+    toCy: to.y,
+    colX: from.x,
+    colW: LW + G,
+    bboxW: TW,
+    bboxH: TH,
   })
 }
 ```
@@ -252,12 +256,12 @@ if (fri === tri) {
 
 ## 影響範囲
 
-| ファイル | 変更内容 |
-|---|---|
-| `src/lib/arrow-routing.ts` | `detectVerticalDetour` 追加、`buildArrowPath` で dispatch、`collectVerticalObstacles` 新設 |
-| `src/lib/arrow-routing.test.ts` | 縦方向迂回テスト 14 件 + `collectVerticalObstacles` テスト 4 件追加 |
-| `src/features/editor/FlowEditor.tsx` | `aPath` の `obstacles` 組み立て条件を `fri === tri || fli === tli` に拡張、`mode` で呼び分け |
-| `src/features/shared/SharedFlowViewer.tsx` | `computeArrowPath` を同様に拡張 |
+| ファイル                                   | 変更内容                                                                                   |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------ | --- | -------------------------------------- |
+| `src/lib/arrow-routing.ts`                 | `detectVerticalDetour` 追加、`buildArrowPath` で dispatch、`collectVerticalObstacles` 新設 |
+| `src/lib/arrow-routing.test.ts`            | 縦方向迂回テスト 14 件 + `collectVerticalObstacles` テスト 4 件追加                        |
+| `src/features/editor/FlowEditor.tsx`       | `aPath` の `obstacles` 組み立て条件を `fri === tri                                         |     | fli === tli` に拡張、`mode` で呼び分け |
+| `src/features/shared/SharedFlowViewer.tsx` | `computeArrowPath` を同様に拡張                                                            |
 
 ## 既知の懸念と対応
 

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -35,7 +35,13 @@ import { toBlob } from 'html-to-image'
 import { pickPixelRatio, buildExportSvg } from './png-export'
 import { calcLaneWidth } from './calcLaneWidth'
 import { NodeLabelText } from '../shared/NodeLabelText'
-import { DS, collectObstacles, type Bbox, type ObstacleNode } from '../../lib/arrow-routing'
+import {
+  DS,
+  collectObstacles,
+  collectVerticalObstacles,
+  type Bbox,
+  type ObstacleNode,
+} from '../../lib/arrow-routing'
 import { useToast } from './hooks/useToast'
 import { ToastList } from './components/Toast'
 import { I, Ico } from './components/EditorIcons'
@@ -1382,7 +1388,7 @@ export default function FlowEditor({
     const from = ct(fli, fri)
     const to = ct(tli, tri)
 
-    // 同一行のときのみ obstacles を組み立てる（迂回判定用）
+    // 同一行/同一レーンのときに obstacles を組み立てる（迂回判定用）
     let obstacles: Bbox[] | undefined
     if (fri === tri) {
       obstacles = collectObstacles({
@@ -1393,6 +1399,18 @@ export default function FlowEditor({
         toCx: to.x,
         rowY: from.y,
         rowH: RH,
+        bboxW: TW,
+        bboxH: TH,
+      })
+    } else if (fli === tli) {
+      obstacles = collectVerticalObstacles({
+        nodes: obstacleNodes,
+        fromKey: arrow.from,
+        toKey: arrow.to,
+        fromCy: from.y,
+        toCy: to.y,
+        colX: from.x,
+        colW: LW + G,
         bboxW: TW,
         bboxH: TH,
       })

--- a/src/features/shared/SharedFlowViewer.tsx
+++ b/src/features/shared/SharedFlowViewer.tsx
@@ -102,7 +102,7 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
     nodeById[n.id] = n
   })
 
-  // 全ノードの中心座標を1度だけ収集（同一行 obstacles 判定で再利用）
+  // 全ノードの中心座標を1度だけ収集（同一行/同一レーン obstacles 判定で再利用）
   // FlowEditor 側は riMap[t.rid] で行インデックスを取得するが、本ビューアでは
   // flow.nodes に直接 rowIndex があるためそのまま ct() に渡せる（両者は等価）。
   const obstacleNodes: ObstacleNode[] = []

--- a/src/features/shared/SharedFlowViewer.tsx
+++ b/src/features/shared/SharedFlowViewer.tsx
@@ -12,6 +12,7 @@ import {
   entryPt,
   buildArrowPath,
   collectObstacles,
+  collectVerticalObstacles,
   DS,
   type Point,
   type Bbox,
@@ -129,7 +130,7 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
     const s = exitPt(f, t, hw, hh, RH, fromNode.shape as 'diamond' | undefined)
     const e = entryPt(t, f, hw, hh, RH, toNode.shape as 'diamond' | undefined)
 
-    // 同一行のときのみ obstacles を組み立てる（迂回判定用）
+    // 同一行/同一レーンのときに obstacles を組み立てる（迂回判定用）
     let obstacles: Bbox[] | undefined
     if (fromNode.rowIndex === toNode.rowIndex) {
       obstacles = collectObstacles({
@@ -140,6 +141,18 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
         toCx: t.x,
         rowY: f.y,
         rowH: RH,
+        bboxW: TW,
+        bboxH: TH,
+      })
+    } else if (fromNode.laneId === toNode.laneId) {
+      obstacles = collectVerticalObstacles({
+        nodes: obstacleNodes,
+        fromKey: fromNode.id,
+        toKey: toNode.id,
+        fromCy: f.y,
+        toCy: t.y,
+        colX: f.x,
+        colW: LW + G,
         bboxW: TW,
         bboxH: TH,
       })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { buildArrowPath, collectObstacles, type Bbox, type ObstacleNode } from './arrow-routing'
+import {
+  buildArrowPath,
+  collectObstacles,
+  collectVerticalObstacles,
+  type Bbox,
+  type ObstacleNode,
+} from './arrow-routing'
 
 describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
   // 共通の始終点（A→C 同一行、A=(200,200), C=(600,200) のときの exitPt/entryPt 後の値）
@@ -424,5 +430,93 @@ describe('buildArrowPath - 縦方向迂回（同一レーン）', () => {
       // detourX = 200 + 76 + 14 = 290
       expect(r.d).toBe('M200,100 L200,110 L290,110 L290,110 L200,110 L200,120')
     })
+  })
+})
+
+describe('collectVerticalObstacles', () => {
+  // A=(200,200), B=(200,400), C=(200,600) 同一レーン (colX=200)
+  // D=(284,400) B 直右列, E=(116,400) B 直左列 (colW=84 → adjacent threshold)
+  // F=(368,400) 2列右（除外対象）
+  // 注: ここではテストしやすい colW=84 を使用。実際の運用では LW + G を渡す。
+  const TW = 152,
+    TH = 56,
+    LANE_W = 84
+
+  const baseNodes: ObstacleNode[] = [
+    { key: 'A', cx: 200, cy: 200 },
+    { key: 'B', cx: 200, cy: 400 },
+    { key: 'C', cx: 200, cy: 600 },
+    { key: 'D', cx: 284, cy: 400 },
+    { key: 'E', cx: 116, cy: 400 },
+    { key: 'F', cx: 368, cy: 400 },
+  ]
+
+  it('A→C: 同一列の B（from-to 間）と直左 E・直右 D を集める。F（2列右）は除外', () => {
+    const result = collectVerticalObstacles({
+      nodes: baseNodes,
+      fromKey: 'A',
+      toKey: 'C',
+      fromCy: 200,
+      toCy: 600,
+      colX: 200,
+      colW: LANE_W,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    expect(result).toHaveLength(3)
+    const cxs = result.map((b) => b.x).sort((a, b) => a - b)
+    expect(cxs).toEqual([116, 200, 284])
+    expect(result.every((b) => b.x !== 368)).toBe(true)
+  })
+
+  it('from/to 自身は除外される', () => {
+    const result = collectVerticalObstacles({
+      nodes: baseNodes,
+      fromKey: 'A',
+      toKey: 'C',
+      fromCy: 200,
+      toCy: 600,
+      colX: 200,
+      colW: LANE_W,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    const xys = result.map((b) => `${b.x},${b.y}`)
+    expect(xys).not.toContain('200,200')
+    expect(xys).not.toContain('200,600')
+  })
+
+  it('A→B（隣接、間にノードなし）: 同一列は from-to 間限定なので空、直左/直右列は Y 制限なしで含む', () => {
+    const result = collectVerticalObstacles({
+      nodes: baseNodes,
+      fromKey: 'A',
+      toKey: 'B',
+      fromCy: 200,
+      toCy: 400,
+      colX: 200,
+      colW: LANE_W,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    expect(result).toHaveLength(2)
+    const cxs = result.map((b) => b.x).sort((a, b) => a - b)
+    expect(cxs).toEqual([116, 284])
+  })
+
+  it('下→上方向（fromCy > toCy）でも同一列・隣接列を正しく抽出', () => {
+    const result = collectVerticalObstacles({
+      nodes: baseNodes,
+      fromKey: 'C',
+      toKey: 'A',
+      fromCy: 600,
+      toCy: 200,
+      colX: 200,
+      colW: LANE_W,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    expect(result).toHaveLength(3)
+    const cxs = result.map((b) => b.x).sort((a, b) => a - b)
+    expect(cxs).toEqual([116, 200, 284])
   })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -398,6 +398,23 @@ describe('buildArrowPath - 縦方向迂回（同一レーン）', () => {
     expect(r.mx).toBe(290)
   })
 
+  it('上向き矢印（同一レーン・サイド出口で s.x = lane center + hw）でも障害を検出して迂回', () => {
+    // 上向き矢印では exitPt/entryPt がサイド出口を返すため s.x/e.x がレーン中心からズレる。
+    // colX オフセットが bboxW/2 までであり「< bboxW/2 + 2」マージンに収まることを保証する回帰テスト。
+    // A=(200,600) → C=(200,200) を上向きに引いた想定: s=(276,600), e=(276,200)
+    const sUp = { x: 276, y: 600 }
+    const eUp = { x: 276, y: 200 }
+    const fcUp = { x: 200, y: 600 }
+    const tcUp = { x: 200, y: 200 }
+    // 障害 B はレーン中心 (200) にあり、s.x (276) との差は hw=76 < bboxW/2 + 2 = 78 で検出される
+    const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+    const r = buildArrowPath(sUp, eUp, fcUp, tcUp, [B])
+    // detourX = 200 + 76 + 14 = 290 (障害の右端基準、s.x ではなく b.x 基準)
+    // sign=-1, halfDy=200, departY=600-14=586, approachY=200+14=214
+    expect(r.d).toBe('M276,600 L276,586 L290,586 L290,214 L276,214 L276,200')
+    expect(r.mx).toBe(290)
+  })
+
   describe('垂直進入＋垂直 depart（始終点とも垂直）', () => {
     it('右迂回パスは 6 セグメントで最初と最終セグメントが垂直', () => {
       const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -279,3 +279,150 @@ describe('collectObstacles', () => {
     expect(cys).toEqual([116, 200, 284])
   })
 })
+
+describe('buildArrowPath - 縦方向迂回（同一レーン）', () => {
+  // 共通の始終点（A→C 同一レーン、A=(200,200), C=(200,600) のときの exitPt/entryPt 後の値）
+  // ノード TW=152, TH=56 → hh=28, exit Y=200+28=228, entry Y=600-28=572
+  const s = { x: 200, y: 228 }
+  const e = { x: 200, y: 572 }
+  const fc = { x: 200, y: 200 }
+  const tc = { x: 200, y: 600 }
+
+  it('obstacles 省略 → 既存の直線パスを返す（垂直直線）', () => {
+    const r = buildArrowPath(s, e, fc, tc)
+    expect(r.d).toBe('M200,228 L200,572')
+  })
+
+  it('obstacles が空配列 → 既存の直線パスを返す', () => {
+    const r = buildArrowPath(s, e, fc, tc, [])
+    expect(r.d).toBe('M200,228 L200,572')
+  })
+
+  it('同一列・障害1個・左右空き → 右迂回パス（detourX = 障害右端 + 14）', () => {
+    const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B])
+    // detourX = 200 + 76 + 14 = 290
+    // sign=+1, halfDy=172, departY=228+14=242, approachY=572-14=558
+    expect(r.d).toBe('M200,228 L200,242 L290,242 L290,558 L200,558 L200,572')
+    expect(r.mx).toBe(290)
+    expect(r.my).toBe(400)
+  })
+
+  it('同一列・障害1個・直右塞がり → 左迂回（detourX = 障害左端 - 14）', () => {
+    const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+    const Bright: Bbox = { x: 284, y: 400, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B, Bright])
+    // detourX = 200 - 76 - 14 = 110
+    expect(r.d).toBe('M200,228 L200,242 L110,242 L110,558 L200,558 L200,572')
+    expect(r.mx).toBe(110)
+  })
+
+  it('同一列・障害1個・両塞がり → 右優先で右迂回', () => {
+    const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+    const Bright: Bbox = { x: 284, y: 400, w: 152, h: 56 }
+    const Bleft: Bbox = { x: 116, y: 400, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B, Bright, Bleft])
+    expect(r.mx).toBe(290)
+  })
+
+  it('同一列・障害2個・右空き → まとめて右迂回（detourX は最右端の最大）', () => {
+    const B: Bbox = { x: 200, y: 380, w: 152, h: 56 }
+    const C2: Bbox = { x: 200, y: 480, w: 200, h: 56 }
+    const sExt = { x: 200, y: 228 }
+    const eExt = { x: 200, y: 624 }
+    const r = buildArrowPath(sExt, eExt, { x: 200, y: 200 }, { x: 200, y: 700 }, [B, C2])
+    // 最右端: max(200+76, 200+100) = 300, +14 = 314
+    expect(r.mx).toBe(314)
+    expect(r.d).toBe('M200,228 L200,242 L314,242 L314,610 L200,610 L200,624')
+  })
+
+  it('同一列・障害2個・1つだけ直右塞がり → 左迂回', () => {
+    const B: Bbox = { x: 200, y: 380, w: 152, h: 56 }
+    const C2: Bbox = { x: 200, y: 480, w: 152, h: 56 }
+    const Bright: Bbox = { x: 284, y: 380, w: 152, h: 56 }
+    const sExt = { x: 200, y: 228 }
+    const eExt = { x: 200, y: 624 }
+    const r = buildArrowPath(sExt, eExt, { x: 200, y: 200 }, { x: 200, y: 700 }, [B, C2, Bright])
+    // 最左端: min(200-76, 200-76) = 124, -14 = 110
+    expect(r.mx).toBe(110)
+  })
+
+  it('同一列・障害なし（経路上に bbox がない）→ 直線', () => {
+    const farUp: Bbox = { x: 200, y: 100, w: 152, h: 56 }
+    const farDown: Bbox = { x: 200, y: 700, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [farUp, farDown])
+    expect(r.d).toBe('M200,228 L200,572')
+  })
+
+  it('斜め方向（dx >= 2）→ 既存の Z/L 字ロジック（縦迂回しない）', () => {
+    const sDiag = { x: 200, y: 228 }
+    const eDiag = { x: 300, y: 572 }
+    const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+    const r = buildArrowPath(sDiag, eDiag, { x: 200, y: 200 }, { x: 300, y: 600 }, [B])
+    expect(r.d).not.toContain('L290,242')
+  })
+
+  it('始終点が同じ Y（自己参照） → inCol 空 → 直線', () => {
+    const B: Bbox = { x: 200, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(
+      { x: 200, y: 200 },
+      { x: 200, y: 200 },
+      { x: 200, y: 200 },
+      { x: 200, y: 200 },
+      [B],
+    )
+    expect(r.d).toBe('M200,200 L200,200')
+  })
+
+  it('from/to 自身の bbox が混入しても Y±1 マージンで除外される', () => {
+    const fromSelfBbox: Bbox = { x: 200, y: 200, w: 152, h: 56 }
+    const toSelfBbox: Bbox = { x: 200, y: 600, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [fromSelfBbox, toSelfBbox])
+    expect(r.d).toBe('M200,228 L200,572')
+  })
+
+  it('同一列・下→上方向でも右迂回する（s.y > e.y）', () => {
+    const sR = { x: 200, y: 572 }
+    const eR = { x: 200, y: 228 }
+    const fcR = { x: 200, y: 600 }
+    const tcR = { x: 200, y: 200 }
+    const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+    const r = buildArrowPath(sR, eR, fcR, tcR, [B])
+    expect(r.d).toBe('M200,572 L200,558 L290,558 L290,242 L200,242 L200,228')
+    expect(r.mx).toBe(290)
+  })
+
+  describe('垂直進入＋垂直 depart（始終点とも垂直）', () => {
+    it('右迂回パスは 6 セグメントで最初と最終セグメントが垂直', () => {
+      const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+      const r = buildArrowPath(s, e, fc, tc, [B])
+      const segments = r.d.match(/[ML][^ML]+/g) ?? []
+      expect(segments).toHaveLength(6)
+      const first = segments[0]
+      const second = segments[1]
+      const firstX = Number(first.slice(1).split(',')[0])
+      const secondX = Number(second.slice(1).split(',')[0])
+      expect(firstX).toBe(secondX)
+      expect(firstX).toBe(s.x)
+      const last = segments[segments.length - 1]
+      const prev = segments[segments.length - 2]
+      const lastX = Number(last.slice(1).split(',')[0])
+      const prevX = Number(prev.slice(1).split(',')[0])
+      expect(lastX).toBe(prevX)
+      expect(lastX).toBe(e.x)
+    })
+
+    it('垂直距離が DEPART_GAP*2 未満の場合 departY/approachY は中央で接合し自己交差しない', () => {
+      const sN = { x: 200, y: 100 }
+      const eN = { x: 200, y: 120 }
+      const fcN = { x: 200, y: 80 }
+      const tcN = { x: 200, y: 140 }
+      const B: Bbox = { x: 200, y: 110, w: 152, h: 16 }
+      const r = buildArrowPath(sN, eN, fcN, tcN, [B])
+      // departY = 100 + 1 * Math.min(14, 10) = 110
+      // approachY = 120 - 1 * Math.min(14, 10) = 110
+      // detourX = 200 + 76 + 14 = 290
+      expect(r.d).toBe('M200,100 L200,110 L290,110 L290,110 L200,110 L200,120')
+    })
+  })
+})

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -519,4 +519,34 @@ describe('collectVerticalObstacles', () => {
     const cxs = result.map((b) => b.x).sort((a, b) => a - b)
     expect(cxs).toEqual([116, 200, 284])
   })
+
+  it('Bbox の w, h は引数の bboxW, bboxH と一致する', () => {
+    const result = collectVerticalObstacles({
+      nodes: baseNodes,
+      fromKey: 'A',
+      toKey: 'C',
+      fromCy: 200,
+      toCy: 600,
+      colX: 200,
+      colW: LANE_W,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    expect(result.every((b) => b.w === TW && b.h === TH)).toBe(true)
+  })
+
+  it('nodes が空配列 → 空配列を返す', () => {
+    const result = collectVerticalObstacles({
+      nodes: [],
+      fromKey: 'A',
+      toKey: 'C',
+      fromCy: 200,
+      toCy: 600,
+      colX: 200,
+      colW: LANE_W,
+      bboxW: TW,
+      bboxH: TH,
+    })
+    expect(result).toEqual([])
+  })
 })

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -58,11 +58,7 @@ function detectDetour(s: Point, e: Point, obstacles: Bbox[]): { detourY: number 
   return { detourY }
 }
 
-function detectVerticalDetour(
-  s: Point,
-  e: Point,
-  obstacles: Bbox[],
-): { detourX: number } | null {
+function detectVerticalDetour(s: Point, e: Point, obstacles: Bbox[]): { detourX: number } | null {
   // 垂直直線でなければ迂回しない
   if (Math.abs(e.x - s.x) >= 2) return null
 

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -64,6 +64,11 @@ function detectVerticalDetour(s: Point, e: Point, obstacles: Bbox[]): { detourX:
 
   const yLow = Math.min(s.y, e.y)
   const yHigh = Math.max(s.y, e.y)
+  // 注: 上向き同一レーン矢印では exitPt/entryPt がサイド出口（c.x ± hw）を返すため
+  // s.x はレーン中心ではなく `lane center ± bboxW/2` になりうる。一方、collectVerticalObstacles
+  // 側はレーン中心を colX に渡している。そのため同一レーンの障害ノード b.x との差は最大で
+  // bboxW/2 となるが、下記の `< b.w/2 + 2` 判定が `bboxW/2 < bboxW/2 + 2` を保証するため
+  // 同一列の障害は確実に検出される（マージン設計でカバー）。
   const colX = s.x
 
   // 垂直移動がなければ迂回対象なし

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -58,6 +58,49 @@ function detectDetour(s: Point, e: Point, obstacles: Bbox[]): { detourY: number 
   return { detourY }
 }
 
+function detectVerticalDetour(
+  s: Point,
+  e: Point,
+  obstacles: Bbox[],
+): { detourX: number } | null {
+  // 垂直直線でなければ迂回しない
+  if (Math.abs(e.x - s.x) >= 2) return null
+
+  const yLow = Math.min(s.y, e.y)
+  const yHigh = Math.max(s.y, e.y)
+  const colX = s.x
+
+  // 垂直移動がなければ迂回対象なし
+  if (yLow >= yHigh - 1) return null
+
+  // 経路上の障害ノード = 同一列（colX と X が重なる）かつ Y が始終点の間
+  const inCol = obstacles.filter(
+    (b) =>
+      Math.abs(b.x - colX) < b.w / 2 + 2 && b.y - b.h / 2 < yHigh - 1 && b.y + b.h / 2 > yLow + 1,
+  )
+  if (inCol.length === 0) return null
+
+  // 左右塞がり判定（Y 重なりするノードが直左/直右に存在するか）
+  // 前提: obstacles 配列には呼び出し側で「同一列＋直左列＋直右列のみ」をフィルタ済み
+  const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
+  const rightBlocked = inCol.some((obs) =>
+    obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
+  )
+  const leftBlocked = inCol.some((obs) =>
+    obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
+  )
+
+  // 方向決定: 右空きなら右、右塞がり＆左空きなら左、両塞がりは右優先
+  const goRight = !rightBlocked || leftBlocked
+
+  // detourX: 障害ノード群の最右端 + マージン or 最左端 - マージン
+  const detourX = goRight
+    ? Math.max(...inCol.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+    : Math.min(...inCol.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+
+  return { detourX }
+}
+
 interface ArrowPath {
   d: string
   mx: number
@@ -172,6 +215,20 @@ export const buildArrowPath = (
       //               → 垂直(e.y まで) → 水平(e.x へ進入)
       const d = `M${s.x},${s.y} L${departX},${s.y} L${departX},${detourY} L${approachX},${detourY} L${approachX},${e.y} L${e.x},${e.y}`
       return { d, mx: (s.x + e.x) / 2, my: detourY }
+    }
+
+    const vDetour = detectVerticalDetour(s, e, obstacles)
+    if (vDetour) {
+      const { detourX } = vDetour
+      // |e.y - s.y| / 2 で clamp（横版と対称な防御コード）
+      const sign = Math.sign(dy)
+      const halfDy = Math.abs(dy) / 2
+      const departY = s.y + sign * Math.min(DEPART_GAP, halfDy)
+      const approachY = e.y - sign * Math.min(APPROACH_GAP, halfDy)
+      // 6 セグメント: M → 垂直(departY まで) → 水平(detourX まで) → 垂直(approachY まで)
+      //               → 水平(e.x まで=s.x なので戻る) → 垂直(e.y へ進入)
+      const d = `M${s.x},${s.y} L${s.x},${departY} L${detourX},${departY} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
+      return { d, mx: detourX, my: (s.y + e.y) / 2 }
     }
   }
 

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -317,3 +317,49 @@ export function collectObstacles(args: CollectObstaclesArgs): Bbox[] {
   }
   return result
 }
+
+interface CollectVerticalObstaclesArgs {
+  nodes: ObstacleNode[]
+  fromKey: string
+  toKey: string
+  fromCy: number // 始点 Y
+  toCy: number // 終点 Y
+  colX: number // 同一列 X（始点・終点共通）
+  colW: number // 列ピッチ（FlowEditor の LW + G を渡す）
+  bboxW: number
+  bboxH: number
+}
+
+/**
+ * 矢印の同一列・直左列・直右列にあるノードを bbox 配列に変換する（縦版）。
+ * 同一列は from-to 間レンジに限定。直左/直右列は Y 制限なしで含める（左右塞がり判定用）。
+ * from/to 自身および 2 列以上離れたノードは除外する。
+ *
+ * 呼び出し側は同一レーン（fromLane === toLane）のときのみ本関数を呼ぶ想定。
+ * colX には fromNode の X 座標を渡すこと（同一レーンなので toNode.x と等価）。
+ *
+ * collectObstacles の対称版。横版の rowH に相当するのが colW（レーンピッチ）。
+ */
+export function collectVerticalObstacles(args: CollectVerticalObstaclesArgs): Bbox[] {
+  const { nodes, fromKey, toKey, fromCy, toCy, colX, colW, bboxW, bboxH } = args
+  const yLow = Math.min(fromCy, toCy)
+  const yHigh = Math.max(fromCy, toCy)
+  const result: Bbox[] = []
+  for (const n of nodes) {
+    if (n.key === fromKey || n.key === toKey) continue
+    const dx = Math.abs(n.cx - colX)
+    const onCol = dx < bboxW / 2 + 2
+    // 直左/直右列のみを採用（dx が colW に近い）。2列以上離れたノードは除外。
+    const onAdjacentCol = !onCol && dx > colW - bboxW / 2 && dx < colW + bboxW / 2
+    if (onCol) {
+      // 同一列: from-to 間レンジに限定（始終点 Y は除外）
+      if (n.cy > yLow + 1 && n.cy < yHigh - 1) {
+        result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+      }
+    } else if (onAdjacentCol) {
+      // 直左/直右列: 左右塞がり判定用に Y 制限なしで含める
+      result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+    }
+  }
+  return result
+}

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -198,7 +198,7 @@ export const buildArrowPath = (
   const dx = e.x - s.x,
     dy = e.y - s.y
 
-  // 迂回モード: 同一行で経路上に障害ノードがある場合
+  // 迂回モード: 同一行（水平直線）または同一レーン（垂直直線）で経路上に障害ノードがある場合
   if (obstacles && obstacles.length > 0) {
     const detour = detectDetour(s, e, obstacles)
     if (detour) {
@@ -220,13 +220,15 @@ export const buildArrowPath = (
     const vDetour = detectVerticalDetour(s, e, obstacles)
     if (vDetour) {
       const { detourX } = vDetour
-      // |e.y - s.y| / 2 で clamp（横版と対称な防御コード）
+      // |e.y - s.y| / 2 で clamp。横版（上方の detectDetour ブロック）と対称な防御コードで、
+      // ノード高が縮小しても departY/approachY が反対側を越えて自己交差するのを防ぐ。
+      // 縮退ケースでは中央垂直セグメントがゼロ長になる。
       const sign = Math.sign(dy)
       const halfDy = Math.abs(dy) / 2
       const departY = s.y + sign * Math.min(DEPART_GAP, halfDy)
       const approachY = e.y - sign * Math.min(APPROACH_GAP, halfDy)
       // 6 セグメント: M → 垂直(departY まで) → 水平(detourX まで) → 垂直(approachY まで)
-      //               → 水平(e.x まで=s.x なので戻る) → 垂直(e.y へ進入)
+      //               → 水平(e.x まで) → 垂直(e.y へ進入)
       const d = `M${s.x},${s.y} L${s.x},${departY} L${detourX},${departY} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
       return { d, mx: detourX, my: (s.y + e.y) / 2 }
     }


### PR DESCRIPTION
## Summary
- 同一レーン（縦方向）で A→C の間に B があるとき、右優先で B を迂回するロジックを追加（issue #333）
- 横方向の迂回（#314）の対称版。両塞がりでは右優先（横版の下優先と対称）
- `arrow-routing.ts` に `detectVerticalDetour` と `collectVerticalObstacles` を追加
- `FlowEditor.aPath` と `SharedFlowViewer.computeArrowPath` を `fri === tri || fli === tli` で分岐させて呼び出し

## Design / Plan
- 設計: `docs/superpowers/specs/2026-04-30-vertical-arrow-detour-design.md`
- 実装計画: `docs/superpowers/plans/2026-04-30-vertical-arrow-detour-plan.md`

## Test plan
- [x] 縦方向迂回ユニットテスト 14 件追加（基本/塞がり/複数障害/エッジ/6セグ形状/clamp）
- [x] `collectVerticalObstacles` ユニットテスト 6 件追加（同一列＋直左/直右、from/to除外、隣接、下→上、bbox 寸法、空配列）
- [x] 既存横方向テスト全 PASS（regression なし、71 → 77 件）
- [x] 全 1513 テスト pass、TypeScript clean
- [ ] エディタで A→C 縦迂回確認（**merge 前にユーザー目視確認お願いします**）
- [ ] 共有ビューアで同じ挙動確認

## 既知の懸念（spec 既載）
- depart 脚クリアランス問題（#328 の縦版）は本 PR ではスコープ外。横版と同じ単純 GAP 定数を採用しているため、密レイアウトでの depart 区間の貫通リスクは横版と同等の水準。#328 の対応で両方向まとめて clamp 拡張する方針。

## Notes
- レーンピッチ（`LW + G`）は `laneX(li) = LM + li * (LW + G)` より uniform。グループ親レーンの幅 (`getGroupWidth`) は header 表示のみ影響、ノードの実 X 位置は影響なし。
- 設計上、`detectDetour` / `detectVerticalDetour` および `collectObstacles` / `collectVerticalObstacles` は意図的に対称コピー。共通化（軸抽象化）は読みやすさと regression 安全性を優先して採用せず（spec 内で記録）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)