### PR TITLE
fix(#336): auto-connect でセル通過矢印への割り込みを実装 (Step 2.5)

### DIFF
--- a/docs/plans/2026-04-30-issue-336-auto-connect-step25-design.md
+++ b/docs/plans/2026-04-30-issue-336-auto-connect-step25-design.md
@@ -1,0 +1,134 @@
+# Issue #336: 自動接続 Step 2.5（経路通過矢印への割り込み）設計書
+
+- **Issue**: https://github.com/tomohirof/flowline/issues/336
+- **作成日**: 2026-04-30
+- **対象**: `src/features/editor/auto-connect.ts`, `src/features/editor/hooks/useArrows.ts`
+
+## 背景と問題
+
+縦方向に通過する矢印 `A → C`（A は上の行、C は下の行）の経路上のセルに新ノード B を追加したとき、自動接続が `A → B`（または `A → B → C` のスプライス）を作らず、行が遠い別のテールから B に矢印を引く。
+
+実例: `案件情報登録 (sharepoint, 行12) → 正式登録 (入力担当, 行14)` が `入力担当・行13` を縦に通過している状態で同セルに `AAAA` を追加すると、`情報提供依頼 (営業対応, 行10) → AAAA` が引かれる。
+
+### 原因
+
+`findClosestUpstream` の現状の優先順位：
+
+1. 同行（同じ row、左右どちらでも近いレーン）
+2. 同レーン上流（同じ lane の上の行で最も近い）
+3. 上流テール（outgoing を持たない、上の行のノード）
+
+経路通過のシナリオでは Step 1, 2 にヒットせず、Step 3 のテール選定では「outgoing を持つ `A` は除外」されるため、無関係な別レーンの遠いテールが選ばれてしまう。
+
+`findCrossingArrows` + `detectCrossing` は行ごと挿入時のみ起動するため、既存セルへの追加では救済されない。
+
+## 解決方針
+
+`findClosestUpstream` の Step 2 と Step 3 の間に **Step 2.5: 経路通過矢印の上流を返す** を挿入する。`autoConnectOnCreate` 側ではヒットした矢印 ID を受け取り、**その矢印1本だけを** スプライス対象にする。
+
+既存の broad splice（`bestKey` の outgoing 全部）は Step 1/2/3 経由のときだけ温存し、Step 2.5 経由では関係ない下流まで巻き込まないようにする（α 方針）。
+
+## API 変更
+
+### `findClosestUpstream` の戻り値
+
+`string | null` から以下に変更：
+
+```ts
+export type UpstreamResult = {
+  key: string
+  splitArrowId?: string  // Step 2.5 でヒットした矢印 ID（その場合のみセット）
+}
+
+export function findClosestUpstream(
+  tasks: Record<string, { lid: string; rid: string }>,
+  rows: { id: string }[],
+  lanes: { id: string }[],
+  newRi: number,
+  newLi: number,
+  arrows: { id: string; from: string; to: string }[],
+): UpstreamResult | null
+```
+
+呼び出し側で「Step 2.5 ヒットだったか」を判別できるようにするためのもの。`splitArrowId` の有無が discriminator。
+
+`arrows` 引数の型は現状 `{ from, to }` のみ受け取っているが、`id` を必須化する（`autoConnectOnCreate` の呼び出し側はもとから `InternalArrow` を渡しているので破壊変更にはならない）。
+
+### Step 2.5 の判定ロジック
+
+新ヘルパー（`findClosestUpstream` 内のローカル処理として実装してよい）：
+
+候補矢印：
+- `arrow.from` / `arrow.to` の task が存在し、その rid/lid が rows/lanes に解決できる（できない矢印はスキップ）
+- `fromRi < newRi < toRi`（行跨ぎ）
+- かつ次のいずれか
+  - **タイプ①**: `toLi === newLi`（矢印が newLi に着地）
+  - **タイプ②**: `min(fromLi, toLi) <= newLi <= max(fromLi, toLi)`（newLi が fromLi-toLi の範囲内）
+
+優先順位：
+
+1. タイプ① > タイプ②
+2. 同タイプ内では `newRi - fromRi` が小さい方（より近い上流）
+3. 同点なら最初に見つかったもの
+
+ヒットしたら `{ key: arrow.from, splitArrowId: arrow.id }` を返す。
+
+### `autoConnectOnCreate` のスプライス処理
+
+```ts
+const result = findClosestUpstream(...)
+if (!result) return
+const { key: bestKey, splitArrowId } = result
+
+const splitArrows = splitArrowId
+  ? arrows.filter((a) => a.id === splitArrowId)        // ★ Step 2.5: 対象1本のみ
+  : (bestRi >= 0 && bestRi < ri
+      ? arrows.filter((a) => {
+          if (a.from !== bestKey) return false
+          const toTask = tasks[a.to]
+          if (!toTask) return false
+          const toRi = rows.findIndex((r) => r.id === toTask.rid)
+          return toRi > ri
+        })                                              // 既存の broad splice（Step 1/2/3 用）
+      : [])
+```
+
+`autoSplitHandledRef.current = splitIds` の代入はそのまま。Step 2.5 経由でも `splitArrowId` が含まれた `splitIds` セットがトースト抑止に使われる（issue 懸念 B）。
+
+## テスト計画
+
+### `auto-connect.test.ts`
+
+既存テストの戻り値形式を `expect(result).toBe('X')` → `expect(result?.key).toBe('X')` に機械的更新（約16〜18箇所）。挙動は変えない。
+
+新規テスト：
+
+| # | ケース | 期待 |
+|---|---|---|
+| 1 | 通過矢印 `A→C` のセルに B 追加 → A を返し splitArrowId をセット | `result.key === 'A' && result.splitArrowId === 'a1'` |
+| 2 | 複数候補で `toLi===newLi` の方を優先（タイプ①優先） | タイプ①の矢印 |
+| 3 | 複数候補で `fromRi` が近い方を優先 | より近い fromRi の矢印 |
+| 4 | Step 2（同レーン上流）が Step 2.5 より優先 | 同レーン上流のキー、`splitArrowId === undefined` |
+| 5 | Step 1（同行）が Step 2.5 より優先 | 同行のキー、`splitArrowId === undefined` |
+| 6 | レーン条件を満たさない（行跨ぎだけ）→ Step 2.5 ヒットせず Step 3 へ | テール |
+| 7 | issue 再現シナリオ（案件情報登録 → 正式登録 を入力担当・行13 のセルで挟む） | 案件情報登録のキー + 矢印 ID |
+
+### `useArrows.test.ts`
+
+| # | ケース | 期待 |
+|---|---|---|
+| 1 | 上流 A が `A→C`（通過）と `A→D`（無関係な別レーン下流）を持つ。B を `A→C` 経路上に追加 | `A→C` のみ `A→B→C` にスプライスされ、`A→D` は無傷 |
+
+## スコープ外
+
+- 既存セル追加時に `detectCrossing` トーストを出す対応（Step 2.5 で根治するため不要）
+- `findCrossingArrows`（既存関数）の改修。Step 2.5 用ロジックは別ヘルパー or `findClosestUpstream` 内のローカル実装にする
+- `arrow-routing.ts` の描画側（#333 とは別問題）
+- autoConnect OFF 時の挙動（既存通り `autoConnectOnCreate` 自体がスキップされるため無影響）
+
+## 関連 Issue
+
+- #182 自動接続をフロー位置順に改善＆行挿入時の矢印再整理トーストを追加
+- #188 自動接続の候補を Tail に限定（このルールで本件が顕在化）
+- #265, #297 同行ノードの優先順位調整
+- #333 縦方向の矢印迂回（描画側、本件は接続側で別問題）

--- a/docs/plans/2026-04-30-issue-336-auto-connect-step25-design.md
+++ b/docs/plans/2026-04-30-issue-336-auto-connect-step25-design.md
@@ -37,7 +37,7 @@
 ```ts
 export type UpstreamResult = {
   key: string
-  splitArrowId?: string  // Step 2.5 でヒットした矢印 ID（その場合のみセット）
+  splitArrowId?: string // Step 2.5 でヒットした矢印 ID（その場合のみセット）
 }
 
 export function findClosestUpstream(
@@ -59,6 +59,7 @@ export function findClosestUpstream(
 新ヘルパー（`findClosestUpstream` 内のローカル処理として実装してよい）：
 
 候補矢印：
+
 - `arrow.from` / `arrow.to` の task が存在し、その rid/lid が rows/lanes に解決できる（できない矢印はスキップ）
 - `fromRi < newRi < toRi`（行跨ぎ）
 - かつ次のいずれか
@@ -103,21 +104,21 @@ const splitArrows = splitArrowId
 
 新規テスト：
 
-| # | ケース | 期待 |
-|---|---|---|
-| 1 | 通過矢印 `A→C` のセルに B 追加 → A を返し splitArrowId をセット | `result.key === 'A' && result.splitArrowId === 'a1'` |
-| 2 | 複数候補で `toLi===newLi` の方を優先（タイプ①優先） | タイプ①の矢印 |
-| 3 | 複数候補で `fromRi` が近い方を優先 | より近い fromRi の矢印 |
-| 4 | Step 2（同レーン上流）が Step 2.5 より優先 | 同レーン上流のキー、`splitArrowId === undefined` |
-| 5 | Step 1（同行）が Step 2.5 より優先 | 同行のキー、`splitArrowId === undefined` |
-| 6 | レーン条件を満たさない（行跨ぎだけ）→ Step 2.5 ヒットせず Step 3 へ | テール |
-| 7 | issue 再現シナリオ（案件情報登録 → 正式登録 を入力担当・行13 のセルで挟む） | 案件情報登録のキー + 矢印 ID |
+| #   | ケース                                                                      | 期待                                                 |
+| --- | --------------------------------------------------------------------------- | ---------------------------------------------------- |
+| 1   | 通過矢印 `A→C` のセルに B 追加 → A を返し splitArrowId をセット             | `result.key === 'A' && result.splitArrowId === 'a1'` |
+| 2   | 複数候補で `toLi===newLi` の方を優先（タイプ①優先）                         | タイプ①の矢印                                        |
+| 3   | 複数候補で `fromRi` が近い方を優先                                          | より近い fromRi の矢印                               |
+| 4   | Step 2（同レーン上流）が Step 2.5 より優先                                  | 同レーン上流のキー、`splitArrowId === undefined`     |
+| 5   | Step 1（同行）が Step 2.5 より優先                                          | 同行のキー、`splitArrowId === undefined`             |
+| 6   | レーン条件を満たさない（行跨ぎだけ）→ Step 2.5 ヒットせず Step 3 へ         | テール                                               |
+| 7   | issue 再現シナリオ（案件情報登録 → 正式登録 を入力担当・行13 のセルで挟む） | 案件情報登録のキー + 矢印 ID                         |
 
 ### `useArrows.test.ts`
 
-| # | ケース | 期待 |
-|---|---|---|
-| 1 | 上流 A が `A→C`（通過）と `A→D`（無関係な別レーン下流）を持つ。B を `A→C` 経路上に追加 | `A→C` のみ `A→B→C` にスプライスされ、`A→D` は無傷 |
+| #   | ケース                                                                                 | 期待                                              |
+| --- | -------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| 1   | 上流 A が `A→C`（通過）と `A→D`（無関係な別レーン下流）を持つ。B を `A→C` 経路上に追加 | `A→C` のみ `A→B→C` にスプライスされ、`A→D` は無傷 |
 
 ## スコープ外
 

--- a/docs/plans/2026-04-30-issue-336-auto-connect-step25-plan.md
+++ b/docs/plans/2026-04-30-issue-336-auto-connect-step25-plan.md
@@ -5,6 +5,7 @@
 **Goal:** `findClosestUpstream` に「経路通過矢印への割り込み」(Step 2.5) を追加し、新ノードを既存矢印の経路上に挿入したとき、その矢印1本だけを `from → new → to` にスプライスする。
 
 **Architecture:**
+
 - `findClosestUpstream` の戻り値を `{ key, splitArrowId? } | null` に拡張し、Step 2 と Step 3 の間に Step 2.5 を挿入。
 - `autoConnectOnCreate` は `splitArrowId` がある場合のみ「対象1本だけ」をスプライス、無い場合は既存の broad splice を維持。
 
@@ -16,11 +17,11 @@
 
 ## File Structure
 
-| File | Role |
-|---|---|
-| `src/features/editor/auto-connect.ts` | `UpstreamResult` 型・Step 2.5 ロジックを追加 |
-| `src/features/editor/auto-connect.test.ts` | 既存テストの戻り値形式更新 + Step 2.5 ケース追加 |
-| `src/features/editor/hooks/useArrows.ts` | `splitArrowId` を使ったターゲット限定スプライス |
+| File                                          | Role                                             |
+| --------------------------------------------- | ------------------------------------------------ |
+| `src/features/editor/auto-connect.ts`         | `UpstreamResult` 型・Step 2.5 ロジックを追加     |
+| `src/features/editor/auto-connect.test.ts`    | 既存テストの戻り値形式更新 + Step 2.5 ケース追加 |
+| `src/features/editor/hooks/useArrows.ts`      | `splitArrowId` を使ったターゲット限定スプライス  |
 | `src/features/editor/hooks/useArrows.test.ts` | 通過矢印スプライス時の他 outgoing 不変テスト追加 |
 
 ---
@@ -28,6 +29,7 @@
 ## Task 1: `findClosestUpstream` 戻り値型のリファクタ
 
 **Files:**
+
 - Modify: `src/features/editor/auto-connect.ts:1-97`
 - Modify: `src/features/editor/auto-connect.test.ts` (16〜18 箇所のアサーション形式変更)
 - Modify: `src/features/editor/hooks/useArrows.ts:24-25`
@@ -174,9 +176,9 @@ const autoConnectOnCreate = (taskKey: string, ri: number, li: number): void => {
 
 `src/features/editor/auto-connect.test.ts` 全体で `findClosestUpstream(...)` の戻り値を扱う行を以下のように書き換える：
 
-| 旧 | 新 |
-|---|---|
-| `expect(result).toBe('X')` | `expect(result?.key).toBe('X')` |
+| 旧                          | 新                                       |
+| --------------------------- | ---------------------------------------- |
+| `expect(result).toBe('X')`  | `expect(result?.key).toBe('X')`          |
 | `expect(result).toBeNull()` | `expect(result).toBeNull()` （変更なし） |
 
 対象行（line 12, 23, 33, 43, 51, 61, 72, 88, 101, 113, 130, 150, 165, 187, 198, 211, 226, 263, 276, 287 付近）。`expect(result).toBeNull()` の行は変更不要。
@@ -210,6 +212,7 @@ EOF
 ## Task 2: Step 2.5 を TDD で実装（基本ケース）
 
 **Files:**
+
 - Modify: `src/features/editor/auto-connect.ts` (Step 2 と Step 3 の間に Step 2.5 ブロック追加)
 - Modify: `src/features/editor/auto-connect.test.ts` (新規テスト追加)
 
@@ -218,23 +221,23 @@ EOF
 `src/features/editor/auto-connect.test.ts` の `describe('findClosestUpstream', () => { ... })` の末尾、最後の `it(...)` の後ろに以下を追加：
 
 ```ts
-  it('should return crossing arrow upstream when new node is on its path (Step 2.5)', () => {
-    // A(l0,r0) → C(l1,r2). New node at (r1, l1).
-    // Step 1: same-row r1 — none.
-    // Step 2: same-lane l1 upstream — none (C is downstream).
-    // Step 2.5: arrow A→C, fromRi=0 < newRi=1 < toRi=2, toLi=l1 === newLi=l1 (タイプ①).
-    //          → returns A + splitArrowId.
-    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
-    const lanes = [{ id: 'l0' }, { id: 'l1' }]
-    const tasks: Record<string, { lid: string; rid: string }> = {
-      A: { lid: 'l0', rid: 'r0' },
-      C: { lid: 'l1', rid: 'r2' },
-    }
-    const arrows = [{ id: 'a1', from: 'A', to: 'C', comment: '' }]
-    const result = findClosestUpstream(tasks, rows, lanes, 1, 1, arrows)
-    expect(result?.key).toBe('A')
-    expect(result?.splitArrowId).toBe('a1')
-  })
+it('should return crossing arrow upstream when new node is on its path (Step 2.5)', () => {
+  // A(l0,r0) → C(l1,r2). New node at (r1, l1).
+  // Step 1: same-row r1 — none.
+  // Step 2: same-lane l1 upstream — none (C is downstream).
+  // Step 2.5: arrow A→C, fromRi=0 < newRi=1 < toRi=2, toLi=l1 === newLi=l1 (タイプ①).
+  //          → returns A + splitArrowId.
+  const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+  const lanes = [{ id: 'l0' }, { id: 'l1' }]
+  const tasks: Record<string, { lid: string; rid: string }> = {
+    A: { lid: 'l0', rid: 'r0' },
+    C: { lid: 'l1', rid: 'r2' },
+  }
+  const arrows = [{ id: 'a1', from: 'A', to: 'C', comment: '' }]
+  const result = findClosestUpstream(tasks, rows, lanes, 1, 1, arrows)
+  expect(result?.key).toBe('A')
+  expect(result?.splitArrowId).toBe('a1')
+})
 ```
 
 - [ ] **Step 2: テスト失敗を確認（RED）**
@@ -250,41 +253,41 @@ npx vitest run src/features/editor/auto-connect.test.ts -t "Step 2.5"
 `src/features/editor/auto-connect.ts` の Step 2 ブロック直後（既存の Step 3 ブロック直前）に以下を挿入：
 
 ```ts
-  // 2.5. Crossing arrow at cell: if an arrow's path passes through (newRi, newLi),
-  //      use its `from` node as upstream and tag the arrow ID for targeted splice.
-  //      Inserted between Step 2 and Step 3 so same-row / same-lane upstream wins,
-  //      but a crossing arrow beats an unrelated tail.
-  {
-    type Candidate = { id: string; from: string; toLiMatches: boolean; fromRiDist: number }
-    let best: Candidate | null = null
-    for (const arrow of arrows) {
-      const fromTask = tasks[arrow.from]
-      const toTask = tasks[arrow.to]
-      if (!fromTask || !toTask) continue
-      const fromRi = rows.findIndex((r) => r.id === fromTask.rid)
-      const toRi = rows.findIndex((r) => r.id === toTask.rid)
-      const fromLi = lanes.findIndex((l) => l.id === fromTask.lid)
-      const toLi = lanes.findIndex((l) => l.id === toTask.lid)
-      if (fromRi < 0 || toRi < 0 || fromLi < 0 || toLi < 0) continue
-      if (!(fromRi < newRi && toRi > newRi)) continue
+// 2.5. Crossing arrow at cell: if an arrow's path passes through (newRi, newLi),
+//      use its `from` node as upstream and tag the arrow ID for targeted splice.
+//      Inserted between Step 2 and Step 3 so same-row / same-lane upstream wins,
+//      but a crossing arrow beats an unrelated tail.
+{
+  type Candidate = { id: string; from: string; toLiMatches: boolean; fromRiDist: number }
+  let best: Candidate | null = null
+  for (const arrow of arrows) {
+    const fromTask = tasks[arrow.from]
+    const toTask = tasks[arrow.to]
+    if (!fromTask || !toTask) continue
+    const fromRi = rows.findIndex((r) => r.id === fromTask.rid)
+    const toRi = rows.findIndex((r) => r.id === toTask.rid)
+    const fromLi = lanes.findIndex((l) => l.id === fromTask.lid)
+    const toLi = lanes.findIndex((l) => l.id === toTask.lid)
+    if (fromRi < 0 || toRi < 0 || fromLi < 0 || toLi < 0) continue
+    if (!(fromRi < newRi && toRi > newRi)) continue
 
-      const toLiMatches = toLi === newLi
-      const minLi = Math.min(fromLi, toLi)
-      const maxLi = Math.max(fromLi, toLi)
-      const passesLaneRange = minLi <= newLi && newLi <= maxLi
-      if (!toLiMatches && !passesLaneRange) continue
+    const toLiMatches = toLi === newLi
+    const minLi = Math.min(fromLi, toLi)
+    const maxLi = Math.max(fromLi, toLi)
+    const passesLaneRange = minLi <= newLi && newLi <= maxLi
+    if (!toLiMatches && !passesLaneRange) continue
 
-      const fromRiDist = newRi - fromRi
-      if (
-        !best ||
-        (toLiMatches && !best.toLiMatches) ||
-        (toLiMatches === best.toLiMatches && fromRiDist < best.fromRiDist)
-      ) {
-        best = { id: arrow.id, from: arrow.from, toLiMatches, fromRiDist }
-      }
+    const fromRiDist = newRi - fromRi
+    if (
+      !best ||
+      (toLiMatches && !best.toLiMatches) ||
+      (toLiMatches === best.toLiMatches && fromRiDist < best.fromRiDist)
+    ) {
+      best = { id: arrow.id, from: arrow.from, toLiMatches, fromRiDist }
     }
-    if (best) return { key: best.from, splitArrowId: best.id }
   }
+  if (best) return { key: best.from, splitArrowId: best.id }
+}
 ```
 
 - [ ] **Step 4: テスト成功を確認（GREEN）**
@@ -324,6 +327,7 @@ EOF
 ## Task 3: Step 2.5 のカバレッジテスト追加
 
 **Files:**
+
 - Modify: `src/features/editor/auto-connect.test.ts`
 
 Task 2 で実装は完了しているので、本タスクは挙動を網羅するテストを追加するだけ。すべて初回からパスするはず。
@@ -333,140 +337,134 @@ Task 2 で実装は完了しているので、本タスクは挙動を網羅す�
 `describe('findClosestUpstream', ...)` の末尾に追加：
 
 ```ts
-  it('should prefer toLi===newLi (タイプ①) over lane-range match (タイプ②) in Step 2.5', () => {
-    // Two crossing arrows:
-    //   - A(l0,r0) → B(l4,r2): タイプ② (newLi=l2 in [l0..l4])
-    //   - X(l1,r0) → Y(l2,r2): タイプ① (toLi=l2=newLi)
-    // New at (r1, l2). Both pass row crossing. タイプ① must win.
-    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
-    const lanes = [{ id: 'l0' }, { id: 'l1' }, { id: 'l2' }, { id: 'l3' }, { id: 'l4' }]
-    const tasks: Record<string, { lid: string; rid: string }> = {
-      A: { lid: 'l0', rid: 'r0' },
-      B: { lid: 'l4', rid: 'r2' },
-      X: { lid: 'l1', rid: 'r0' },
-      Y: { lid: 'l2', rid: 'r2' },
-    }
-    const arrows = [
-      { id: 'aAB', from: 'A', to: 'B', comment: '' },
-      { id: 'aXY', from: 'X', to: 'Y', comment: '' },
-    ]
-    const result = findClosestUpstream(tasks, rows, lanes, 1, 2, arrows)
-    expect(result?.key).toBe('X')
-    expect(result?.splitArrowId).toBe('aXY')
-  })
+it('should prefer toLi===newLi (タイプ①) over lane-range match (タイプ②) in Step 2.5', () => {
+  // Two crossing arrows:
+  //   - A(l0,r0) → B(l4,r2): タイプ② (newLi=l2 in [l0..l4])
+  //   - X(l1,r0) → Y(l2,r2): タイプ① (toLi=l2=newLi)
+  // New at (r1, l2). Both pass row crossing. タイプ① must win.
+  const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+  const lanes = [{ id: 'l0' }, { id: 'l1' }, { id: 'l2' }, { id: 'l3' }, { id: 'l4' }]
+  const tasks: Record<string, { lid: string; rid: string }> = {
+    A: { lid: 'l0', rid: 'r0' },
+    B: { lid: 'l4', rid: 'r2' },
+    X: { lid: 'l1', rid: 'r0' },
+    Y: { lid: 'l2', rid: 'r2' },
+  }
+  const arrows = [
+    { id: 'aAB', from: 'A', to: 'B', comment: '' },
+    { id: 'aXY', from: 'X', to: 'Y', comment: '' },
+  ]
+  const result = findClosestUpstream(tasks, rows, lanes, 1, 2, arrows)
+  expect(result?.key).toBe('X')
+  expect(result?.splitArrowId).toBe('aXY')
+})
 ```
 
 - [ ] **Step 2: fromRi 近接タイブレークのテストを追加**
 
 ```ts
-  it('should prefer closer fromRi when both candidates are タイプ① in Step 2.5', () => {
-    // Two タイプ① arrows landing in newLi=l1:
-    //   - A(l0,r0) → C(l1,r5)  fromRi=0, dist=2
-    //   - D(l0,r1) → E(l1,r5)  fromRi=1, dist=1 ← closer
-    // New at (r2, l1).
-    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }, { id: 'r3' }, { id: 'r4' }, { id: 'r5' }]
-    const lanes = [{ id: 'l0' }, { id: 'l1' }]
-    const tasks: Record<string, { lid: string; rid: string }> = {
-      A: { lid: 'l0', rid: 'r0' },
-      C: { lid: 'l1', rid: 'r5' },
-      D: { lid: 'l0', rid: 'r1' },
-      E: { lid: 'l1', rid: 'r5' },
-    }
-    const arrows = [
-      { id: 'aAC', from: 'A', to: 'C', comment: '' },
-      { id: 'aDE', from: 'D', to: 'E', comment: '' },
-    ]
-    const result = findClosestUpstream(tasks, rows, lanes, 2, 1, arrows)
-    expect(result?.key).toBe('D')
-    expect(result?.splitArrowId).toBe('aDE')
-  })
+it('should prefer closer fromRi when both candidates are タイプ① in Step 2.5', () => {
+  // Two タイプ① arrows landing in newLi=l1:
+  //   - A(l0,r0) → C(l1,r5)  fromRi=0, dist=2
+  //   - D(l0,r1) → E(l1,r5)  fromRi=1, dist=1 ← closer
+  // New at (r2, l1).
+  const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }, { id: 'r3' }, { id: 'r4' }, { id: 'r5' }]
+  const lanes = [{ id: 'l0' }, { id: 'l1' }]
+  const tasks: Record<string, { lid: string; rid: string }> = {
+    A: { lid: 'l0', rid: 'r0' },
+    C: { lid: 'l1', rid: 'r5' },
+    D: { lid: 'l0', rid: 'r1' },
+    E: { lid: 'l1', rid: 'r5' },
+  }
+  const arrows = [
+    { id: 'aAC', from: 'A', to: 'C', comment: '' },
+    { id: 'aDE', from: 'D', to: 'E', comment: '' },
+  ]
+  const result = findClosestUpstream(tasks, rows, lanes, 2, 1, arrows)
+  expect(result?.key).toBe('D')
+  expect(result?.splitArrowId).toBe('aDE')
+})
 ```
 
 - [ ] **Step 3: Step 2 が Step 2.5 より優先されるテストを追加**
 
 ```ts
-  it('should prefer same-lane upstream (Step 2) over crossing arrow (Step 2.5)', () => {
-    // Same-lane upstream P(l1,r1) and crossing arrow A→C exist.
-    // Step 2 must return P, splitArrowId must be undefined.
-    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }, { id: 'r3' }]
-    const lanes = [{ id: 'l0' }, { id: 'l1' }]
-    const tasks: Record<string, { lid: string; rid: string }> = {
-      P: { lid: 'l1', rid: 'r1' },
-      A: { lid: 'l0', rid: 'r0' },
-      C: { lid: 'l1', rid: 'r3' },
-    }
-    const arrows = [{ id: 'aAC', from: 'A', to: 'C', comment: '' }]
-    const result = findClosestUpstream(tasks, rows, lanes, 2, 1, arrows)
-    expect(result?.key).toBe('P')
-    expect(result?.splitArrowId).toBeUndefined()
-  })
+it('should prefer same-lane upstream (Step 2) over crossing arrow (Step 2.5)', () => {
+  // Same-lane upstream P(l1,r1) and crossing arrow A→C exist.
+  // Step 2 must return P, splitArrowId must be undefined.
+  const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }, { id: 'r3' }]
+  const lanes = [{ id: 'l0' }, { id: 'l1' }]
+  const tasks: Record<string, { lid: string; rid: string }> = {
+    P: { lid: 'l1', rid: 'r1' },
+    A: { lid: 'l0', rid: 'r0' },
+    C: { lid: 'l1', rid: 'r3' },
+  }
+  const arrows = [{ id: 'aAC', from: 'A', to: 'C', comment: '' }]
+  const result = findClosestUpstream(tasks, rows, lanes, 2, 1, arrows)
+  expect(result?.key).toBe('P')
+  expect(result?.splitArrowId).toBeUndefined()
+})
 ```
 
 - [ ] **Step 4: Step 1 が Step 2.5 より優先されるテストを追加**
 
 ```ts
-  it('should prefer same-row node (Step 1) over crossing arrow (Step 2.5)', () => {
-    // Same-row node SR(l0,r1) and crossing arrow A→C through (r1,l1).
-    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
-    const lanes = [{ id: 'l0' }, { id: 'l1' }]
-    const tasks: Record<string, { lid: string; rid: string }> = {
-      SR: { lid: 'l0', rid: 'r1' },
-      A: { lid: 'l0', rid: 'r0' },
-      C: { lid: 'l1', rid: 'r2' },
-    }
-    const arrows = [{ id: 'aAC', from: 'A', to: 'C', comment: '' }]
-    const result = findClosestUpstream(tasks, rows, lanes, 1, 1, arrows)
-    expect(result?.key).toBe('SR')
-    expect(result?.splitArrowId).toBeUndefined()
-  })
+it('should prefer same-row node (Step 1) over crossing arrow (Step 2.5)', () => {
+  // Same-row node SR(l0,r1) and crossing arrow A→C through (r1,l1).
+  const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+  const lanes = [{ id: 'l0' }, { id: 'l1' }]
+  const tasks: Record<string, { lid: string; rid: string }> = {
+    SR: { lid: 'l0', rid: 'r1' },
+    A: { lid: 'l0', rid: 'r0' },
+    C: { lid: 'l1', rid: 'r2' },
+  }
+  const arrows = [{ id: 'aAC', from: 'A', to: 'C', comment: '' }]
+  const result = findClosestUpstream(tasks, rows, lanes, 1, 1, arrows)
+  expect(result?.key).toBe('SR')
+  expect(result?.splitArrowId).toBeUndefined()
+})
 ```
 
 - [ ] **Step 5: レーン条件不一致のとき Step 3 へフォールスルーするテストを追加**
 
 ```ts
-  it('should fall through to Step 3 when crossing arrow does not match lane criteria', () => {
-    // Arrow A(l0,r0) → C(l1,r2). New at (r1, l3).
-    // Row crossing OK, but neither toLi(l1)===newLi(l3) nor newLi in [l0..l1] range.
-    // → Step 2.5 misses, Step 3 picks tail T.
-    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
-    const lanes = [{ id: 'l0' }, { id: 'l1' }, { id: 'l2' }, { id: 'l3' }]
-    const tasks: Record<string, { lid: string; rid: string }> = {
-      A: { lid: 'l0', rid: 'r0' },
-      C: { lid: 'l1', rid: 'r2' },
-      T: { lid: 'l3', rid: 'r0' }, // isolated tail in upstream row
-    }
-    const arrows = [{ id: 'aAC', from: 'A', to: 'C', comment: '' }]
-    const result = findClosestUpstream(tasks, rows, lanes, 1, 3, arrows)
-    expect(result?.key).toBe('T')
-    expect(result?.splitArrowId).toBeUndefined()
-  })
+it('should fall through to Step 3 when crossing arrow does not match lane criteria', () => {
+  // Arrow A(l0,r0) → C(l1,r2). New at (r1, l3).
+  // Row crossing OK, but neither toLi(l1)===newLi(l3) nor newLi in [l0..l1] range.
+  // → Step 2.5 misses, Step 3 picks tail T.
+  const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+  const lanes = [{ id: 'l0' }, { id: 'l1' }, { id: 'l2' }, { id: 'l3' }]
+  const tasks: Record<string, { lid: string; rid: string }> = {
+    A: { lid: 'l0', rid: 'r0' },
+    C: { lid: 'l1', rid: 'r2' },
+    T: { lid: 'l3', rid: 'r0' }, // isolated tail in upstream row
+  }
+  const arrows = [{ id: 'aAC', from: 'A', to: 'C', comment: '' }]
+  const result = findClosestUpstream(tasks, rows, lanes, 1, 3, arrows)
+  expect(result?.key).toBe('T')
+  expect(result?.splitArrowId).toBeUndefined()
+})
 ```
 
 - [ ] **Step 6: issue 再現シナリオのテストを追加**
 
 ```ts
-  it('should reproduce issue #336 scenario (案件情報登録 → 正式登録 with new node on path)', () => {
-    // 案件情報登録 (l_sharepoint, r12) → 正式登録 (l_input, r14)
-    // 情報提供依頼 (l_sales, r10) is an isolated tail — must NOT be picked.
-    // New node at (r13, l_input). Step 2.5 must intercept.
-    const rows = Array.from({ length: 16 }, (_, i) => ({ id: `r${i}` }))
-    const lanes = [
-      { id: 'l_sales' },
-      { id: 'l_sharepoint' },
-      { id: 'l_input' },
-    ]
-    const tasks: Record<string, { lid: string; rid: string }> = {
-      info_request: { lid: 'l_sales', rid: 'r10' }, // 情報提供依頼 (tail)
-      sp_register: { lid: 'l_sharepoint', rid: 'r12' }, // 案件情報登録
-      formal_register: { lid: 'l_input', rid: 'r14' }, // 正式登録
-    }
-    const arrows = [
-      { id: 'a_sp_to_formal', from: 'sp_register', to: 'formal_register', comment: '' },
-    ]
-    const result = findClosestUpstream(tasks, rows, lanes, 13, 2, arrows)
-    expect(result?.key).toBe('sp_register')
-    expect(result?.splitArrowId).toBe('a_sp_to_formal')
-  })
+it('should reproduce issue #336 scenario (案件情報登録 → 正式登録 with new node on path)', () => {
+  // 案件情報登録 (l_sharepoint, r12) → 正式登録 (l_input, r14)
+  // 情報提供依頼 (l_sales, r10) is an isolated tail — must NOT be picked.
+  // New node at (r13, l_input). Step 2.5 must intercept.
+  const rows = Array.from({ length: 16 }, (_, i) => ({ id: `r${i}` }))
+  const lanes = [{ id: 'l_sales' }, { id: 'l_sharepoint' }, { id: 'l_input' }]
+  const tasks: Record<string, { lid: string; rid: string }> = {
+    info_request: { lid: 'l_sales', rid: 'r10' }, // 情報提供依頼 (tail)
+    sp_register: { lid: 'l_sharepoint', rid: 'r12' }, // 案件情報登録
+    formal_register: { lid: 'l_input', rid: 'r14' }, // 正式登録
+  }
+  const arrows = [{ id: 'a_sp_to_formal', from: 'sp_register', to: 'formal_register', comment: '' }]
+  const result = findClosestUpstream(tasks, rows, lanes, 13, 2, arrows)
+  expect(result?.key).toBe('sp_register')
+  expect(result?.splitArrowId).toBe('a_sp_to_formal')
+})
 ```
 
 - [ ] **Step 7: テスト実行 → 全パス確認**
@@ -494,6 +492,7 @@ EOF
 ## Task 4: `useArrows` のターゲット限定スプライスを TDD で実装
 
 **Files:**
+
 - Modify: `src/features/editor/hooks/useArrows.ts:30-44`
 - Modify: `src/features/editor/hooks/useArrows.test.ts`
 
@@ -502,51 +501,51 @@ EOF
 `src/features/editor/hooks/useArrows.test.ts` の `describe('autoConnectOnCreate', ...)` の末尾、最後の `it(...)` の後ろに追加：
 
 ```ts
-    it('should splice only the crossing arrow (Step 2.5), not unrelated outgoing from same upstream', () => {
-      // A(l0,r0) → C(l1,r2): タイプ① crossing arrow through (r1, l1)
-      // A(l0,r0) → D(l2,r3): unrelated downstream, NOT on path of (r1, l1)
-      //   But min(l0,l2)=0, max=2, newLi=1 → タイプ② would also match for A→D.
-      //   タイプ① (A→C) must win, and only A→C must be spliced.
-      const tasks: Record<string, TaskData> = {
-        A: { label: 'A', lid: 'l0', rid: 'r0', nodeId: 'n1' },
-        C: { label: 'C', lid: 'l1', rid: 'r2', nodeId: 'n3' },
-        D: { label: 'D', lid: 'l2', rid: 'r3', nodeId: 'n4' },
-        l1_r1: { label: 'B', lid: 'l1', rid: 'r1', nodeId: 'n2' },
-      }
-      const rows: RowData[] = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }, { id: 'r3' }]
-      const lanes: InternalLane[] = [
-        { id: 'l0', name: 'L0', ci: 0 },
-        { id: 'l1', name: 'L1', ci: 1 },
-        { id: 'l2', name: 'L2', ci: 2 },
-      ]
-      const arrows: InternalArrow[] = [
-        { id: 'aAC', from: 'A', to: 'C', comment: 'orig' },
-        { id: 'aAD', from: 'A', to: 'D', comment: '' },
-      ]
-      const { result } = renderHook(() =>
-        useArrows({
-          ...defaultOptions(),
-          tasks,
-          rows,
-          lanes,
-          initialArrows: arrows,
-        }),
-      )
-      act(() => {
-        result.current.autoConnectOnCreate('l1_r1', 1, 1)
-      })
+it('should splice only the crossing arrow (Step 2.5), not unrelated outgoing from same upstream', () => {
+  // A(l0,r0) → C(l1,r2): タイプ① crossing arrow through (r1, l1)
+  // A(l0,r0) → D(l2,r3): unrelated downstream, NOT on path of (r1, l1)
+  //   But min(l0,l2)=0, max=2, newLi=1 → タイプ② would also match for A→D.
+  //   タイプ① (A→C) must win, and only A→C must be spliced.
+  const tasks: Record<string, TaskData> = {
+    A: { label: 'A', lid: 'l0', rid: 'r0', nodeId: 'n1' },
+    C: { label: 'C', lid: 'l1', rid: 'r2', nodeId: 'n3' },
+    D: { label: 'D', lid: 'l2', rid: 'r3', nodeId: 'n4' },
+    l1_r1: { label: 'B', lid: 'l1', rid: 'r1', nodeId: 'n2' },
+  }
+  const rows: RowData[] = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }, { id: 'r3' }]
+  const lanes: InternalLane[] = [
+    { id: 'l0', name: 'L0', ci: 0 },
+    { id: 'l1', name: 'L1', ci: 1 },
+    { id: 'l2', name: 'L2', ci: 2 },
+  ]
+  const arrows: InternalArrow[] = [
+    { id: 'aAC', from: 'A', to: 'C', comment: 'orig' },
+    { id: 'aAD', from: 'A', to: 'D', comment: '' },
+  ]
+  const { result } = renderHook(() =>
+    useArrows({
+      ...defaultOptions(),
+      tasks,
+      rows,
+      lanes,
+      initialArrows: arrows,
+    }),
+  )
+  act(() => {
+    result.current.autoConnectOnCreate('l1_r1', 1, 1)
+  })
 
-      // A→C is spliced into A→B + B→C; A→D is untouched.
-      const pairs = result.current.arrows.map((a) => `${a.from}->${a.to}`).sort()
-      expect(pairs).toEqual(['A->D', 'A->l1_r1', 'l1_r1->C'])
-      // Original A→D arrow ID preserved (not removed and re-added)
-      expect(result.current.arrows.find((a) => a.id === 'aAD')).toBeDefined()
-      // Original A→C arrow is removed
-      expect(result.current.arrows.find((a) => a.id === 'aAC')).toBeUndefined()
-      // Comment from A→C carries to B→C
-      const bToC = result.current.arrows.find((a) => a.from === 'l1_r1' && a.to === 'C')
-      expect(bToC?.comment).toBe('orig')
-    })
+  // A→C is spliced into A→B + B→C; A→D is untouched.
+  const pairs = result.current.arrows.map((a) => `${a.from}->${a.to}`).sort()
+  expect(pairs).toEqual(['A->D', 'A->l1_r1', 'l1_r1->C'])
+  // Original A→D arrow ID preserved (not removed and re-added)
+  expect(result.current.arrows.find((a) => a.id === 'aAD')).toBeDefined()
+  // Original A→C arrow is removed
+  expect(result.current.arrows.find((a) => a.id === 'aAC')).toBeUndefined()
+  // Comment from A→C carries to B→C
+  const bToC = result.current.arrows.find((a) => a.from === 'l1_r1' && a.to === 'C')
+  expect(bToC?.comment).toBe('orig')
+})
 ```
 
 - [ ] **Step 2: テスト失敗を確認（RED）**
@@ -562,46 +561,46 @@ npx vitest run src/features/editor/hooks/useArrows.test.ts -t "splice only the c
 `src/features/editor/hooks/useArrows.ts:22-53` の `autoConnectOnCreate` 全体を以下に書き換える：
 
 ```ts
-  const autoConnectOnCreate = (taskKey: string, ri: number, li: number): void => {
-    if (!autoConnect || Object.keys(tasks).length < 1) return
-    const result = findClosestUpstream(tasks, rows, lanes, ri, li, arrows)
-    if (!result) return
-    const bestKey = result.key
-    const splitArrowId = result.splitArrowId
+const autoConnectOnCreate = (taskKey: string, ri: number, li: number): void => {
+  if (!autoConnect || Object.keys(tasks).length < 1) return
+  const result = findClosestUpstream(tasks, rows, lanes, ri, li, arrows)
+  if (!result) return
+  const bestKey = result.key
+  const splitArrowId = result.splitArrowId
 
-    // Step 2.5 hit: splice only the matched arrow (targeted).
-    // Otherwise (Step 1/2/3): if upstream is in a row above, splice all of its
-    // outgoing arrows whose target is below the new node (broad — preserves
-    // existing same-lane chain insertion behavior).
-    let splitArrows: InternalArrow[]
-    if (splitArrowId) {
-      splitArrows = arrows.filter((a) => a.id === splitArrowId)
-    } else {
-      const bestTask = tasks[bestKey]
-      const bestRi = bestTask ? rows.findIndex((r) => r.id === bestTask.rid) : -1
-      splitArrows =
-        bestRi >= 0 && bestRi < ri
-          ? arrows.filter((a) => {
-              if (a.from !== bestKey) return false
-              const toTask = tasks[a.to]
-              if (!toTask) return false
-              const toRi = rows.findIndex((r) => r.id === toTask.rid)
-              return toRi > ri
-            })
-          : []
-    }
-
-    const splitIds = new Set(splitArrows.map((a) => a.id))
-    autoSplitHandledRef.current = splitIds
-    setArrows((prev) => {
-      const filtered = prev.filter((a) => !splitIds.has(a.id))
-      const additions: InternalArrow[] = [{ id: uid(), from: bestKey, to: taskKey, comment: '' }]
-      for (const s of splitArrows) {
-        additions.push({ id: uid(), from: taskKey, to: s.to, comment: s.comment })
-      }
-      return [...filtered, ...additions]
-    })
+  // Step 2.5 hit: splice only the matched arrow (targeted).
+  // Otherwise (Step 1/2/3): if upstream is in a row above, splice all of its
+  // outgoing arrows whose target is below the new node (broad — preserves
+  // existing same-lane chain insertion behavior).
+  let splitArrows: InternalArrow[]
+  if (splitArrowId) {
+    splitArrows = arrows.filter((a) => a.id === splitArrowId)
+  } else {
+    const bestTask = tasks[bestKey]
+    const bestRi = bestTask ? rows.findIndex((r) => r.id === bestTask.rid) : -1
+    splitArrows =
+      bestRi >= 0 && bestRi < ri
+        ? arrows.filter((a) => {
+            if (a.from !== bestKey) return false
+            const toTask = tasks[a.to]
+            if (!toTask) return false
+            const toRi = rows.findIndex((r) => r.id === toTask.rid)
+            return toRi > ri
+          })
+        : []
   }
+
+  const splitIds = new Set(splitArrows.map((a) => a.id))
+  autoSplitHandledRef.current = splitIds
+  setArrows((prev) => {
+    const filtered = prev.filter((a) => !splitIds.has(a.id))
+    const additions: InternalArrow[] = [{ id: uid(), from: bestKey, to: taskKey, comment: '' }]
+    for (const s of splitArrows) {
+      additions.push({ id: uid(), from: taskKey, to: s.to, comment: s.comment })
+    }
+    return [...filtered, ...additions]
+  })
+}
 ```
 
 注: ロジック差分は冒頭の `result` 受け取りと `splitArrowId` 分岐のみ。それ以降の `splitIds` 管理 / `setArrows` の差分計算 / `autoSplitHandledRef` 連携は据え置き。

--- a/docs/plans/2026-04-30-issue-336-auto-connect-step25-plan.md
+++ b/docs/plans/2026-04-30-issue-336-auto-connect-step25-plan.md
@@ -1,0 +1,692 @@
+# Issue #336: 自動接続 Step 2.5 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `findClosestUpstream` に「経路通過矢印への割り込み」(Step 2.5) を追加し、新ノードを既存矢印の経路上に挿入したとき、その矢印1本だけを `from → new → to` にスプライスする。
+
+**Architecture:**
+- `findClosestUpstream` の戻り値を `{ key, splitArrowId? } | null` に拡張し、Step 2 と Step 3 の間に Step 2.5 を挿入。
+- `autoConnectOnCreate` は `splitArrowId` がある場合のみ「対象1本だけ」をスプライス、無い場合は既存の broad splice を維持。
+
+**Tech Stack:** TypeScript, Vitest (`npm test` = `vitest run`), React (hooks via `@testing-library/react`)
+
+**Spec:** [`docs/plans/2026-04-30-issue-336-auto-connect-step25-design.md`](./2026-04-30-issue-336-auto-connect-step25-design.md)
+
+---
+
+## File Structure
+
+| File | Role |
+|---|---|
+| `src/features/editor/auto-connect.ts` | `UpstreamResult` 型・Step 2.5 ロジックを追加 |
+| `src/features/editor/auto-connect.test.ts` | 既存テストの戻り値形式更新 + Step 2.5 ケース追加 |
+| `src/features/editor/hooks/useArrows.ts` | `splitArrowId` を使ったターゲット限定スプライス |
+| `src/features/editor/hooks/useArrows.test.ts` | 通過矢印スプライス時の他 outgoing 不変テスト追加 |
+
+---
+
+## Task 1: `findClosestUpstream` 戻り値型のリファクタ
+
+**Files:**
+- Modify: `src/features/editor/auto-connect.ts:1-97`
+- Modify: `src/features/editor/auto-connect.test.ts` (16〜18 箇所のアサーション形式変更)
+- Modify: `src/features/editor/hooks/useArrows.ts:24-25`
+
+挙動変更なしの純粋なリファクタ。型変更とテスト更新を1コミットで完結させる。
+
+- [ ] **Step 1: `auto-connect.ts` に型を追加し、戻り値を変更**
+
+`src/features/editor/auto-connect.ts` を以下に書き換える（Step 2.5 はまだ入れない）：
+
+```ts
+/**
+ * Result of upstream lookup. `splitArrowId` is set only when matched via
+ * Step 2.5 (the new node lies on an existing arrow's path), telling the
+ * caller to splice that specific arrow rather than all outgoing arrows.
+ */
+export type UpstreamResult = {
+  key: string
+  splitArrowId?: string
+}
+
+/**
+ * Find the closest upstream node key for auto-connection.
+ *
+ * Priority:
+ * 1. Same-row nodes: closest by lane distance (bidirectional),
+ *    with tail nodes preferred over non-tails at equal distance.
+ * 2. Same-lane upstream: closest row in the same lane (tail or non-tail).
+ *    Handles insertions between already-linked nodes within the same lane.
+ * 3. Upstream tails (previous rows): closest by row index,
+ *    with flow-connected tails preferred over isolated at same row.
+ *
+ * @returns The upstream lookup result, or null if none found.
+ */
+export function findClosestUpstream(
+  tasks: Record<string, { lid: string; rid: string }>,
+  rows: { id: string }[],
+  lanes: { id: string }[],
+  newRi: number,
+  newLi: number,
+  arrows: { id: string; from: string; to: string }[],
+): UpstreamResult | null {
+  const outgoing = new Set(arrows.map((a) => a.from))
+  const incoming = new Set(arrows.map((a) => a.to))
+  const allKeys = Object.keys(tasks)
+  const tails = allKeys.filter((k) => !outgoing.has(k))
+
+  // 1. Same-row: closest by lane distance (bidirectional)
+  //    Tiebreaker: prefer tails over non-tails
+  {
+    let bestKey: string | null = null
+    let bestDist = Infinity
+    let bestIsTail = false
+    for (const key of allKeys) {
+      const task = tasks[key]
+      const tRi = rows.findIndex((r) => r.id === task.rid)
+      if (tRi !== newRi) continue
+      const tLi = lanes.findIndex((l) => l.id === task.lid)
+      if (tLi < 0 || tLi === newLi) continue
+      const dist = Math.abs(tLi - newLi)
+      const isTail = !outgoing.has(key)
+      if (dist < bestDist || (dist === bestDist && isTail && !bestIsTail)) {
+        bestKey = key
+        bestDist = dist
+        bestIsTail = isTail
+      }
+    }
+    if (bestKey) return { key: bestKey }
+  }
+
+  // 2. Same-lane upstream: pick the closest (largest tRi < newRi) node in the same lane.
+  //    A same-lane predecessor is the natural upstream even when it already has outgoing
+  //    arrows, because the user is inserting a new step into an existing chain.
+  {
+    let bestKey: string | null = null
+    let bestRi = -1
+    for (const key of allKeys) {
+      const task = tasks[key]
+      const tLi = lanes.findIndex((l) => l.id === task.lid)
+      if (tLi !== newLi) continue
+      const tRi = rows.findIndex((r) => r.id === task.rid)
+      if (tRi < 0 || tRi >= newRi) continue
+      if (tRi > bestRi) {
+        bestKey = key
+        bestRi = tRi
+      }
+    }
+    if (bestKey) return { key: bestKey }
+  }
+
+  // 3. Upstream tails: closest by row, flow-connected as tiebreaker
+  {
+    let bestKey: string | null = null
+    let bestRi = -1
+    let bestLi = -1
+    let bestIsFlow = false
+    for (const key of tails) {
+      const task = tasks[key]
+      const tRi = rows.findIndex((r) => r.id === task.rid)
+      const tLi = lanes.findIndex((l) => l.id === task.lid)
+      if (tRi < 0 || tLi < 0) continue
+      if (tRi >= newRi) continue
+
+      const isFlow = incoming.has(key)
+      if (
+        tRi > bestRi ||
+        (tRi === bestRi && isFlow && !bestIsFlow) ||
+        (tRi === bestRi && isFlow === bestIsFlow && tLi > bestLi)
+      ) {
+        bestKey = key
+        bestRi = tRi
+        bestLi = tLi
+        bestIsFlow = isFlow
+      }
+    }
+    return bestKey ? { key: bestKey } : null
+  }
+}
+```
+
+注: `arrows` パラメータの型に `id: string` を追加。呼び出し側はもとから `InternalArrow`（`id` 必須）を渡しているので破壊的変更ではない。`findCrossingArrows` と `computeBridgeArrows` はそのまま。
+
+- [ ] **Step 2: `useArrows.ts` の呼び出し側を更新**
+
+`src/features/editor/hooks/useArrows.ts:22-32` を以下に書き換える：
+
+```ts
+const autoConnectOnCreate = (taskKey: string, ri: number, li: number): void => {
+  if (!autoConnect || Object.keys(tasks).length < 1) return
+  const result = findClosestUpstream(tasks, rows, lanes, ri, li, arrows)
+  if (!result) return
+  const bestKey = result.key
+
+  // If the chosen upstream lives in a row above the new node, re-route any arrow
+  // from it to a downstream node (row > ri) through the new node, splitting
+  // `bestKey → downstream` into `bestKey → new → downstream`.
+  const bestTask = tasks[bestKey]
+  const bestRi = bestTask ? rows.findIndex((r) => r.id === bestTask.rid) : -1
+```
+
+それ以下（`splitArrows` 計算〜末尾）はこの段階では変更しない。
+
+- [ ] **Step 3: `auto-connect.test.ts` の既存アサーションを機械的更新**
+
+`src/features/editor/auto-connect.test.ts` 全体で `findClosestUpstream(...)` の戻り値を扱う行を以下のように書き換える：
+
+| 旧 | 新 |
+|---|---|
+| `expect(result).toBe('X')` | `expect(result?.key).toBe('X')` |
+| `expect(result).toBeNull()` | `expect(result).toBeNull()` （変更なし） |
+
+対象行（line 12, 23, 33, 43, 51, 61, 72, 88, 101, 113, 130, 150, 165, 187, 198, 211, 226, 263, 276, 287 付近）。`expect(result).toBeNull()` の行は変更不要。
+
+`findCrossingArrows` と `computeBridgeArrows` のテストは触らない。
+
+- [ ] **Step 4: テスト実行 → 全パス確認**
+
+```bash
+npx vitest run src/features/editor/auto-connect.test.ts src/features/editor/hooks/useArrows.test.ts
+```
+
+期待: 全テストパス。挙動を変えていないので失敗ゼロ。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/editor/auto-connect.ts src/features/editor/auto-connect.test.ts src/features/editor/hooks/useArrows.ts
+git commit -m "$(cat <<'EOF'
+refactor(#336): change findClosestUpstream return type to UpstreamResult
+
+Pure refactor in preparation for Step 2.5. No behavior change.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Step 2.5 を TDD で実装（基本ケース）
+
+**Files:**
+- Modify: `src/features/editor/auto-connect.ts` (Step 2 と Step 3 の間に Step 2.5 ブロック追加)
+- Modify: `src/features/editor/auto-connect.test.ts` (新規テスト追加)
+
+- [ ] **Step 1: 失敗テストを書く（RED）**
+
+`src/features/editor/auto-connect.test.ts` の `describe('findClosestUpstream', () => { ... })` の末尾、最後の `it(...)` の後ろに以下を追加：
+
+```ts
+  it('should return crossing arrow upstream when new node is on its path (Step 2.5)', () => {
+    // A(l0,r0) → C(l1,r2). New node at (r1, l1).
+    // Step 1: same-row r1 — none.
+    // Step 2: same-lane l1 upstream — none (C is downstream).
+    // Step 2.5: arrow A→C, fromRi=0 < newRi=1 < toRi=2, toLi=l1 === newLi=l1 (タイプ①).
+    //          → returns A + splitArrowId.
+    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      A: { lid: 'l0', rid: 'r0' },
+      C: { lid: 'l1', rid: 'r2' },
+    }
+    const arrows = [{ id: 'a1', from: 'A', to: 'C', comment: '' }]
+    const result = findClosestUpstream(tasks, rows, lanes, 1, 1, arrows)
+    expect(result?.key).toBe('A')
+    expect(result?.splitArrowId).toBe('a1')
+  })
+```
+
+- [ ] **Step 2: テスト失敗を確認（RED）**
+
+```bash
+npx vitest run src/features/editor/auto-connect.test.ts -t "Step 2.5"
+```
+
+期待: FAIL — 現状 Step 3 で `null` が返るため `result?.key` は `undefined`。
+
+- [ ] **Step 3: Step 2.5 を実装（GREEN）**
+
+`src/features/editor/auto-connect.ts` の Step 2 ブロック直後（既存の Step 3 ブロック直前）に以下を挿入：
+
+```ts
+  // 2.5. Crossing arrow at cell: if an arrow's path passes through (newRi, newLi),
+  //      use its `from` node as upstream and tag the arrow ID for targeted splice.
+  //      Inserted between Step 2 and Step 3 so same-row / same-lane upstream wins,
+  //      but a crossing arrow beats an unrelated tail.
+  {
+    type Candidate = { id: string; from: string; toLiMatches: boolean; fromRiDist: number }
+    let best: Candidate | null = null
+    for (const arrow of arrows) {
+      const fromTask = tasks[arrow.from]
+      const toTask = tasks[arrow.to]
+      if (!fromTask || !toTask) continue
+      const fromRi = rows.findIndex((r) => r.id === fromTask.rid)
+      const toRi = rows.findIndex((r) => r.id === toTask.rid)
+      const fromLi = lanes.findIndex((l) => l.id === fromTask.lid)
+      const toLi = lanes.findIndex((l) => l.id === toTask.lid)
+      if (fromRi < 0 || toRi < 0 || fromLi < 0 || toLi < 0) continue
+      if (!(fromRi < newRi && toRi > newRi)) continue
+
+      const toLiMatches = toLi === newLi
+      const minLi = Math.min(fromLi, toLi)
+      const maxLi = Math.max(fromLi, toLi)
+      const passesLaneRange = minLi <= newLi && newLi <= maxLi
+      if (!toLiMatches && !passesLaneRange) continue
+
+      const fromRiDist = newRi - fromRi
+      if (
+        !best ||
+        (toLiMatches && !best.toLiMatches) ||
+        (toLiMatches === best.toLiMatches && fromRiDist < best.fromRiDist)
+      ) {
+        best = { id: arrow.id, from: arrow.from, toLiMatches, fromRiDist }
+      }
+    }
+    if (best) return { key: best.from, splitArrowId: best.id }
+  }
+```
+
+- [ ] **Step 4: テスト成功を確認（GREEN）**
+
+```bash
+npx vitest run src/features/editor/auto-connect.test.ts -t "Step 2.5"
+```
+
+期待: PASS。
+
+- [ ] **Step 5: 全関連テストでリグレッションなしを確認**
+
+```bash
+npx vitest run src/features/editor/auto-connect.test.ts src/features/editor/hooks/useArrows.test.ts
+```
+
+期待: 全テストパス。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/editor/auto-connect.ts src/features/editor/auto-connect.test.ts
+git commit -m "$(cat <<'EOF'
+feat(#336): add Step 2.5 crossing-arrow upstream detection
+
+When a new node sits on an existing arrow's path (row crossing + lane match),
+findClosestUpstream returns the arrow's `from` node and tags the matched
+arrow ID for the caller to splice.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Step 2.5 のカバレッジテスト追加
+
+**Files:**
+- Modify: `src/features/editor/auto-connect.test.ts`
+
+Task 2 で実装は完了しているので、本タスクは挙動を網羅するテストを追加するだけ。すべて初回からパスするはず。
+
+- [ ] **Step 1: タイプ①優先のテストを追加**
+
+`describe('findClosestUpstream', ...)` の末尾に追加：
+
+```ts
+  it('should prefer toLi===newLi (タイプ①) over lane-range match (タイプ②) in Step 2.5', () => {
+    // Two crossing arrows:
+    //   - A(l0,r0) → B(l4,r2): タイプ② (newLi=l2 in [l0..l4])
+    //   - X(l1,r0) → Y(l2,r2): タイプ① (toLi=l2=newLi)
+    // New at (r1, l2). Both pass row crossing. タイプ① must win.
+    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }, { id: 'l2' }, { id: 'l3' }, { id: 'l4' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      A: { lid: 'l0', rid: 'r0' },
+      B: { lid: 'l4', rid: 'r2' },
+      X: { lid: 'l1', rid: 'r0' },
+      Y: { lid: 'l2', rid: 'r2' },
+    }
+    const arrows = [
+      { id: 'aAB', from: 'A', to: 'B', comment: '' },
+      { id: 'aXY', from: 'X', to: 'Y', comment: '' },
+    ]
+    const result = findClosestUpstream(tasks, rows, lanes, 1, 2, arrows)
+    expect(result?.key).toBe('X')
+    expect(result?.splitArrowId).toBe('aXY')
+  })
+```
+
+- [ ] **Step 2: fromRi 近接タイブレークのテストを追加**
+
+```ts
+  it('should prefer closer fromRi when both candidates are タイプ① in Step 2.5', () => {
+    // Two タイプ① arrows landing in newLi=l1:
+    //   - A(l0,r0) → C(l1,r5)  fromRi=0, dist=2
+    //   - D(l0,r1) → E(l1,r5)  fromRi=1, dist=1 ← closer
+    // New at (r2, l1).
+    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }, { id: 'r3' }, { id: 'r4' }, { id: 'r5' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      A: { lid: 'l0', rid: 'r0' },
+      C: { lid: 'l1', rid: 'r5' },
+      D: { lid: 'l0', rid: 'r1' },
+      E: { lid: 'l1', rid: 'r5' },
+    }
+    const arrows = [
+      { id: 'aAC', from: 'A', to: 'C', comment: '' },
+      { id: 'aDE', from: 'D', to: 'E', comment: '' },
+    ]
+    const result = findClosestUpstream(tasks, rows, lanes, 2, 1, arrows)
+    expect(result?.key).toBe('D')
+    expect(result?.splitArrowId).toBe('aDE')
+  })
+```
+
+- [ ] **Step 3: Step 2 が Step 2.5 より優先されるテストを追加**
+
+```ts
+  it('should prefer same-lane upstream (Step 2) over crossing arrow (Step 2.5)', () => {
+    // Same-lane upstream P(l1,r1) and crossing arrow A→C exist.
+    // Step 2 must return P, splitArrowId must be undefined.
+    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }, { id: 'r3' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      P: { lid: 'l1', rid: 'r1' },
+      A: { lid: 'l0', rid: 'r0' },
+      C: { lid: 'l1', rid: 'r3' },
+    }
+    const arrows = [{ id: 'aAC', from: 'A', to: 'C', comment: '' }]
+    const result = findClosestUpstream(tasks, rows, lanes, 2, 1, arrows)
+    expect(result?.key).toBe('P')
+    expect(result?.splitArrowId).toBeUndefined()
+  })
+```
+
+- [ ] **Step 4: Step 1 が Step 2.5 より優先されるテストを追加**
+
+```ts
+  it('should prefer same-row node (Step 1) over crossing arrow (Step 2.5)', () => {
+    // Same-row node SR(l0,r1) and crossing arrow A→C through (r1,l1).
+    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      SR: { lid: 'l0', rid: 'r1' },
+      A: { lid: 'l0', rid: 'r0' },
+      C: { lid: 'l1', rid: 'r2' },
+    }
+    const arrows = [{ id: 'aAC', from: 'A', to: 'C', comment: '' }]
+    const result = findClosestUpstream(tasks, rows, lanes, 1, 1, arrows)
+    expect(result?.key).toBe('SR')
+    expect(result?.splitArrowId).toBeUndefined()
+  })
+```
+
+- [ ] **Step 5: レーン条件不一致のとき Step 3 へフォールスルーするテストを追加**
+
+```ts
+  it('should fall through to Step 3 when crossing arrow does not match lane criteria', () => {
+    // Arrow A(l0,r0) → C(l1,r2). New at (r1, l3).
+    // Row crossing OK, but neither toLi(l1)===newLi(l3) nor newLi in [l0..l1] range.
+    // → Step 2.5 misses, Step 3 picks tail T.
+    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }, { id: 'l2' }, { id: 'l3' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      A: { lid: 'l0', rid: 'r0' },
+      C: { lid: 'l1', rid: 'r2' },
+      T: { lid: 'l3', rid: 'r0' }, // isolated tail in upstream row
+    }
+    const arrows = [{ id: 'aAC', from: 'A', to: 'C', comment: '' }]
+    const result = findClosestUpstream(tasks, rows, lanes, 1, 3, arrows)
+    expect(result?.key).toBe('T')
+    expect(result?.splitArrowId).toBeUndefined()
+  })
+```
+
+- [ ] **Step 6: issue 再現シナリオのテストを追加**
+
+```ts
+  it('should reproduce issue #336 scenario (案件情報登録 → 正式登録 with new node on path)', () => {
+    // 案件情報登録 (l_sharepoint, r12) → 正式登録 (l_input, r14)
+    // 情報提供依頼 (l_sales, r10) is an isolated tail — must NOT be picked.
+    // New node at (r13, l_input). Step 2.5 must intercept.
+    const rows = Array.from({ length: 16 }, (_, i) => ({ id: `r${i}` }))
+    const lanes = [
+      { id: 'l_sales' },
+      { id: 'l_sharepoint' },
+      { id: 'l_input' },
+    ]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      info_request: { lid: 'l_sales', rid: 'r10' }, // 情報提供依頼 (tail)
+      sp_register: { lid: 'l_sharepoint', rid: 'r12' }, // 案件情報登録
+      formal_register: { lid: 'l_input', rid: 'r14' }, // 正式登録
+    }
+    const arrows = [
+      { id: 'a_sp_to_formal', from: 'sp_register', to: 'formal_register', comment: '' },
+    ]
+    const result = findClosestUpstream(tasks, rows, lanes, 13, 2, arrows)
+    expect(result?.key).toBe('sp_register')
+    expect(result?.splitArrowId).toBe('a_sp_to_formal')
+  })
+```
+
+- [ ] **Step 7: テスト実行 → 全パス確認**
+
+```bash
+npx vitest run src/features/editor/auto-connect.test.ts
+```
+
+期待: 追加した5件含めて全パス。
+
+- [ ] **Step 8: コミット**
+
+```bash
+git add src/features/editor/auto-connect.test.ts
+git commit -m "$(cat <<'EOF'
+test(#336): cover Step 2.5 priority, tiebreakers, fallthrough, repro
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `useArrows` のターゲット限定スプライスを TDD で実装
+
+**Files:**
+- Modify: `src/features/editor/hooks/useArrows.ts:30-44`
+- Modify: `src/features/editor/hooks/useArrows.test.ts`
+
+- [ ] **Step 1: 失敗テストを書く（RED）**
+
+`src/features/editor/hooks/useArrows.test.ts` の `describe('autoConnectOnCreate', ...)` の末尾、最後の `it(...)` の後ろに追加：
+
+```ts
+    it('should splice only the crossing arrow (Step 2.5), not unrelated outgoing from same upstream', () => {
+      // A(l0,r0) → C(l1,r2): タイプ① crossing arrow through (r1, l1)
+      // A(l0,r0) → D(l2,r3): unrelated downstream, NOT on path of (r1, l1)
+      //   But min(l0,l2)=0, max=2, newLi=1 → タイプ② would also match for A→D.
+      //   タイプ① (A→C) must win, and only A→C must be spliced.
+      const tasks: Record<string, TaskData> = {
+        A: { label: 'A', lid: 'l0', rid: 'r0', nodeId: 'n1' },
+        C: { label: 'C', lid: 'l1', rid: 'r2', nodeId: 'n3' },
+        D: { label: 'D', lid: 'l2', rid: 'r3', nodeId: 'n4' },
+        l1_r1: { label: 'B', lid: 'l1', rid: 'r1', nodeId: 'n2' },
+      }
+      const rows: RowData[] = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }, { id: 'r3' }]
+      const lanes: InternalLane[] = [
+        { id: 'l0', name: 'L0', ci: 0 },
+        { id: 'l1', name: 'L1', ci: 1 },
+        { id: 'l2', name: 'L2', ci: 2 },
+      ]
+      const arrows: InternalArrow[] = [
+        { id: 'aAC', from: 'A', to: 'C', comment: 'orig' },
+        { id: 'aAD', from: 'A', to: 'D', comment: '' },
+      ]
+      const { result } = renderHook(() =>
+        useArrows({
+          ...defaultOptions(),
+          tasks,
+          rows,
+          lanes,
+          initialArrows: arrows,
+        }),
+      )
+      act(() => {
+        result.current.autoConnectOnCreate('l1_r1', 1, 1)
+      })
+
+      // A→C is spliced into A→B + B→C; A→D is untouched.
+      const pairs = result.current.arrows.map((a) => `${a.from}->${a.to}`).sort()
+      expect(pairs).toEqual(['A->D', 'A->l1_r1', 'l1_r1->C'])
+      // Original A→D arrow ID preserved (not removed and re-added)
+      expect(result.current.arrows.find((a) => a.id === 'aAD')).toBeDefined()
+      // Original A→C arrow is removed
+      expect(result.current.arrows.find((a) => a.id === 'aAC')).toBeUndefined()
+      // Comment from A→C carries to B→C
+      const bToC = result.current.arrows.find((a) => a.from === 'l1_r1' && a.to === 'C')
+      expect(bToC?.comment).toBe('orig')
+    })
+```
+
+- [ ] **Step 2: テスト失敗を確認（RED）**
+
+```bash
+npx vitest run src/features/editor/hooks/useArrows.test.ts -t "splice only the crossing arrow"
+```
+
+期待: FAIL — 現状の broad splice では `A→D` も `A→l1_r1 → l1_r1→D` に書き換えられてしまう（または `A→D` の id が変わる）ため `pairs` が一致しない。
+
+- [ ] **Step 3: ターゲット限定スプライスを実装（GREEN）**
+
+`src/features/editor/hooks/useArrows.ts:22-53` の `autoConnectOnCreate` 全体を以下に書き換える：
+
+```ts
+  const autoConnectOnCreate = (taskKey: string, ri: number, li: number): void => {
+    if (!autoConnect || Object.keys(tasks).length < 1) return
+    const result = findClosestUpstream(tasks, rows, lanes, ri, li, arrows)
+    if (!result) return
+    const bestKey = result.key
+    const splitArrowId = result.splitArrowId
+
+    // Step 2.5 hit: splice only the matched arrow (targeted).
+    // Otherwise (Step 1/2/3): if upstream is in a row above, splice all of its
+    // outgoing arrows whose target is below the new node (broad — preserves
+    // existing same-lane chain insertion behavior).
+    let splitArrows: InternalArrow[]
+    if (splitArrowId) {
+      splitArrows = arrows.filter((a) => a.id === splitArrowId)
+    } else {
+      const bestTask = tasks[bestKey]
+      const bestRi = bestTask ? rows.findIndex((r) => r.id === bestTask.rid) : -1
+      splitArrows =
+        bestRi >= 0 && bestRi < ri
+          ? arrows.filter((a) => {
+              if (a.from !== bestKey) return false
+              const toTask = tasks[a.to]
+              if (!toTask) return false
+              const toRi = rows.findIndex((r) => r.id === toTask.rid)
+              return toRi > ri
+            })
+          : []
+    }
+
+    const splitIds = new Set(splitArrows.map((a) => a.id))
+    autoSplitHandledRef.current = splitIds
+    setArrows((prev) => {
+      const filtered = prev.filter((a) => !splitIds.has(a.id))
+      const additions: InternalArrow[] = [{ id: uid(), from: bestKey, to: taskKey, comment: '' }]
+      for (const s of splitArrows) {
+        additions.push({ id: uid(), from: taskKey, to: s.to, comment: s.comment })
+      }
+      return [...filtered, ...additions]
+    })
+  }
+```
+
+注: ロジック差分は冒頭の `result` 受け取りと `splitArrowId` 分岐のみ。それ以降の `splitIds` 管理 / `setArrows` の差分計算 / `autoSplitHandledRef` 連携は据え置き。
+
+- [ ] **Step 4: テスト成功を確認（GREEN）**
+
+```bash
+npx vitest run src/features/editor/hooks/useArrows.test.ts -t "splice only the crossing arrow"
+```
+
+期待: PASS。
+
+- [ ] **Step 5: useArrows.test.ts 全体のリグレッションなしを確認**
+
+特に line 99-126 の「同レーン上流での broad splice」テスト、line 158-191 の「複数 outgoing の broad splice」テスト、line 334-369 の「auto-split された矢印はトーストに出さない」テストが落ちないこと。
+
+```bash
+npx vitest run src/features/editor/hooks/useArrows.test.ts
+```
+
+期待: 全テストパス。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/editor/hooks/useArrows.ts src/features/editor/hooks/useArrows.test.ts
+git commit -m "$(cat <<'EOF'
+feat(#336): targeted splice for Step 2.5 crossing-arrow case
+
+When findClosestUpstream returns splitArrowId (Step 2.5 hit), splice only
+that one arrow. Step 1/2/3 paths keep the existing broad splice for same-lane
+chain insertion.
+
+Closes #336
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: 全体検証
+
+**Files:** なし（検証のみ）
+
+- [ ] **Step 1: 全テストスイート実行**
+
+```bash
+npm test
+```
+
+期待: 全テストパス。FAIL ゼロ。
+
+- [ ] **Step 2: TypeScript / Lint チェック**
+
+```bash
+npm run typecheck 2>/dev/null || npx tsc --noEmit
+npm run lint 2>/dev/null || true
+```
+
+期待: 型エラーゼロ。lint エラーゼロ。
+
+- [ ] **Step 3: ブラウザ目視確認**
+
+`~/.claude/CLAUDE.md` の Workflow Step 6 に従い、Playwright または手動でフローエディタを起動し以下を確認：
+
+1. 既存：縦に通過する矢印 `A → C` を含むフローを開く（または作る）
+2. 矢印の経路上のセル（A〜C 中間行 / C と同レーン）に新ノード B を追加
+3. 自動接続が `A → B → C` のスプライスを実行することを確認
+4. 別の outgoing がある場合（A→D 等）、その矢印が無傷で残ることを確認
+5. LCP が 1秒以内であることを確認
+
+スクリーンショットは `.screenshots/` に保存。
+
+- [ ] **Step 4: 検証合格でコミットなし**
+
+検証のみで新規ファイル変更なし。次は Workflow Step 7（main 同期）→ Step 8（PR 作成）へ進む。
+
+---
+
+## 完了条件
+
+- [ ] Task 1 〜 4 のすべての commit が main にマージ可能な状態
+- [ ] `npm test` 全パス
+- [ ] `npx tsc --noEmit` 型エラーなし
+- [ ] ブラウザで issue #336 のシナリオが解決していることを確認
+- [ ] Step 2.5 が原因で既存テスト・既存挙動にリグレッションがないことを確認

--- a/src/features/editor/auto-connect.test.ts
+++ b/src/features/editor/auto-connect.test.ts
@@ -9,7 +9,7 @@ describe('findClosestUpstream', () => {
       l0_r0: { lid: 'l0', rid: 'r0' },
     }
     const result = findClosestUpstream(tasks, rows, lanes, 1, 0, [])
-    expect(result).toBe('l0_r0')
+    expect(result?.key).toBe('l0_r0')
   })
 
   it('should return the closest upstream node when multiple upstream exist', () => {
@@ -20,7 +20,7 @@ describe('findClosestUpstream', () => {
       l0_r1: { lid: 'l0', rid: 'r1' },
     }
     const result = findClosestUpstream(tasks, rows, lanes, 2, 0, [])
-    expect(result).toBe('l0_r1')
+    expect(result?.key).toBe('l0_r1')
   })
 
   it('should return same-row left-lane node as upstream', () => {
@@ -30,7 +30,7 @@ describe('findClosestUpstream', () => {
       l0_r0: { lid: 'l0', rid: 'r0' },
     }
     const result = findClosestUpstream(tasks, rows, lanes, 0, 1, [])
-    expect(result).toBe('l0_r0')
+    expect(result?.key).toBe('l0_r0')
   })
 
   it('should return null when new node is at the top-left (no upstream)', () => {
@@ -69,7 +69,7 @@ describe('findClosestUpstream', () => {
       l1_r1: { lid: 'l1', rid: 'r1' },
     }
     const result = findClosestUpstream(tasks, rows, lanes, 1, 2, [])
-    expect(result).toBe('l1_r1')
+    expect(result?.key).toBe('l1_r1')
   })
 
   it('should prefer tail node (no outgoing arrow) over mid-chain node', () => {
@@ -85,7 +85,7 @@ describe('findClosestUpstream', () => {
       { id: 'a2', from: 'B', to: 'C', comment: '' },
     ]
     const result = findClosestUpstream(tasks, rows, lanes, 3, 0, arrows)
-    expect(result).toBe('C')
+    expect(result?.key).toBe('C')
   })
 
   it('should prefer flow-connected tail over isolated tail', () => {
@@ -98,7 +98,7 @@ describe('findClosestUpstream', () => {
     }
     const arrows = [{ id: 'a1', from: 'A', to: 'B', comment: '' }]
     const result = findClosestUpstream(tasks, rows, lanes, 2, 0, arrows)
-    expect(result).toBe('B')
+    expect(result?.key).toBe('B')
   })
 
   it('should fall back to isolated tails when no flow-connected tails exist', () => {
@@ -110,7 +110,7 @@ describe('findClosestUpstream', () => {
     }
     const arrows: { id: string; from: string; to: string; comment: string }[] = []
     const result = findClosestUpstream(tasks, rows, lanes, 2, 0, arrows)
-    expect(result).toBe('Y')
+    expect(result?.key).toBe('Y')
   })
 
   it('should return same-row non-tail when no tails exist on same row (#297)', () => {
@@ -127,7 +127,7 @@ describe('findClosestUpstream', () => {
     ]
     // A is same-row (r0), has outgoing but is closest same-row node
     const result = findClosestUpstream(tasks, rows, lanes, 0, 1, arrows)
-    expect(result).toBe('A')
+    expect(result?.key).toBe('A')
   })
 
   it('should prefer same-row node over upstream isolated tail (#241, #297)', () => {
@@ -147,7 +147,7 @@ describe('findClosestUpstream', () => {
       { id: 'a2', from: 'N2', to: 'N3', comment: '' },
     ]
     const result = findClosestUpstream(tasks, rows, lanes, 1, 1, arrows)
-    expect(result).toBe('N2')
+    expect(result?.key).toBe('N2')
   })
 
   it('should prefer same-row isolated tail over previous-row flowTail (#265)', () => {
@@ -162,7 +162,7 @@ describe('findClosestUpstream', () => {
     const arrows = [{ id: 'a1', from: 'A', to: 'B', comment: '' }]
     // New node at row4(r4), lane1(l1) — X is same-row isolated tail, B is flowTail at row3
     const result = findClosestUpstream(tasks, rows, lanes, 4, 1, arrows)
-    expect(result).toBe('X')
+    expect(result?.key).toBe('X')
   })
 
   it('should connect from same-row non-tail node when it is closest (#297)', () => {
@@ -184,7 +184,7 @@ describe('findClosestUpstream', () => {
       { id: 'a2', from: 'N4', to: 'N5', comment: '' },
     ]
     const result = findClosestUpstream(tasks, rows, lanes, 2, 1, arrows)
-    expect(result).toBe('N4')
+    expect(result?.key).toBe('N4')
   })
 
   it('should connect from same-row right-lane node (bidirectional) (#297)', () => {
@@ -195,7 +195,7 @@ describe('findClosestUpstream', () => {
       l1_r0: { lid: 'l1', rid: 'r0' },
     }
     const result = findClosestUpstream(tasks, rows, lanes, 0, 0, [])
-    expect(result).toBe('l1_r0')
+    expect(result?.key).toBe('l1_r0')
   })
 
   it('should prefer same-row tail over same-row non-tail at equal distance (#297)', () => {
@@ -208,7 +208,7 @@ describe('findClosestUpstream', () => {
     }
     const arrows = [{ id: 'a1', from: 'A', to: 'X', comment: '' }]
     const result = findClosestUpstream(tasks, rows, lanes, 0, 2, arrows)
-    expect(result).toBe('B')
+    expect(result?.key).toBe('B')
   })
 
   it('should prefer same-row closest tail when multiple same-row tails exist', () => {
@@ -223,7 +223,7 @@ describe('findClosestUpstream', () => {
     const arrows = [{ id: 'a1', from: 'A', to: 'B', comment: '' }]
     const result = findClosestUpstream(tasks, rows, lanes, 0, 3, arrows)
     // C is closer (l2 vs l1), both are same-row tails
-    expect(result).toBe('C')
+    expect(result?.key).toBe('C')
   })
 
   it('should prefer same-lane upstream non-tail over other-lane tail when inserted between linked nodes', () => {
@@ -260,7 +260,7 @@ describe('findClosestUpstream', () => {
       { id: 'a3', from: 'worker_r3', to: 'worker_r5', comment: '' },
     ]
     const result = findClosestUpstream(tasks, rows, lanes, 4, 2, arrows)
-    expect(result).toBe('worker_r3')
+    expect(result?.key).toBe('worker_r3')
   })
 
   it('should still return same-row node when same-lane upstream and same-row both exist', () => {
@@ -273,7 +273,7 @@ describe('findClosestUpstream', () => {
     }
     const arrows = [{ id: 'a1', from: 'sameLaneUpstream', to: 'other', comment: '' }]
     const result = findClosestUpstream(tasks, rows, lanes, 2, 0, arrows)
-    expect(result).toBe('sameRow')
+    expect(result?.key).toBe('sameRow')
   })
 
   it('should fall through to tail-based search when no same-lane upstream exists', () => {
@@ -284,7 +284,7 @@ describe('findClosestUpstream', () => {
       otherLaneTail: { lid: 'l0', rid: 'r0' },
     }
     const result = findClosestUpstream(tasks, rows, lanes, 1, 1, [])
-    expect(result).toBe('otherLaneTail')
+    expect(result?.key).toBe('otherLaneTail')
   })
 })
 

--- a/src/features/editor/auto-connect.test.ts
+++ b/src/features/editor/auto-connect.test.ts
@@ -286,6 +286,24 @@ describe('findClosestUpstream', () => {
     const result = findClosestUpstream(tasks, rows, lanes, 1, 1, [])
     expect(result?.key).toBe('otherLaneTail')
   })
+
+  it('should return crossing arrow upstream when new node is on its path (Step 2.5)', () => {
+    // A(l0,r0) → C(l1,r2). New node at (r1, l1).
+    // Step 1: same-row r1 — none.
+    // Step 2: same-lane l1 upstream — none (C is downstream).
+    // Step 2.5: arrow A→C, fromRi=0 < newRi=1 < toRi=2, toLi=l1 === newLi=l1 (タイプ①).
+    //          → returns A + splitArrowId.
+    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      A: { lid: 'l0', rid: 'r0' },
+      C: { lid: 'l1', rid: 'r2' },
+    }
+    const arrows = [{ id: 'a1', from: 'A', to: 'C', comment: '' }]
+    const result = findClosestUpstream(tasks, rows, lanes, 1, 1, arrows)
+    expect(result?.key).toBe('A')
+    expect(result?.splitArrowId).toBe('a1')
+  })
 })
 
 describe('findCrossingArrows', () => {

--- a/src/features/editor/auto-connect.test.ts
+++ b/src/features/editor/auto-connect.test.ts
@@ -332,7 +332,14 @@ describe('findClosestUpstream', () => {
     //   - A(l0,r0) → C(l1,r5)  fromRi=0, dist=2
     //   - D(l0,r1) → E(l1,r5)  fromRi=1, dist=1 ← closer
     // New at (r2, l1).
-    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }, { id: 'r3' }, { id: 'r4' }, { id: 'r5' }]
+    const rows = [
+      { id: 'r0' },
+      { id: 'r1' },
+      { id: 'r2' },
+      { id: 'r3' },
+      { id: 'r4' },
+      { id: 'r5' },
+    ]
     const lanes = [{ id: 'l0' }, { id: 'l1' }]
     const tasks: Record<string, { lid: string; rid: string }> = {
       A: { lid: 'l0', rid: 'r0' },
@@ -402,11 +409,7 @@ describe('findClosestUpstream', () => {
     // 情報提供依頼 (l_sales, r10) is an isolated tail — must NOT be picked.
     // New node at (r13, l_input). Step 2.5 must intercept.
     const rows = Array.from({ length: 16 }, (_, i) => ({ id: `r${i}` }))
-    const lanes = [
-      { id: 'l_sales' },
-      { id: 'l_sharepoint' },
-      { id: 'l_input' },
-    ]
+    const lanes = [{ id: 'l_sales' }, { id: 'l_sharepoint' }, { id: 'l_input' }]
     const tasks: Record<string, { lid: string; rid: string }> = {
       info_request: { lid: 'l_sales', rid: 'r10' }, // 情報提供依頼 (tail)
       sp_register: { lid: 'l_sharepoint', rid: 'r12' }, // 案件情報登録

--- a/src/features/editor/auto-connect.test.ts
+++ b/src/features/editor/auto-connect.test.ts
@@ -304,6 +304,121 @@ describe('findClosestUpstream', () => {
     expect(result?.key).toBe('A')
     expect(result?.splitArrowId).toBe('a1')
   })
+
+  it('should prefer toLi===newLi (タイプ①) over lane-range match (タイプ②) in Step 2.5', () => {
+    // Two crossing arrows:
+    //   - A(l0,r0) → B(l4,r2): タイプ② (newLi=l2 in [l0..l4])
+    //   - X(l1,r0) → Y(l2,r2): タイプ① (toLi=l2=newLi)
+    // New at (r1, l2). Both pass row crossing. タイプ① must win.
+    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }, { id: 'l2' }, { id: 'l3' }, { id: 'l4' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      A: { lid: 'l0', rid: 'r0' },
+      B: { lid: 'l4', rid: 'r2' },
+      X: { lid: 'l1', rid: 'r0' },
+      Y: { lid: 'l2', rid: 'r2' },
+    }
+    const arrows = [
+      { id: 'aAB', from: 'A', to: 'B', comment: '' },
+      { id: 'aXY', from: 'X', to: 'Y', comment: '' },
+    ]
+    const result = findClosestUpstream(tasks, rows, lanes, 1, 2, arrows)
+    expect(result?.key).toBe('X')
+    expect(result?.splitArrowId).toBe('aXY')
+  })
+
+  it('should prefer closer fromRi when both candidates are タイプ① in Step 2.5', () => {
+    // Two タイプ① arrows landing in newLi=l1:
+    //   - A(l0,r0) → C(l1,r5)  fromRi=0, dist=2
+    //   - D(l0,r1) → E(l1,r5)  fromRi=1, dist=1 ← closer
+    // New at (r2, l1).
+    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }, { id: 'r3' }, { id: 'r4' }, { id: 'r5' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      A: { lid: 'l0', rid: 'r0' },
+      C: { lid: 'l1', rid: 'r5' },
+      D: { lid: 'l0', rid: 'r1' },
+      E: { lid: 'l1', rid: 'r5' },
+    }
+    const arrows = [
+      { id: 'aAC', from: 'A', to: 'C', comment: '' },
+      { id: 'aDE', from: 'D', to: 'E', comment: '' },
+    ]
+    const result = findClosestUpstream(tasks, rows, lanes, 2, 1, arrows)
+    expect(result?.key).toBe('D')
+    expect(result?.splitArrowId).toBe('aDE')
+  })
+
+  it('should prefer same-lane upstream (Step 2) over crossing arrow (Step 2.5)', () => {
+    // Same-lane upstream P(l1,r1) and crossing arrow A→C exist.
+    // Step 2 must return P, splitArrowId must be undefined.
+    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }, { id: 'r3' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      P: { lid: 'l1', rid: 'r1' },
+      A: { lid: 'l0', rid: 'r0' },
+      C: { lid: 'l1', rid: 'r3' },
+    }
+    const arrows = [{ id: 'aAC', from: 'A', to: 'C', comment: '' }]
+    const result = findClosestUpstream(tasks, rows, lanes, 2, 1, arrows)
+    expect(result?.key).toBe('P')
+    expect(result?.splitArrowId).toBeUndefined()
+  })
+
+  it('should prefer same-row node (Step 1) over crossing arrow (Step 2.5)', () => {
+    // Same-row node SR(l0,r1) and crossing arrow A→C through (r1,l1).
+    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      SR: { lid: 'l0', rid: 'r1' },
+      A: { lid: 'l0', rid: 'r0' },
+      C: { lid: 'l1', rid: 'r2' },
+    }
+    const arrows = [{ id: 'aAC', from: 'A', to: 'C', comment: '' }]
+    const result = findClosestUpstream(tasks, rows, lanes, 1, 1, arrows)
+    expect(result?.key).toBe('SR')
+    expect(result?.splitArrowId).toBeUndefined()
+  })
+
+  it('should fall through to Step 3 when crossing arrow does not match lane criteria', () => {
+    // Arrow A(l0,r0) → C(l1,r2). New at (r1, l3).
+    // Row crossing OK, but neither toLi(l1)===newLi(l3) nor newLi in [l0..l1] range.
+    // → Step 2.5 misses, Step 3 picks tail T.
+    const rows = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }]
+    const lanes = [{ id: 'l0' }, { id: 'l1' }, { id: 'l2' }, { id: 'l3' }]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      A: { lid: 'l0', rid: 'r0' },
+      C: { lid: 'l1', rid: 'r2' },
+      T: { lid: 'l3', rid: 'r0' }, // isolated tail in upstream row
+    }
+    const arrows = [{ id: 'aAC', from: 'A', to: 'C', comment: '' }]
+    const result = findClosestUpstream(tasks, rows, lanes, 1, 3, arrows)
+    expect(result?.key).toBe('T')
+    expect(result?.splitArrowId).toBeUndefined()
+  })
+
+  it('should reproduce issue #336 scenario (案件情報登録 → 正式登録 with new node on path)', () => {
+    // 案件情報登録 (l_sharepoint, r12) → 正式登録 (l_input, r14)
+    // 情報提供依頼 (l_sales, r10) is an isolated tail — must NOT be picked.
+    // New node at (r13, l_input). Step 2.5 must intercept.
+    const rows = Array.from({ length: 16 }, (_, i) => ({ id: `r${i}` }))
+    const lanes = [
+      { id: 'l_sales' },
+      { id: 'l_sharepoint' },
+      { id: 'l_input' },
+    ]
+    const tasks: Record<string, { lid: string; rid: string }> = {
+      info_request: { lid: 'l_sales', rid: 'r10' }, // 情報提供依頼 (tail)
+      sp_register: { lid: 'l_sharepoint', rid: 'r12' }, // 案件情報登録
+      formal_register: { lid: 'l_input', rid: 'r14' }, // 正式登録
+    }
+    const arrows = [
+      { id: 'a_sp_to_formal', from: 'sp_register', to: 'formal_register', comment: '' },
+    ]
+    const result = findClosestUpstream(tasks, rows, lanes, 13, 2, arrows)
+    expect(result?.key).toBe('sp_register')
+    expect(result?.splitArrowId).toBe('a_sp_to_formal')
+  })
 })
 
 describe('findCrossingArrows', () => {

--- a/src/features/editor/auto-connect.ts
+++ b/src/features/editor/auto-connect.ts
@@ -1,4 +1,14 @@
 /**
+ * Result of upstream lookup. `splitArrowId` is set only when matched via
+ * Step 2.5 (the new node lies on an existing arrow's path), telling the
+ * caller to splice that specific arrow rather than all outgoing arrows.
+ */
+export type UpstreamResult = {
+  key: string
+  splitArrowId?: string
+}
+
+/**
  * Find the closest upstream node key for auto-connection.
  *
  * Priority:
@@ -9,7 +19,7 @@
  * 3. Upstream tails (previous rows): closest by row index,
  *    with flow-connected tails preferred over isolated at same row.
  *
- * @returns The task key of the closest upstream node, or null if none found.
+ * @returns The upstream lookup result, or null if none found.
  */
 export function findClosestUpstream(
   tasks: Record<string, { lid: string; rid: string }>,
@@ -17,8 +27,8 @@ export function findClosestUpstream(
   lanes: { id: string }[],
   newRi: number,
   newLi: number,
-  arrows: { from: string; to: string }[],
-): string | null {
+  arrows: { id: string; from: string; to: string }[],
+): UpstreamResult | null {
   const outgoing = new Set(arrows.map((a) => a.from))
   const incoming = new Set(arrows.map((a) => a.to))
   const allKeys = Object.keys(tasks)
@@ -44,7 +54,7 @@ export function findClosestUpstream(
         bestIsTail = isTail
       }
     }
-    if (bestKey) return bestKey
+    if (bestKey) return { key: bestKey }
   }
 
   // 2. Same-lane upstream: pick the closest (largest tRi < newRi) node in the same lane.
@@ -64,7 +74,7 @@ export function findClosestUpstream(
         bestRi = tRi
       }
     }
-    if (bestKey) return bestKey
+    if (bestKey) return { key: bestKey }
   }
 
   // 3. Upstream tails: closest by row, flow-connected as tiebreaker
@@ -92,7 +102,7 @@ export function findClosestUpstream(
         bestIsFlow = isFlow
       }
     }
-    return bestKey
+    return bestKey ? { key: bestKey } : null
   }
 }
 

--- a/src/features/editor/auto-connect.ts
+++ b/src/features/editor/auto-connect.ts
@@ -77,6 +77,42 @@ export function findClosestUpstream(
     if (bestKey) return { key: bestKey }
   }
 
+  // 2.5. Crossing arrow at cell: if an arrow's path passes through (newRi, newLi),
+  //      use its `from` node as upstream and tag the arrow ID for targeted splice.
+  //      Inserted between Step 2 and Step 3 so same-row / same-lane upstream wins,
+  //      but a crossing arrow beats an unrelated tail.
+  {
+    type Candidate = { id: string; from: string; toLiMatches: boolean; fromRiDist: number }
+    let best: Candidate | null = null
+    for (const arrow of arrows) {
+      const fromTask = tasks[arrow.from]
+      const toTask = tasks[arrow.to]
+      if (!fromTask || !toTask) continue
+      const fromRi = rows.findIndex((r) => r.id === fromTask.rid)
+      const toRi = rows.findIndex((r) => r.id === toTask.rid)
+      const fromLi = lanes.findIndex((l) => l.id === fromTask.lid)
+      const toLi = lanes.findIndex((l) => l.id === toTask.lid)
+      if (fromRi < 0 || toRi < 0 || fromLi < 0 || toLi < 0) continue
+      if (!(fromRi < newRi && toRi > newRi)) continue
+
+      const toLiMatches = toLi === newLi
+      const minLi = Math.min(fromLi, toLi)
+      const maxLi = Math.max(fromLi, toLi)
+      const passesLaneRange = minLi <= newLi && newLi <= maxLi
+      if (!toLiMatches && !passesLaneRange) continue
+
+      const fromRiDist = newRi - fromRi
+      if (
+        !best ||
+        (toLiMatches && !best.toLiMatches) ||
+        (toLiMatches === best.toLiMatches && fromRiDist < best.fromRiDist)
+      ) {
+        best = { id: arrow.id, from: arrow.from, toLiMatches, fromRiDist }
+      }
+    }
+    if (best) return { key: best.from, splitArrowId: best.id }
+  }
+
   // 3. Upstream tails: closest by row, flow-connected as tiebreaker
   {
     let bestKey: string | null = null

--- a/src/features/editor/auto-connect.ts
+++ b/src/features/editor/auto-connect.ts
@@ -3,7 +3,7 @@
  * Step 2.5 (the new node lies on an existing arrow's path), telling the
  * caller to splice that specific arrow rather than all outgoing arrows.
  */
-export type UpstreamResult = {
+type UpstreamResult = {
   key: string
   splitArrowId?: string
 }
@@ -95,11 +95,10 @@ export function findClosestUpstream(
       if (fromRi < 0 || toRi < 0 || fromLi < 0 || toLi < 0) continue
       if (!(fromRi < newRi && toRi > newRi)) continue
 
-      const toLiMatches = toLi === newLi
       const minLi = Math.min(fromLi, toLi)
       const maxLi = Math.max(fromLi, toLi)
-      const passesLaneRange = minLi <= newLi && newLi <= maxLi
-      if (!toLiMatches && !passesLaneRange) continue
+      if (newLi < minLi || newLi > maxLi) continue
+      const toLiMatches = toLi === newLi
 
       const fromRiDist = newRi - fromRi
       if (

--- a/src/features/editor/hooks/useArrows.test.ts
+++ b/src/features/editor/hooks/useArrows.test.ts
@@ -368,6 +368,52 @@ describe('useArrows', () => {
       expect(pairs).toEqual(['l0_r0->l0_r1', 'l0_r1->l0_r2'])
     })
 
+    it('should splice only the crossing arrow (Step 2.5), not unrelated outgoing from same upstream', () => {
+      // A(l0,r0) → C(l1,r2): タイプ① crossing arrow through (r1, l1)
+      // A(l0,r0) → D(l2,r3): unrelated downstream, NOT on path of (r1, l1)
+      //   But min(l0,l2)=0, max=2, newLi=1 → タイプ② would also match for A→D.
+      //   タイプ① (A→C) must win, and only A→C must be spliced.
+      const tasks: Record<string, TaskData> = {
+        A: { label: 'A', lid: 'l0', rid: 'r0', nodeId: 'n1' },
+        C: { label: 'C', lid: 'l1', rid: 'r2', nodeId: 'n3' },
+        D: { label: 'D', lid: 'l2', rid: 'r3', nodeId: 'n4' },
+        l1_r1: { label: 'B', lid: 'l1', rid: 'r1', nodeId: 'n2' },
+      }
+      const rows: RowData[] = [{ id: 'r0' }, { id: 'r1' }, { id: 'r2' }, { id: 'r3' }]
+      const lanes: InternalLane[] = [
+        { id: 'l0', name: 'L0', ci: 0 },
+        { id: 'l1', name: 'L1', ci: 1 },
+        { id: 'l2', name: 'L2', ci: 2 },
+      ]
+      const arrows: InternalArrow[] = [
+        { id: 'aAC', from: 'A', to: 'C', comment: 'orig' },
+        { id: 'aAD', from: 'A', to: 'D', comment: '' },
+      ]
+      const { result } = renderHook(() =>
+        useArrows({
+          ...defaultOptions(),
+          tasks,
+          rows,
+          lanes,
+          initialArrows: arrows,
+        }),
+      )
+      act(() => {
+        result.current.autoConnectOnCreate('l1_r1', 1, 1)
+      })
+
+      // A→C is spliced into A→B + B→C; A→D is untouched.
+      const pairs = result.current.arrows.map((a) => `${a.from}->${a.to}`).sort()
+      expect(pairs).toEqual(['A->D', 'A->l1_r1', 'l1_r1->C'])
+      // Original A→D arrow ID preserved (not removed and re-added)
+      expect(result.current.arrows.find((a) => a.id === 'aAD')).toBeDefined()
+      // Original A→C arrow is removed
+      expect(result.current.arrows.find((a) => a.id === 'aAC')).toBeUndefined()
+      // Comment from A→C carries to B→C
+      const bToC = result.current.arrows.find((a) => a.from === 'l1_r1' && a.to === 'C')
+      expect(bToC?.comment).toBe('orig')
+    })
+
     it('should still offer toast for remaining crossings not handled by auto-split', () => {
       // A→C is auto-split by autoConnectOnCreate (same-lane upstream),
       // but X→Y still crosses the inserted row and was NOT touched.

--- a/src/features/editor/hooks/useArrows.ts
+++ b/src/features/editor/hooks/useArrows.ts
@@ -21,8 +21,9 @@ export function useArrows({ initialArrows, tasks, rows, lanes, autoConnect }: Us
 
   const autoConnectOnCreate = (taskKey: string, ri: number, li: number): void => {
     if (!autoConnect || Object.keys(tasks).length < 1) return
-    const bestKey = findClosestUpstream(tasks, rows, lanes, ri, li, arrows)
-    if (!bestKey) return
+    const result = findClosestUpstream(tasks, rows, lanes, ri, li, arrows)
+    if (!result) return
+    const bestKey = result.key
 
     // If the chosen upstream lives in a row above the new node, re-route any arrow
     // from it to a downstream node (row > ri) through the new node, splitting

--- a/src/features/editor/hooks/useArrows.ts
+++ b/src/features/editor/hooks/useArrows.ts
@@ -24,22 +24,29 @@ export function useArrows({ initialArrows, tasks, rows, lanes, autoConnect }: Us
     const result = findClosestUpstream(tasks, rows, lanes, ri, li, arrows)
     if (!result) return
     const bestKey = result.key
+    const splitArrowId = result.splitArrowId
 
-    // If the chosen upstream lives in a row above the new node, re-route any arrow
-    // from it to a downstream node (row > ri) through the new node, splitting
-    // `bestKey → downstream` into `bestKey → new → downstream`.
-    const bestTask = tasks[bestKey]
-    const bestRi = bestTask ? rows.findIndex((r) => r.id === bestTask.rid) : -1
-    const splitArrows =
-      bestRi >= 0 && bestRi < ri
-        ? arrows.filter((a) => {
-            if (a.from !== bestKey) return false
-            const toTask = tasks[a.to]
-            if (!toTask) return false
-            const toRi = rows.findIndex((r) => r.id === toTask.rid)
-            return toRi > ri
-          })
-        : []
+    // Step 2.5 hit: splice only the matched arrow (targeted).
+    // Otherwise (Step 1/2/3): if upstream is in a row above, splice all of its
+    // outgoing arrows whose target is below the new node (broad — preserves
+    // existing same-lane chain insertion behavior).
+    let splitArrows: InternalArrow[]
+    if (splitArrowId) {
+      splitArrows = arrows.filter((a) => a.id === splitArrowId)
+    } else {
+      const bestTask = tasks[bestKey]
+      const bestRi = bestTask ? rows.findIndex((r) => r.id === bestTask.rid) : -1
+      splitArrows =
+        bestRi >= 0 && bestRi < ri
+          ? arrows.filter((a) => {
+              if (a.from !== bestKey) return false
+              const toTask = tasks[a.to]
+              if (!toTask) return false
+              const toRi = rows.findIndex((r) => r.id === toTask.rid)
+              return toRi > ri
+            })
+          : []
+    }
 
     const splitIds = new Set(splitArrows.map((a) => a.id))
     autoSplitHandledRef.current = splitIds


### PR DESCRIPTION
## Summary

- 新ノードを既存矢印の経路上に追加したとき、無関係な遠いテールに矢印を引いてしまうバグを修正 (#336)
- \`findClosestUpstream\` の Step 2 と Step 3 の間に **Step 2.5: 経路通過矢印への割り込み** を追加
- Step 2.5 ヒット時はターゲット限定スプライス（対象1本のみ）。Step 1/2/3 経由は既存の broad splice を維持

## 詳細

### 原因

縦に通過する矢印 \`A → C\` の経路上のセルに新ノード B を追加したとき、Step 1/2 はミスし、Step 3（上流テイル）は \`A\`（outgoing 持ち）を除外するため、無関係な遠いテールが選ばれていた。

### 修正

- \`findClosestUpstream\` の戻り値を \`UpstreamResult | null\` (\`{ key, splitArrowId? }\`) に拡張
- Step 2 と Step 3 の間に Step 2.5 を挿入：
  - 候補矢印: \`fromRi < newRi < toRi\` かつ (\`toLi === newLi\` (タイプ①) または \`min(fromLi,toLi) <= newLi <= max(fromLi,toLi)\` (タイプ②))
  - 優先順位: タイプ① > タイプ② → 同タイプ内では \`fromRi\` が近い方
- \`autoConnectOnCreate\` は \`splitArrowId\` セット時はその1本だけスプライス、それ以外は既存の broad splice を維持

## Test plan

- [x] \`auto-connect.test.ts\` 39 件 全パス（既存 33 + 新規 6: タイプ①優先、fromRi 近接、Step 1/2 優先、フォールスルー、issue #336 再現シナリオ、基本ケース）
- [x] \`useArrows.test.ts\` 23 件 全パス（既存 22 + 新規 1: ターゲット限定スプライス）
- [x] \`npm test\` 全 1548 件 パス
- [x] \`tsc --noEmit\` 型エラーなし
- [x] \`npm run lint\` (eslint + prettier) 既存の warning 以外エラーなし
- [ ] ブラウザ目視確認: この worktree に \`.env\` ファイルがなく authenticated 動作確認は未実施。issue 再現シナリオはユニットテストで再現済み

## 設計・計画

- 設計書: \`docs/plans/2026-04-30-issue-336-auto-connect-step25-design.md\`
- 実装計画: \`docs/plans/2026-04-30-issue-336-auto-connect-step25-plan.md\`

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)