### PR TITLE
feat(#342): 共有ページをGoogle等のクローラーから除外 (noindex)

### DIFF
--- a/api/lib/ogp.ts
+++ b/api/lib/ogp.ts
@@ -86,5 +86,14 @@ export function injectOgpMeta(indexHtml: string, params: OgpParams): string {
     (_, p1, p2) => `${p1}${ogImage}${p2}`,
   )
 
+  // Exclude shared pages from search engines. Inserted just before </head>
+  // so it survives re-injection (idempotent: replace if already present).
+  const robotsMeta = '<meta name="robots" content="noindex, nofollow" />'
+  if (/<meta\s+name="robots"[^>]*>/i.test(html)) {
+    html = html.replace(/<meta\s+name="robots"[^>]*>/i, robotsMeta)
+  } else {
+    html = html.replace(/<\/head>/i, `  ${robotsMeta}\n  </head>`)
+  }
+
   return html
 }

--- a/api/routes/ogp.ts
+++ b/api/routes/ogp.ts
@@ -17,6 +17,7 @@ ogp.get('/share/:tokenPng', async (c) => {
       headers: {
         'Content-Type': res.headers.get('Content-Type') || 'image/png',
         'Cache-Control': res.headers.get('Cache-Control') || 'public, max-age=86400',
+        'X-Robots-Tag': res.headers.get('X-Robots-Tag') || 'noindex, nofollow',
       },
     })
   } catch {

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -22,6 +22,12 @@ async function fetchIndexHtml(context: EventContext<Env, string, unknown>): Prom
   return context.env.ASSETS.fetch(new Request(url.toString(), context.request))
 }
 
+function withNoindex(res: Response): Response {
+  const headers = new Headers(res.headers)
+  headers.set('X-Robots-Tag', 'noindex, nofollow')
+  return new Response(res.body, { status: res.status, statusText: res.statusText, headers })
+}
+
 export const onRequest: PagesFunction<Env> = async (context) => {
   const url = new URL(context.request.url)
   const path = url.pathname
@@ -42,7 +48,7 @@ export const onRequest: PagesFunction<Env> = async (context) => {
       .bind(token)
       .first<FlowWithAuthor>()
 
-    if (!flow) return fetchIndexHtml(context)
+    if (!flow) return withNoindex(await fetchIndexHtml(context))
 
     const [lanesResult, nodesResult] = await db.batch([
       db.prepare('SELECT COUNT(*) as count FROM lanes WHERE flow_id = ?').bind(flow.id),
@@ -69,10 +75,11 @@ export const onRequest: PagesFunction<Env> = async (context) => {
       headers: {
         'Content-Type': 'text/html; charset=utf-8',
         'Cache-Control': 'public, max-age=3600',
+        'X-Robots-Tag': 'noindex, nofollow',
       },
     })
   } catch {
-    // On error, fall through to SPA
-    return fetchIndexHtml(context)
+    // On error, fall through to SPA but still mark as noindex (shared path).
+    return withNoindex(await fetchIndexHtml(context))
   }
 }

--- a/tests/api/lib/ogp.test.ts
+++ b/tests/api/lib/ogp.test.ts
@@ -248,9 +248,7 @@ describe('OGP Utility', () => {
     // ========================================
     it('should inject robots noindex meta tag for shared pages', () => {
       const result = injectOgpMeta(SAMPLE_INDEX_HTML, defaultParams)
-      expect(result).toMatch(
-        /<meta\s+name="robots"\s+content="noindex,\s*nofollow"\s*\/?>/i,
-      )
+      expect(result).toMatch(/<meta\s+name="robots"\s+content="noindex,\s*nofollow"\s*\/?>/i)
     })
 
     it('should inject robots meta only once even if called repeatedly', () => {
@@ -262,10 +260,7 @@ describe('OGP Utility', () => {
 
     it('should place robots noindex meta inside <head>', () => {
       const result = injectOgpMeta(SAMPLE_INDEX_HTML, defaultParams)
-      const headSection = result.slice(
-        result.indexOf('<head>'),
-        result.indexOf('</head>'),
-      )
+      const headSection = result.slice(result.indexOf('<head>'), result.indexOf('</head>'))
       expect(headSection).toMatch(/<meta\s+name="robots"\s+content="noindex/i)
     })
   })

--- a/tests/api/lib/ogp.test.ts
+++ b/tests/api/lib/ogp.test.ts
@@ -242,5 +242,31 @@ describe('OGP Utility', () => {
       })
       expect(result).toContain('$1 予算チームさんが作成したフロー図')
     })
+
+    // ========================================
+    // noindex / robots meta (issue #342)
+    // ========================================
+    it('should inject robots noindex meta tag for shared pages', () => {
+      const result = injectOgpMeta(SAMPLE_INDEX_HTML, defaultParams)
+      expect(result).toMatch(
+        /<meta\s+name="robots"\s+content="noindex,\s*nofollow"\s*\/?>/i,
+      )
+    })
+
+    it('should inject robots meta only once even if called repeatedly', () => {
+      const once = injectOgpMeta(SAMPLE_INDEX_HTML, defaultParams)
+      const twice = injectOgpMeta(once, defaultParams)
+      const matches = twice.match(/<meta\s+name="robots"/gi) ?? []
+      expect(matches.length).toBe(1)
+    })
+
+    it('should place robots noindex meta inside <head>', () => {
+      const result = injectOgpMeta(SAMPLE_INDEX_HTML, defaultParams)
+      const headSection = result.slice(
+        result.indexOf('<head>'),
+        result.indexOf('</head>'),
+      )
+      expect(headSection).toMatch(/<meta\s+name="robots"\s+content="noindex/i)
+    })
   })
 })

--- a/tests/api/routes/ogp.test.ts
+++ b/tests/api/routes/ogp.test.ts
@@ -43,6 +43,22 @@ describe('OGP Proxy Route', () => {
       expect(res.headers.get('cache-control')).toBe('public, max-age=86400')
     })
 
+    it('should set X-Robots-Tag noindex header on proxied OGP image (issue #342)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(VALID_PNG, {
+          status: 200,
+          headers: { 'Content-Type': 'image/png' },
+        }),
+      )
+
+      const res = await app.request('/api/ogp/share/abc123.png', {}, env)
+      expect(res.status).toBe(200)
+      const robotsTag = res.headers.get('x-robots-tag')
+      expect(robotsTag).toBeTruthy()
+      expect(robotsTag).toMatch(/noindex/i)
+      expect(robotsTag).toMatch(/nofollow/i)
+    })
+
     it('should forward 404 from OGP Worker for non-existent token', async () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
         new Response(JSON.stringify({ error: '共有フローが見つかりません' }), {

--- a/tests/functions/middleware.test.ts
+++ b/tests/functions/middleware.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import Database from 'better-sqlite3'
-import { createTestDb } from '../helpers/mock-d1'
+import { createTestDb, createMockD1 } from '../helpers/mock-d1'
 import { injectOgpMeta } from '../../api/lib/ogp'
+import { onRequest } from '../../functions/_middleware'
 
 describe('Shared page middleware logic', () => {
   let db: ReturnType<typeof Database>
@@ -314,5 +315,91 @@ describe('Shared page middleware logic', () => {
     expect(html).toContain(
       '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;さんが作成したフロー図',
     )
+  })
+
+  // --- onRequest end-to-end: response headers and HTML for shared pages (issue #342) ---
+
+  function buildContext(
+    request: Request,
+    sqliteDb: ReturnType<typeof Database>,
+    indexHtml: string,
+  ) {
+    const assets = {
+      fetch: async () =>
+        new Response(indexHtml, {
+          status: 200,
+          headers: { 'Content-Type': 'text/html; charset=utf-8' },
+        }),
+    }
+    return {
+      request,
+      env: { FLOWLINE_DB: createMockD1(sqliteDb), ASSETS: assets },
+      next: async () =>
+        new Response('next-fallthrough', {
+          status: 200,
+          headers: { 'Content-Type': 'text/plain' },
+        }),
+      // Pages function fields below are unused by our middleware; cast handles types
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+  }
+
+  const MINI_INDEX = `<!doctype html>
+<html lang="ja">
+<head>
+<title>Flowline — フローを描く。チームが動く。</title>
+<meta name="description" content="default" />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="https://flowline.six1.jp" />
+<meta property="og:title" content="Flowline" />
+<meta property="og:description" content="default" />
+<meta property="og:image" content="https://flowline.six1.jp/ogp/default.png" />
+<meta name="twitter:title" content="Flowline" />
+<meta name="twitter:description" content="default" />
+<meta name="twitter:image" content="https://flowline.six1.jp/ogp/default.png" />
+</head>
+<body><div id="root"></div></body>
+</html>`
+
+  it('should set X-Robots-Tag noindex header on /shared/:token response (issue #342)', async () => {
+    db.prepare(
+      'INSERT INTO flows (id, user_id, title, theme_id, share_token) VALUES (?, ?, ?, ?, ?)',
+    ).run('flow-noindex', 'user-1', 'noindexテスト', 'cloud', 'noindex-token')
+
+    const ctx = buildContext(
+      new Request('https://flowline.six1.jp/shared/noindex-token'),
+      db,
+      MINI_INDEX,
+    )
+    const res = await onRequest(ctx)
+
+    expect(res.status).toBe(200)
+    const robotsTag = res.headers.get('x-robots-tag')
+    expect(robotsTag).toBeTruthy()
+    expect(robotsTag).toMatch(/noindex/i)
+    expect(robotsTag).toMatch(/nofollow/i)
+  })
+
+  it('should include robots noindex meta tag in /shared/:token HTML body (issue #342)', async () => {
+    db.prepare(
+      'INSERT INTO flows (id, user_id, title, theme_id, share_token) VALUES (?, ?, ?, ?, ?)',
+    ).run('flow-noindex-html', 'user-1', 'noindex本文', 'cloud', 'noindex-html-token')
+
+    const ctx = buildContext(
+      new Request('https://flowline.six1.jp/shared/noindex-html-token'),
+      db,
+      MINI_INDEX,
+    )
+    const res = await onRequest(ctx)
+    const body = await res.text()
+
+    expect(body).toMatch(/<meta\s+name="robots"\s+content="noindex,\s*nofollow"/i)
+  })
+
+  it('should NOT add X-Robots-Tag header on non-shared paths (passes through)', async () => {
+    const ctx = buildContext(new Request('https://flowline.six1.jp/'), db, MINI_INDEX)
+    const res = await onRequest(ctx)
+    // Non-shared paths fall through to context.next() and should not be tagged by this middleware
+    expect(res.headers.get('x-robots-tag')).toBeNull()
   })
 })

--- a/tests/workers/ogp/index.test.ts
+++ b/tests/workers/ogp/index.test.ts
@@ -142,6 +142,17 @@ describe('OGP Worker', () => {
       expect(res.headers.get('cache-control')).toBe('public, max-age=86400')
     })
 
+    it('should set X-Robots-Tag noindex header to exclude OGP image from search engines (issue #342)', async () => {
+      insertFlowWithShareToken(db, 'flow-1', USER_ID, 'My Flow', 'abc123')
+
+      const res = await getRequest('/share/abc123.png', env)
+      expect(res.status).toBe(200)
+      const robotsTag = res.headers.get('x-robots-tag')
+      expect(robotsTag).toBeTruthy()
+      expect(robotsTag).toMatch(/noindex/i)
+      expect(robotsTag).toMatch(/nofollow/i)
+    })
+
     it('should return valid PNG data with correct PNG signature bytes', async () => {
       insertFlowWithShareToken(db, 'flow-1', USER_ID, 'My Flow', 'abc123')
 

--- a/workers/ogp/src/index.ts
+++ b/workers/ogp/src/index.ts
@@ -628,6 +628,7 @@ app.get('/share/:tokenPng', async (c) => {
       headers: {
         'Content-Type': 'image/png',
         'Cache-Control': 'public, max-age=86400',
+        'X-Robots-Tag': 'noindex, nofollow',
       },
     })
   } catch (e) {


### PR DESCRIPTION
Closes #342

## Summary
- `/shared/:token` のHTMLに `<meta name="robots" content="noindex, nofollow">` を注入
- `/shared/:token` および OGP画像エンドポイント (`/api/ogp/share/:token.png`, worker `/share/:tokenPng`) のレスポンスヘッダーに `X-Robots-Tag: noindex, nofollow` を付与
- robots.txt は意図的に使わない（Disallow するとクローラーが noindex を読めなくなるため）

## なぜ必要か
共有URLはユーザー間で渡される想定で、Googleの検索結果に出ることは望ましくない。middlewareがDBから取得したフロー名・作者名・統計情報をHTMLに埋め込んでいるため、現状はクローラーが内容を読み取れる状態だった。

## 実装範囲
| ファイル | 変更内容 |
|---|---|
| `api/lib/ogp.ts` | `injectOgpMeta` で robots noindex メタタグを `</head>` 直前に注入（冪等） |
| `functions/_middleware.ts` | `/shared/:token` 全レスポンスに `X-Robots-Tag` 付与（flow not found / catch fallback も含む） |
| `workers/ogp/src/index.ts` | OGP画像レスポンスに `X-Robots-Tag` 付与 |
| `api/routes/ogp.ts` | プロキシで `X-Robots-Tag` を転送（fallback で常に noindex） |

## Test plan
- [x] `api/lib/ogp` の `injectOgpMeta` が noindex メタを1回だけ `<head>` 内に注入
- [x] `functions/_middleware` の `/shared/:token` レスポンスに `X-Robots-Tag` ヘッダーが付く
- [x] `/shared/:token` 以外のパスではヘッダーが付かない（passthrough）
- [x] OGP Worker `/share/:tokenPng` レスポンスに `X-Robots-Tag` が付く
- [x] OGPプロキシ `/api/ogp/share/:tokenPng` でもヘッダーが転送される
- [x] 全テスト pass (1559 passed)
- [x] 実画面確認: `curl -I` で `/shared/<token>` に `X-Robots-Tag: noindex, nofollow` 確認、`/` `/flows` には付かないこと確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)