### PR TITLE
fix(#346): 斜め配置矢印の Z字パスが中間行ノードを貫通する問題を修正

### DIFF
--- a/docs/superpowers/plans/2026-05-22-issue-346-diagonal-arrow-detour-plan.md
+++ b/docs/superpowers/plans/2026-05-22-issue-346-diagonal-arrow-detour-plan.md
@@ -1,0 +1,1493 @@
+# issue #346: 斜め配置矢印 Z字パスの中間行ノード貫通修正 — 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 斜め配置 (異行×異レーン) の矢印 Z字パスが中間行のノードを貫通するバグを修正する。`detectDiagonalDetour` と `collectDiagonalObstacles` を新規追加し、Z字パス 3 セグメント全てに衝突判定を入れる。
+
+**Architecture:** 既存 `collectObstacles` / `collectVerticalObstacles` / `detectDetour` / `detectVerticalDetour` には触れず、新規 `Diagonal` 系関数として独立実装。`buildArrowPath` の斜め分岐に迂回判定を追加し、`FlowEditor.aPath` / `SharedFlowViewer.computeArrowPath` の obstacles 組み立て分岐に `else` 節を 1 行追加する。
+
+**Tech Stack:** TypeScript, React, Vitest, SVG path arithmetic, Playwright (目視確認)
+
+**Spec:** [docs/superpowers/specs/2026-05-22-issue-346-diagonal-arrow-detour-design.md](../specs/2026-05-22-issue-346-diagonal-arrow-detour-design.md)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+| --- | --- | --- |
+| `src/lib/arrow-routing.ts` | Modify | 新規 `collectDiagonalObstacles` / `detectDiagonalDetour` 追加、`buildArrowPath` の斜め分岐拡張 |
+| `src/lib/arrow-routing.test.ts` | Modify | 新規 detector / collector の単体テスト、`buildArrowPath` 統合テスト、regression テスト |
+| `src/features/editor/FlowEditor.tsx` | Modify | `aPath` の obstacles 組み立てに diagonal 分岐追加 (1 箇所) |
+| `src/features/shared/SharedFlowViewer.tsx` | Modify | `computeArrowPath` の obstacles 組み立てに diagonal 分岐追加 (1 箇所) |
+
+---
+
+## 共通テスト fixture
+
+以降のタスクで使用する座標 (post-exitPt/entryPt 後の値):
+
+- **source 中心**: `f = (200, 100)`
+- **target 中心**: `t = (600, 400)`
+- **s (source bottom)**: `(200, 128)`
+- **e (target top)**: `(600, 372)`
+- **初期 my**: `(128 + 372) / 2 = 250`
+- **bbox**: `w = 152, h = 56`
+- **source 列 x**: 200
+- **target 列 x**: 600
+- **中央行 Y**: 250
+
+定数: `DETOUR_MARGIN = 14`, `APPROACH_GAP = 14`, `DEPART_GAP = 14` (既存)
+
+---
+
+### Task 1: `collectDiagonalObstacles` の skeleton + from/to 除外
+
+**Files:**
+- Modify: `src/lib/arrow-routing.ts`
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`src/lib/arrow-routing.test.ts` の末尾 (last `describe` 後) に追加:
+
+```ts
+describe('collectDiagonalObstacles', () => {
+  const baseArgs = {
+    fromKey: 'A',
+    toKey: 'C',
+    fromCx: 200,
+    fromCy: 100,
+    toCx: 600,
+    toCy: 400,
+    rowH: 84,
+    colW: 200,
+    bboxW: 152,
+    bboxH: 56,
+  }
+
+  it('should exclude from/to nodes themselves when only from/to exist', () => {
+    const nodes: ObstacleNode[] = [
+      { key: 'A', cx: 200, cy: 100 },
+      { key: 'C', cx: 600, cy: 400 },
+    ]
+    const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+    expect(r).toEqual([])
+  })
+})
+```
+
+ファイル先頭の import に `collectDiagonalObstacles` を追加:
+
+```ts
+import {
+  buildArrowPath,
+  collectObstacles,
+  collectVerticalObstacles,
+  collectDiagonalObstacles,
+  type Bbox,
+  type ObstacleNode,
+} from './arrow-routing'
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: FAIL — `collectDiagonalObstacles` is not exported / not a function
+
+- [ ] **Step 3: Write minimal implementation**
+
+`src/lib/arrow-routing.ts` の末尾 (last `export function` 後) に追加:
+
+```ts
+interface CollectDiagonalObstaclesArgs {
+  nodes: ObstacleNode[]
+  fromKey: string
+  toKey: string
+  fromCx: number
+  fromCy: number
+  toCx: number
+  toCy: number
+  rowH: number
+  colW: number
+  bboxW: number
+  bboxH: number
+}
+
+/**
+ * 斜め配置矢印 (異行×異レーン) の Z字パスに沿った障害ノードを bbox 配列で返す。
+ * source 列・target 列・中央行・各列の隣接列を広めに収集し、detector 側で再フィルタする。
+ * from/to 自身と Z字パスから離れたノードは除外する。
+ */
+export function collectDiagonalObstacles(args: CollectDiagonalObstaclesArgs): Bbox[] {
+  const { nodes, fromKey, toKey } = args
+  const result: Bbox[] = []
+  for (const n of nodes) {
+    if (n.key === fromKey || n.key === toKey) continue
+    // TODO: 後続タスクで収集ロジックを追加
+  }
+  return result
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts
+git commit -m "feat(#346): add collectDiagonalObstacles skeleton with from/to exclusion"
+```
+
+---
+
+### Task 2: `collectDiagonalObstacles` - source 列ストリップ収集
+
+**Files:**
+- Modify: `src/lib/arrow-routing.ts`
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`describe('collectDiagonalObstacles', ...)` 内に追加:
+
+```ts
+it('should collect source-column obstacle between source and target rows', () => {
+  const nodes: ObstacleNode[] = [
+    { key: 'A', cx: 200, cy: 100 },
+    { key: 'B', cx: 200, cy: 250 }, // source 列 (x=200), 中央行
+    { key: 'C', cx: 600, cy: 400 },
+  ]
+  const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+  expect(r).toEqual([{ x: 200, y: 250, w: 152, h: 56 }])
+})
+
+it('should not collect source-column nodes outside Z-path Y range', () => {
+  const nodes: ObstacleNode[] = [
+    { key: 'A', cx: 200, cy: 100 },
+    { key: 'B', cx: 200, cy: 50 },  // source 行より上 (out of range)
+    { key: 'D', cx: 200, cy: 450 }, // target 行より下 (out of range)
+    { key: 'C', cx: 600, cy: 400 },
+  ]
+  const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+  expect(r).toEqual([])
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: FAIL — empty array returned, expected `{ x: 200, y: 250, ... }`
+
+- [ ] **Step 3: Update implementation**
+
+`collectDiagonalObstacles` 内のループに追加:
+
+```ts
+export function collectDiagonalObstacles(args: CollectDiagonalObstaclesArgs): Bbox[] {
+  const { nodes, fromKey, toKey, fromCx, fromCy, toCx, toCy, bboxW, bboxH } = args
+  const yLow = Math.min(fromCy, toCy)
+  const yHigh = Math.max(fromCy, toCy)
+  const result: Bbox[] = []
+  for (const n of nodes) {
+    if (n.key === fromKey || n.key === toKey) continue
+    const onSourceCol = Math.abs(n.cx - fromCx) < bboxW / 2 + 2
+    const inZRangeY = n.cy > yLow + 1 && n.cy < yHigh - 1
+    if (onSourceCol && inZRangeY) {
+      result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+      continue
+    }
+  }
+  return result
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: PASS (both new tests + Task 1 test)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts
+git commit -m "feat(#346): collectDiagonalObstacles picks up source-column obstacles"
+```
+
+---
+
+### Task 3: `collectDiagonalObstacles` - target 列ストリップ収集
+
+**Files:**
+- Modify: `src/lib/arrow-routing.ts`
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('should collect target-column obstacle between source and target rows', () => {
+  const nodes: ObstacleNode[] = [
+    { key: 'A', cx: 200, cy: 100 },
+    { key: 'B', cx: 600, cy: 250 }, // target 列 (x=600), 中央行
+    { key: 'C', cx: 600, cy: 400 },
+  ]
+  const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+  expect(r).toEqual([{ x: 600, y: 250, w: 152, h: 56 }])
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: FAIL — `[]` returned, expected `[{ x: 600, ... }]`
+
+- [ ] **Step 3: Update implementation**
+
+`collectDiagonalObstacles` ループ内に分岐追加:
+
+```ts
+    const onSourceCol = Math.abs(n.cx - fromCx) < bboxW / 2 + 2
+    const onTargetCol = Math.abs(n.cx - toCx) < bboxW / 2 + 2
+    const inZRangeY = n.cy > yLow + 1 && n.cy < yHigh - 1
+    if ((onSourceCol || onTargetCol) && inZRangeY) {
+      result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+      continue
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts
+git commit -m "feat(#346): collectDiagonalObstacles picks up target-column obstacles"
+```
+
+---
+
+### Task 4: `collectDiagonalObstacles` - 中央行ストリップ収集
+
+**Files:**
+- Modify: `src/lib/arrow-routing.ts`
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('should collect middle-row obstacle between source and target X', () => {
+  const nodes: ObstacleNode[] = [
+    { key: 'A', cx: 200, cy: 100 },
+    { key: 'B', cx: 400, cy: 250 }, // 中央 X、中央行 Y
+    { key: 'C', cx: 600, cy: 400 },
+  ]
+  const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+  expect(r).toEqual([{ x: 400, y: 250, w: 152, h: 56 }])
+})
+
+it('should not collect nodes outside Z-path X range at middle row', () => {
+  const nodes: ObstacleNode[] = [
+    { key: 'A', cx: 200, cy: 100 },
+    { key: 'B', cx: 50, cy: 250 },  // source の左 (out of range)
+    { key: 'D', cx: 750, cy: 250 }, // target の右 (out of range, 隣接列でもない)
+    { key: 'C', cx: 600, cy: 400 },
+  ]
+  const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+  expect(r).toEqual([])
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: FAIL — middle row node not collected
+
+- [ ] **Step 3: Update implementation**
+
+```ts
+    const onSourceCol = Math.abs(n.cx - fromCx) < bboxW / 2 + 2
+    const onTargetCol = Math.abs(n.cx - toCx) < bboxW / 2 + 2
+    const inZRangeY = n.cy > yLow + 1 && n.cy < yHigh - 1
+    if ((onSourceCol || onTargetCol) && inZRangeY) {
+      result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+      continue
+    }
+    const midY = (fromCy + toCy) / 2
+    const onMiddleRow = Math.abs(n.cy - midY) < bboxH / 2 + 2
+    const xLow = Math.min(fromCx, toCx)
+    const xHigh = Math.max(fromCx, toCx)
+    const inZRangeX = n.cx > xLow + 1 && n.cx < xHigh - 1
+    if (onMiddleRow && inZRangeX) {
+      result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+      continue
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts
+git commit -m "feat(#346): collectDiagonalObstacles picks up middle-row obstacles"
+```
+
+---
+
+### Task 5: `collectDiagonalObstacles` - 隣接列 (左右1列) 収集
+
+**Files:**
+- Modify: `src/lib/arrow-routing.ts`
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+it('should collect source-adjacent-column obstacle within extended Y range', () => {
+  const nodes: ObstacleNode[] = [
+    { key: 'A', cx: 200, cy: 100 },
+    { key: 'B', cx: 400, cy: 100 }, // source の右隣列 (x=200+colW=400), source 行と同じ Y
+    { key: 'C', cx: 600, cy: 400 },
+  ]
+  const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+  expect(r).toContainEqual({ x: 400, y: 100, w: 152, h: 56 })
+})
+
+it('should collect target-adjacent-column obstacle for direction decision', () => {
+  const nodes: ObstacleNode[] = [
+    { key: 'A', cx: 200, cy: 100 },
+    { key: 'B', cx: 800, cy: 400 }, // target の右隣列 (x=600+colW=800)
+    { key: 'C', cx: 600, cy: 400 },
+  ]
+  const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+  expect(r).toContainEqual({ x: 800, y: 400, w: 152, h: 56 })
+})
+
+it('should not collect adjacent-column nodes outside extended Y range', () => {
+  const nodes: ObstacleNode[] = [
+    { key: 'A', cx: 200, cy: 100 },
+    { key: 'B', cx: 400, cy: 800 }, // source の右隣列だが Y が範囲外
+    { key: 'C', cx: 600, cy: 400 },
+  ]
+  const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+  expect(r).toEqual([])
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: FAIL — adjacent column nodes not collected
+
+- [ ] **Step 3: Update implementation**
+
+`collectDiagonalObstacles` 内のループに分岐追加:
+
+```ts
+    const { nodes, fromKey, toKey, fromCx, fromCy, toCx, toCy, rowH, colW, bboxW, bboxH } = args
+    // ... 既存収集ロジックの後 ...
+
+    const onSourceAdjacentCol =
+      Math.abs(n.cx - fromCx) > colW - bboxW / 2 && Math.abs(n.cx - fromCx) < colW + bboxW / 2
+    const onTargetAdjacentCol =
+      Math.abs(n.cx - toCx) > colW - bboxW / 2 && Math.abs(n.cx - toCx) < colW + bboxW / 2
+    const inExtendedY = n.cy >= yLow - rowH / 2 && n.cy <= yHigh + rowH / 2
+    if ((onSourceAdjacentCol || onTargetAdjacentCol) && inExtendedY) {
+      result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+      continue
+    }
+```
+
+注: `rowH` と `colW` を関数先頭の destructure に追加すること。
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts
+git commit -m "feat(#346): collectDiagonalObstacles picks up adjacent-column obstacles"
+```
+
+---
+
+### Task 6: `detectDiagonalDetour` - null ガード (水平・垂直・空配列)
+
+**Files:**
+- Modify: `src/lib/arrow-routing.ts`
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+import に `detectDiagonalDetour` を追加:
+
+```ts
+import {
+  buildArrowPath,
+  collectObstacles,
+  collectVerticalObstacles,
+  collectDiagonalObstacles,
+  detectDiagonalDetour,
+  type Bbox,
+  type ObstacleNode,
+} from './arrow-routing'
+```
+
+新規 describe を `collectDiagonalObstacles` の describe 後に追加:
+
+```ts
+describe('detectDiagonalDetour', () => {
+  const s = { x: 200, y: 128 }
+  const e = { x: 600, y: 372 }
+
+  it('should return null when arrow is horizontal (|dy| < 2)', () => {
+    const r = detectDiagonalDetour({ x: 200, y: 200 }, { x: 600, y: 201 }, [
+      { x: 400, y: 200, w: 152, h: 56 },
+    ])
+    expect(r).toBeNull()
+  })
+
+  it('should return null when arrow is vertical (|dx| < 2)', () => {
+    const r = detectDiagonalDetour({ x: 200, y: 100 }, { x: 201, y: 400 }, [
+      { x: 200, y: 250, w: 152, h: 56 },
+    ])
+    expect(r).toBeNull()
+  })
+
+  it('should return null with empty obstacles array', () => {
+    expect(detectDiagonalDetour(s, e, [])).toBeNull()
+  })
+
+  it('should return null when no obstacles intersect Z-path', () => {
+    const farAway: Bbox = { x: 50, y: 50, w: 152, h: 56 }
+    expect(detectDiagonalDetour(s, e, [farAway])).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: FAIL — `detectDiagonalDetour` is not exported
+
+- [ ] **Step 3: Write minimal implementation**
+
+`src/lib/arrow-routing.ts` の `detectVerticalDetour` 関数の後 (line 103 付近) に追加:
+
+```ts
+type DiagonalDetourResult =
+  | { kind: 'shift-my'; my: number }
+  | { kind: 'target-detour'; my: number; detourX: number; approachY: number }
+  | { kind: 'source-detour'; departY: number; detourX: number; my: number }
+  | {
+      kind: 'both-detour'
+      departY: number
+      sourceDetourX: number
+      my: number
+      targetDetourX: number
+      approachY: number
+    }
+
+/**
+ * 斜め配置矢印 (異行×異レーン) の Z字パス 3 セグメント (source 縦/中央水平/target 縦) と
+ * 障害ノードの衝突を判定し、迂回パスを記述する DiagonalDetourResult を返す。
+ * 障害なしまたは斜めでない (水平・垂直直線) ときは null を返す。
+ *
+ * 優先順位:
+ *   sourceColHit && targetColHit → 'both-detour' (8 セグ)
+ *   targetColHit                 → 'target-detour' (6 セグ、core ケース)
+ *   sourceColHit                 → 'source-detour' (6 セグ、鏡像)
+ *   middleRowHit のみ             → 'shift-my' (4 セグ維持)
+ */
+export function detectDiagonalDetour(
+  s: Point,
+  e: Point,
+  obstacles: Bbox[],
+): DiagonalDetourResult | null {
+  if (Math.abs(e.x - s.x) < 2 || Math.abs(e.y - s.y) < 2) return null
+  if (obstacles.length === 0) return null
+
+  // TODO: 後続タスクで衝突判定を追加
+  return null
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts
+git commit -m "feat(#346): add detectDiagonalDetour skeleton with null guards"
+```
+
+---
+
+### Task 7: `detectDiagonalDetour` - target-detour (右優先) を返す
+
+**Files:**
+- Modify: `src/lib/arrow-routing.ts`
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`describe('detectDiagonalDetour', ...)` 内に追加:
+
+```ts
+it('should return target-detour when obstacle is in target column between my and e.y', () => {
+  // s=(200,128), e=(600,372), initial my = 250
+  // 障害 B は target 列 (x=600) の中央行 (y=250)
+  const B: Bbox = { x: 600, y: 250, w: 152, h: 56 }
+  const r = detectDiagonalDetour(s, e, [B])
+  expect(r).toEqual({
+    kind: 'target-detour',
+    my: 250,
+    detourX: 600 + 76 + 14, // 690 (右迂回: 障害右端 + DETOUR_MARGIN)
+    approachY: 372 - 14,    // 358
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: FAIL — `null` returned
+
+- [ ] **Step 3: Update implementation**
+
+`detectDiagonalDetour` の本体を実装:
+
+```ts
+export function detectDiagonalDetour(
+  s: Point,
+  e: Point,
+  obstacles: Bbox[],
+): DiagonalDetourResult | null {
+  if (Math.abs(e.x - s.x) < 2 || Math.abs(e.y - s.y) < 2) return null
+  if (obstacles.length === 0) return null
+
+  const my = (s.y + e.y) / 2
+
+  // source 列衝突: source 縦セグメント (s.y → my) と重なる障害
+  const sourceColHits = obstacles.filter((b) => {
+    const yLow = Math.min(s.y, my)
+    const yHigh = Math.max(s.y, my)
+    return (
+      Math.abs(b.x - s.x) < b.w / 2 + 2 &&
+      b.y - b.h / 2 < yHigh - 1 &&
+      b.y + b.h / 2 > yLow + 1
+    )
+  })
+
+  // target 列衝突: target 縦セグメント (my → e.y) と重なる障害
+  const targetColHits = obstacles.filter((b) => {
+    const yLow = Math.min(my, e.y)
+    const yHigh = Math.max(my, e.y)
+    return (
+      Math.abs(b.x - e.x) < b.w / 2 + 2 &&
+      b.y - b.h / 2 < yHigh - 1 &&
+      b.y + b.h / 2 > yLow + 1
+    )
+  })
+
+  if (targetColHits.length > 0 && sourceColHits.length === 0) {
+    // 方向決定: target 列障害の左右塞がり判定
+    const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
+    const rightBlocked = targetColHits.some((obs) =>
+      obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
+    )
+    const leftBlocked = targetColHits.some((obs) =>
+      obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
+    )
+    const goRight = !rightBlocked || leftBlocked
+    const detourX = goRight
+      ? Math.max(...targetColHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+      : Math.min(...targetColHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+    const sign = Math.sign(e.y - my)
+    const halfDy = Math.abs(e.y - my) / 2
+    const approachY = e.y - sign * Math.min(APPROACH_GAP, halfDy)
+    return { kind: 'target-detour', my, detourX, approachY }
+  }
+
+  return null
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts
+git commit -m "feat(#346): detectDiagonalDetour returns target-detour for target-column obstacle"
+```
+
+---
+
+### Task 8: `detectDiagonalDetour` - target-detour 左迂回 (右塞がり時)
+
+**Files:**
+- Modify: `src/lib/arrow-routing.ts`
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('should return target-detour with left-side detourX when target column is right-blocked', () => {
+  const B: Bbox = { x: 600, y: 250, w: 152, h: 56 } // target 列障害
+  const R: Bbox = { x: 800, y: 250, w: 152, h: 56 } // 直右に障害 (Y 重なり)
+  const r = detectDiagonalDetour(s, e, [B, R])
+  expect(r).toEqual({
+    kind: 'target-detour',
+    my: 250,
+    detourX: 600 - 76 - 14, // 510 (左迂回)
+    approachY: 358,
+  })
+})
+
+it('should prefer right detour when both sides of target column are blocked', () => {
+  const B: Bbox = { x: 600, y: 250, w: 152, h: 56 }
+  const R: Bbox = { x: 800, y: 250, w: 152, h: 56 }
+  const L: Bbox = { x: 400, y: 250, w: 152, h: 56 }
+  const r = detectDiagonalDetour(s, e, [B, R, L])
+  expect(r).toEqual({
+    kind: 'target-detour',
+    my: 250,
+    detourX: 690, // 右優先
+    approachY: 358,
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail / pass**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: 1個目 (左迂回) FAIL、2個目 (両塞がり右優先) PASS (既存ロジックで動く)
+
+- [ ] **Step 3: Verify left detour logic works (no code change needed)**
+
+Task 7 で実装した左右判定ロジックは既に正しく左迂回を返すはず。失敗テストの原因が `detourX` 計算式の符号ミスでないか確認:
+- `goRight = !rightBlocked || leftBlocked` → 右塞がり&左空きで `false`
+- `detourX = goRight ? max(右端)+14 : min(左端)-14` → 左迂回時は `600 - 76 - 14 = 510` ✓
+
+実装変更不要。テストのみ追加。
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/arrow-routing.test.ts
+git commit -m "test(#346): cover target-detour direction (left side, both-blocked priority)"
+```
+
+---
+
+### Task 9: `detectDiagonalDetour` - source-detour (鏡像)
+
+**Files:**
+- Modify: `src/lib/arrow-routing.ts`
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('should return source-detour when obstacle is in source column between s.y and my', () => {
+  const B: Bbox = { x: 200, y: 250, w: 152, h: 56 } // source 列 (x=200), 中央行
+  const r = detectDiagonalDetour(s, e, [B])
+  expect(r).toEqual({
+    kind: 'source-detour',
+    departY: 128 + 14, // 142
+    detourX: 200 + 76 + 14, // 290 (右優先)
+    my: 250,
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: FAIL — `null` returned
+
+- [ ] **Step 3: Update implementation**
+
+`detectDiagonalDetour` の `target-detour` 分岐の後に追加:
+
+```ts
+  if (sourceColHits.length > 0 && targetColHits.length === 0) {
+    const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
+    const rightBlocked = sourceColHits.some((obs) =>
+      obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
+    )
+    const leftBlocked = sourceColHits.some((obs) =>
+      obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
+    )
+    const goRight = !rightBlocked || leftBlocked
+    const detourX = goRight
+      ? Math.max(...sourceColHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+      : Math.min(...sourceColHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+    const sign = Math.sign(my - s.y)
+    const halfDy = Math.abs(my - s.y) / 2
+    const departY = s.y + sign * Math.min(DEPART_GAP, halfDy)
+    return { kind: 'source-detour', departY, detourX, my }
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts
+git commit -m "feat(#346): detectDiagonalDetour returns source-detour for source-column obstacle"
+```
+
+---
+
+### Task 10: `detectDiagonalDetour` - shift-my (中央水平のみ衝突)
+
+**Files:**
+- Modify: `src/lib/arrow-routing.ts`
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('should return shift-my when only middle horizontal segment is blocked', () => {
+  // 中央 X (x=400), 中央行 Y (y=250) — source/target 列に重ならない
+  const B: Bbox = { x: 400, y: 250, w: 152, h: 56 }
+  const r = detectDiagonalDetour(s, e, [B])
+  expect(r).toEqual({
+    kind: 'shift-my',
+    my: 250 + 28 + 14, // 292 (下優先: 障害下端 + DETOUR_MARGIN)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: FAIL — `null` returned
+
+- [ ] **Step 3: Update implementation**
+
+`detectDiagonalDetour` の `source-detour` 分岐の後に追加:
+
+```ts
+  // 中央水平セグメント衝突: Y ≈ my で X が源-標的間
+  const middleRowHits = obstacles.filter((b) => {
+    const xLow = Math.min(s.x, e.x)
+    const xHigh = Math.max(s.x, e.x)
+    return (
+      Math.abs(b.y - my) < b.h / 2 + 2 &&
+      b.x - b.w / 2 < xHigh - 1 &&
+      b.x + b.w / 2 > xLow + 1
+    )
+  })
+
+  if (middleRowHits.length > 0 && sourceColHits.length === 0 && targetColHits.length === 0) {
+    // 上下塞がり判定 (xOverlap で X 方向に重なる障害を直上/直下から探す)
+    const xOverlap = (a: Bbox, b: Bbox) => Math.abs(a.x - b.x) < (a.w + b.w) / 2
+    const downBlocked = middleRowHits.some((obs) =>
+      obstacles.some((b) => b.y > obs.y + 1 && xOverlap(obs, b)),
+    )
+    const upBlocked = middleRowHits.some((obs) =>
+      obstacles.some((b) => b.y < obs.y - 1 && xOverlap(obs, b)),
+    )
+    const goDown = !downBlocked || upBlocked
+    const shiftedMy = goDown
+      ? Math.max(...middleRowHits.map((o) => o.y + o.h / 2)) + DETOUR_MARGIN
+      : Math.min(...middleRowHits.map((o) => o.y - o.h / 2)) - DETOUR_MARGIN
+
+    // ガード: shiftedMy が source 行 / target 行を侵食しないこと
+    const yLow = Math.min(s.y, e.y)
+    const yHigh = Math.max(s.y, e.y)
+    const bboxHEst = middleRowHits[0]?.h ?? 56
+    const lo = yLow + bboxHEst / 2 + 1
+    const hi = yHigh - bboxHEst / 2 - 1
+    if (shiftedMy >= lo && shiftedMy <= hi) {
+      return { kind: 'shift-my', my: shiftedMy }
+    }
+    // 範囲外 → 後続タスクで target-detour 昇格 (Task 11)
+  }
+
+  return null
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts
+git commit -m "feat(#346): detectDiagonalDetour returns shift-my for middle-row obstacle"
+```
+
+---
+
+### Task 11: `detectDiagonalDetour` - shift-my エスカレーション → target-detour
+
+**Files:**
+- Modify: `src/lib/arrow-routing.ts`
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('should escalate to target-detour when shift-my would exceed row bounds', () => {
+  // 狭い dy: s=(200,128), e=(600,172), my=150. ガード幅は実質ゼロ。
+  const sNarrow = { x: 200, y: 128 }
+  const eNarrow = { x: 600, y: 172 }
+  const B: Bbox = { x: 400, y: 150, w: 152, h: 56 } // 中央 X、中央行近傍
+  const r = detectDiagonalDetour(sNarrow, eNarrow, [B])
+  expect(r?.kind).toBe('target-detour')
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: FAIL — `null` returned (escalation 未実装)
+
+- [ ] **Step 3: Update implementation**
+
+`detectDiagonalDetour` 内、shift-my ガード失敗時に `middleRowHits` を `targetColHits` 扱いで再度 target-detour ロジックを実行:
+
+`shift-my` ブロックの最後の `// 範囲外 → 後続タスクで target-detour 昇格 (Task 11)` 行を以下に置き換え:
+
+```ts
+    // 範囲外 → 中央障害を targetColHit 扱いで target-detour に昇格
+    const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
+    const rightBlocked = middleRowHits.some((obs) =>
+      obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
+    )
+    const leftBlocked = middleRowHits.some((obs) =>
+      obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
+    )
+    const goRight2 = !rightBlocked || leftBlocked
+    const detourX = goRight2
+      ? Math.max(...middleRowHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+      : Math.min(...middleRowHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+    const sign = Math.sign(e.y - my)
+    const halfDy = Math.abs(e.y - my) / 2
+    const approachY = e.y - sign * Math.min(APPROACH_GAP, halfDy)
+    return { kind: 'target-detour', my, detourX, approachY }
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts
+git commit -m "feat(#346): detectDiagonalDetour escalates shift-my to target-detour on row clamp"
+```
+
+---
+
+### Task 12: `detectDiagonalDetour` - both-detour (両列衝突)
+
+**Files:**
+- Modify: `src/lib/arrow-routing.ts`
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('should return both-detour when source and target columns both have obstacles', () => {
+  const Bs: Bbox = { x: 200, y: 250, w: 152, h: 56 } // source 列
+  const Bt: Bbox = { x: 600, y: 250, w: 152, h: 56 } // target 列
+  const r = detectDiagonalDetour(s, e, [Bs, Bt])
+  expect(r).toEqual({
+    kind: 'both-detour',
+    departY: 142,
+    sourceDetourX: 290,
+    my: 250,
+    targetDetourX: 690,
+    approachY: 358,
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: FAIL — 現状は `target-detour` が返る (sourceColHits も targetColHits も両方ある条件分岐がない)
+
+- [ ] **Step 3: Update implementation**
+
+`detectDiagonalDetour` の最初に `both-detour` 分岐を追加。`source-detour` / `target-detour` 分岐の **前** に挿入:
+
+```ts
+  // 両列衝突 → 8 セグメント二重迂回
+  if (sourceColHits.length > 0 && targetColHits.length > 0) {
+    const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
+    // source 列の方向決定
+    const srcRightBlocked = sourceColHits.some((obs) =>
+      obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
+    )
+    const srcLeftBlocked = sourceColHits.some((obs) =>
+      obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
+    )
+    const srcGoRight = !srcRightBlocked || srcLeftBlocked
+    const sourceDetourX = srcGoRight
+      ? Math.max(...sourceColHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+      : Math.min(...sourceColHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+    // target 列の方向決定
+    const tgtRightBlocked = targetColHits.some((obs) =>
+      obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
+    )
+    const tgtLeftBlocked = targetColHits.some((obs) =>
+      obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
+    )
+    const tgtGoRight = !tgtRightBlocked || tgtLeftBlocked
+    const targetDetourX = tgtGoRight
+      ? Math.max(...targetColHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+      : Math.min(...targetColHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+    // depart / approach Y
+    const signS = Math.sign(my - s.y)
+    const halfDyS = Math.abs(my - s.y) / 2
+    const departY = s.y + signS * Math.min(DEPART_GAP, halfDyS)
+    const signE = Math.sign(e.y - my)
+    const halfDyE = Math.abs(e.y - my) / 2
+    const approachY = e.y - signE * Math.min(APPROACH_GAP, halfDyE)
+    return { kind: 'both-detour', departY, sourceDetourX, my, targetDetourX, approachY }
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts
+git commit -m "feat(#346): detectDiagonalDetour returns both-detour for both-column collision"
+```
+
+---
+
+### Task 13: `buildArrowPath` - 斜め分岐に target-detour を統合
+
+**Files:**
+- Modify: `src/lib/arrow-routing.ts`
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+新規 describe を `collectVerticalObstacles` の describe 後に追加:
+
+```ts
+describe('buildArrowPath - 斜め迂回（異行×異レーン）', () => {
+  // s=(200,128), e=(600,372), fc=(200,100), tc=(600,400)
+  const s = { x: 200, y: 128 }
+  const e = { x: 600, y: 372 }
+  const fc = { x: 200, y: 100 }
+  const tc = { x: 600, y: 400 }
+
+  it('should produce 6-segment target-detour path when obstacle in target column (core bug case)', () => {
+    const B: Bbox = { x: 600, y: 250, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B])
+    expect(r.d).toBe('M200,128 L200,250 L690,250 L690,358 L600,358 L600,372')
+    expect(r.mx).toBe((200 + 690) / 2)
+    expect(r.my).toBe(250)
+  })
+
+  it('should produce default Z-path when no obstacles intersect (diagonal)', () => {
+    const r = buildArrowPath(s, e, fc, tc, [])
+    // 既存 Z字: M(s.x,s.y) L(s.x,my) L(e.x,my) L(e.x,e.y)
+    expect(r.d).toBe('M200,128 L200,250 L600,250 L600,372')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: 1個目 FAIL (target-detour 未統合)、2個目 PASS
+
+- [ ] **Step 3: Update buildArrowPath**
+
+`src/lib/arrow-routing.ts` の `buildArrowPath` 内、`detectVerticalDetour` 分岐 (line 221-235) の **後** に追加:
+
+```ts
+    const dDetour = detectDiagonalDetour(s, e, obstacles)
+    if (dDetour) {
+      if (dDetour.kind === 'target-detour') {
+        const { my, detourX, approachY } = dDetour
+        const d = `M${s.x},${s.y} L${s.x},${my} L${detourX},${my} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
+        return { d, mx: (s.x + detourX) / 2, my }
+      }
+      // 後続タスクで source-detour / both-detour / shift-my 分岐を追加
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts
+git commit -m "feat(#346): buildArrowPath emits target-detour 6-segment path"
+```
+
+---
+
+### Task 14: `buildArrowPath` - source-detour / both-detour / shift-my 統合
+
+**Files:**
+- Modify: `src/lib/arrow-routing.ts`
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+`buildArrowPath - 斜め迂回` describe 内に追加:
+
+```ts
+it('should produce 6-segment source-detour path (mirror)', () => {
+  const B: Bbox = { x: 200, y: 250, w: 152, h: 56 } // source 列
+  const r = buildArrowPath(s, e, fc, tc, [B])
+  expect(r.d).toBe('M200,128 L200,142 L290,142 L290,250 L600,250 L600,372')
+  expect(r.mx).toBe((290 + 600) / 2)
+  expect(r.my).toBe(250)
+})
+
+it('should produce 8-segment both-detour path when both columns blocked', () => {
+  const Bs: Bbox = { x: 200, y: 250, w: 152, h: 56 }
+  const Bt: Bbox = { x: 600, y: 250, w: 152, h: 56 }
+  const r = buildArrowPath(s, e, fc, tc, [Bs, Bt])
+  expect(r.d).toBe(
+    'M200,128 L200,142 L290,142 L290,250 L690,250 L690,358 L600,358 L600,372',
+  )
+  expect(r.mx).toBe((290 + 690) / 2)
+  expect(r.my).toBe(250)
+})
+
+it('should produce 4-segment shift-my path when only middle horizontal segment is blocked', () => {
+  const B: Bbox = { x: 400, y: 250, w: 152, h: 56 } // 中央 X、中央行
+  const r = buildArrowPath(s, e, fc, tc, [B])
+  expect(r.d).toBe('M200,128 L200,292 L600,292 L600,372')
+  expect(r.mx).toBe(400)
+  expect(r.my).toBe(292)
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: 3 件 FAIL — 各 kind の分岐が未実装
+
+- [ ] **Step 3: Update buildArrowPath**
+
+Task 13 で追加した `if (dDetour) { ... }` ブロックを以下に置き換え:
+
+```ts
+    const dDetour = detectDiagonalDetour(s, e, obstacles)
+    if (dDetour) {
+      if (dDetour.kind === 'target-detour') {
+        const { my, detourX, approachY } = dDetour
+        const d = `M${s.x},${s.y} L${s.x},${my} L${detourX},${my} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
+        return { d, mx: (s.x + detourX) / 2, my }
+      }
+      if (dDetour.kind === 'source-detour') {
+        const { departY, detourX, my } = dDetour
+        const d = `M${s.x},${s.y} L${s.x},${departY} L${detourX},${departY} L${detourX},${my} L${e.x},${my} L${e.x},${e.y}`
+        return { d, mx: (detourX + e.x) / 2, my }
+      }
+      if (dDetour.kind === 'both-detour') {
+        const { departY, sourceDetourX, my, targetDetourX, approachY } = dDetour
+        const d = `M${s.x},${s.y} L${s.x},${departY} L${sourceDetourX},${departY} L${sourceDetourX},${my} L${targetDetourX},${my} L${targetDetourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
+        return { d, mx: (sourceDetourX + targetDetourX) / 2, my }
+      }
+      if (dDetour.kind === 'shift-my') {
+        const { my } = dDetour
+        const d = `M${s.x},${s.y} L${s.x},${my} L${e.x},${my} L${e.x},${e.y}`
+        return { d, mx: (s.x + e.x) / 2, my }
+      }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts
+git commit -m "feat(#346): buildArrowPath emits source/both/shift-my diagonal detour paths"
+```
+
+---
+
+### Task 15: regression guard - 既存横方向/縦方向迂回への影響なし
+
+**Files:**
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`buildArrowPath - 斜め迂回` describe 内に追加:
+
+```ts
+it('should not affect horizontal arrow detour (regression guard for #314)', () => {
+  // 同一行: s=(276,200), e=(524,200) (既存テスト同等)
+  const sH = { x: 276, y: 200 }
+  const eH = { x: 524, y: 200 }
+  const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
+  const r = buildArrowPath(sH, eH, { x: 200, y: 200 }, { x: 600, y: 200 }, [B])
+  expect(r.d).toBe('M276,200 L290,200 L290,242 L510,242 L510,200 L524,200')
+})
+
+it('should not affect vertical arrow detour (regression guard for #333)', () => {
+  // 同一列: s=(200,128), e=(200,372) (X 一致 → 垂直)
+  const sV = { x: 200, y: 128 }
+  const eV = { x: 200, y: 372 }
+  // 同一列障害 (x=200, 中央)
+  const B: Bbox = { x: 200, y: 250, w: 152, h: 56 }
+  const r = buildArrowPath(sV, eV, { x: 200, y: 100 }, { x: 200, y: 400 }, [B])
+  // 既存 detectVerticalDetour による 6 セグ右迂回
+  expect(r.d).toContain('M200,128')
+  expect(r.d).toContain('L200,372')
+  expect(r.d).toMatch(/L290,\d+/) // 右迂回 detourX = 200+76+14 = 290
+})
+
+it('should produce default Z-path when obstacles array is undefined (diagonal)', () => {
+  const r = buildArrowPath(s, e, fc, tc)
+  expect(r.d).toBe('M200,128 L200,250 L600,250 L600,372')
+})
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: PASS (regression なし)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/arrow-routing.test.ts
+git commit -m "test(#346): add regression guards for #314 / #333 / undefined obstacles"
+```
+
+---
+
+### Task 16: Diamond ノードでの diagonal detour 動作確認
+
+**Files:**
+- Test: `src/lib/arrow-routing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('should handle diagonal detour when source/target points come from diamond shape', () => {
+  // Diamond の exitPt/entryPt は頂点 (DS=34) を返すが、buildArrowPath には
+  // 既に exitPt/entryPt 後の s/e が渡るので、Diamond 形状でも同じ振る舞いになるはず。
+  const sDia = { x: 200, y: 134 } // ≈ ノード中心 (200,100) + DS(34) 下
+  const eDia = { x: 600, y: 366 } // ≈ ノード中心 (600,400) - DS(34) 上
+  const B: Bbox = { x: 600, y: 250, w: 152, h: 56 } // target 列障害
+  const r = buildArrowPath(sDia, eDia, { x: 200, y: 100 }, { x: 600, y: 400 }, [B])
+  // target-detour パターン: M(s) L(s.x,my) L(detourX,my) L(detourX,approachY) L(e.x,approachY) L(e)
+  expect(r.d).toMatch(/^M200,134 L200,250 L690,250 L690,\d+ L600,\d+ L600,366$/)
+})
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `npm test -- src/lib/arrow-routing.test.ts`
+Expected: PASS (既存ロジックは Diamond 専用ではないので動くはず)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/arrow-routing.test.ts
+git commit -m "test(#346): diagonal detour works with diamond-shape exit/entry points"
+```
+
+---
+
+### Task 17: `FlowEditor.aPath` に diagonal 分岐を追加
+
+**Files:**
+- Modify: `src/features/editor/FlowEditor.tsx`
+
+- [ ] **Step 1: Locate and update the obstacles assembly block**
+
+`src/features/editor/FlowEditor.tsx` の `aPath` 関数内、現 1397-1423 行付近の `obstacles` 組み立て分岐に `else` 節を追加:
+
+```ts
+    // 同一行/同一レーン/斜め配置のときに obstacles を組み立てる（迂回判定用）
+    let obstacles: Bbox[] | undefined
+    if (fri === tri) {
+      obstacles = collectObstacles({
+        nodes: obstacleNodes,
+        fromKey: arrow.from,
+        toKey: arrow.to,
+        fromCx: from.x,
+        toCx: to.x,
+        rowY: from.y,
+        rowH: RH,
+        bboxW: TW,
+        bboxH: TH,
+      })
+    } else if (fli === tli) {
+      obstacles = collectVerticalObstacles({
+        nodes: obstacleNodes,
+        fromKey: arrow.from,
+        toKey: arrow.to,
+        fromCy: from.y,
+        toCy: to.y,
+        colX: from.x,
+        colW: LW + G,
+        bboxW: TW,
+        bboxH: TH,
+      })
+    } else {
+      obstacles = collectDiagonalObstacles({
+        nodes: obstacleNodes,
+        fromKey: arrow.from,
+        toKey: arrow.to,
+        fromCx: from.x,
+        fromCy: from.y,
+        toCx: to.x,
+        toCy: to.y,
+        rowH: RH,
+        colW: LW + G,
+        bboxW: TW,
+        bboxH: TH,
+      })
+    }
+```
+
+ファイル先頭の import に `collectDiagonalObstacles` を追加:
+
+```ts
+import {
+  ...
+  collectObstacles,
+  collectVerticalObstacles,
+  collectDiagonalObstacles,
+  ...
+} from '@/lib/arrow-routing'
+```
+
+(import パスは既存に従う)
+
+- [ ] **Step 2: Run typecheck and unit tests**
+
+Run: `npm test`
+Expected: PASS (全テスト)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/features/editor/FlowEditor.tsx
+git commit -m "feat(#346): wire collectDiagonalObstacles into FlowEditor.aPath"
+```
+
+---
+
+### Task 18: `SharedFlowViewer.computeArrowPath` に diagonal 分岐を追加
+
+**Files:**
+- Modify: `src/features/shared/SharedFlowViewer.tsx`
+
+- [ ] **Step 1: Locate and update the obstacles assembly block**
+
+`src/features/shared/SharedFlowViewer.tsx` の `computeArrowPath` 内、現 135-159 行付近の obstacles 組み立て分岐に `else` 節を追加:
+
+```ts
+    let obstacles: Bbox[] | undefined
+    if (fromNode.rowIndex === toNode.rowIndex) {
+      obstacles = collectObstacles({ ... })           // 既存
+    } else if (fromNode.laneId === toNode.laneId) {
+      obstacles = collectVerticalObstacles({ ... })   // 既存
+    } else {
+      obstacles = collectDiagonalObstacles({
+        nodes: obstacleNodes,
+        fromKey: fromNode.id,
+        toKey: toNode.id,
+        fromCx: f.x,
+        fromCy: f.y,
+        toCx: t.x,
+        toCy: t.y,
+        rowH: RH,
+        colW: LW + G,
+        bboxW: TW,
+        bboxH: TH,
+      })
+    }
+```
+
+ファイル先頭の import に `collectDiagonalObstacles` を追加:
+
+```ts
+import {
+  ...
+  collectObstacles,
+  collectVerticalObstacles,
+  collectDiagonalObstacles,
+  ...
+} from '@/lib/arrow-routing'
+```
+
+- [ ] **Step 2: Run typecheck and unit tests**
+
+Run: `npm test`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/features/shared/SharedFlowViewer.tsx
+git commit -m "feat(#346): wire collectDiagonalObstacles into SharedFlowViewer"
+```
+
+---
+
+### Task 19: 実画面検証 (Playwright / 目視)
+
+**Files:**
+- スクリーンショット保存: `.screenshots/issue-346-after.png`
+
+- [ ] **Step 1: 開発サーバー起動**
+
+Run (バックグラウンド): `npm run dev`
+Wait until: `Local: http://localhost:5173` (or similar) が表示される
+
+- [ ] **Step 2: bug 再現データで矢印描画を確認**
+
+Playwright で `https://flowline.six1.jp/flows/951c20ca-2430-495b-af6d-068795a93c60` (ALLFIT-コンシェルジュ flow) を開く (要ログイン: `.env.local` の `E2E_USER_EMAIL` / `E2E_USER_PASSWORD`)。
+
+- ガイド → 店舗詳細 の矢印が 一覧ページを貫通していないことを確認
+- スクリーンショット保存: `.screenshots/issue-346-after.png`
+
+- [ ] **Step 3: regression 確認**
+
+- ダッシュボード一覧の表示が崩れていないこと
+- 通常の Z字矢印 (障害なし) が直線的に描かれていること
+- 横方向迂回 (#314) のテスト flow があれば崩れていないこと
+
+- [ ] **Step 4: LCP 確認**
+
+Chrome DevTools の Performance タブで LCP < 1秒 を確認。超過していたら原因調査。
+
+- [ ] **Step 5: Commit (スクリーンショットのみ。`.gitignore` 外なら)**
+
+`.screenshots/` は `.gitignore` 配下なのでコミット不要。確認のみで完了。
+
+---
+
+### Task 20: 最終チェックと PR 作成準備
+
+**Files:**
+- なし (CI/CD と git 操作のみ)
+
+- [ ] **Step 1: 最新 main と同期**
+
+```bash
+git fetch origin
+git pull origin main --rebase
+npm test
+```
+
+Expected: 全テスト PASS
+
+- [ ] **Step 2: ビルド確認**
+
+```bash
+npm run build
+```
+
+Expected: Success
+
+- [ ] **Step 3: Prettier / Lint**
+
+```bash
+npx prettier --check src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts src/features/editor/FlowEditor.tsx src/features/shared/SharedFlowViewer.tsx
+```
+
+差分があれば `--write` で修正してコミット。
+
+- [ ] **Step 4: PR push**
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "fix(#346): 斜め配置矢印の Z字パスが中間行ノードを貫通する問題を修正" --body "$(cat <<'EOF'
+## Summary
+- 斜め配置 (異行×異レーン) の Z字矢印が target 列の中間行ノードを貫通するバグを修正
+- 新規 collectDiagonalObstacles / detectDiagonalDetour を arrow-routing.ts に追加
+- Z字パス 3 セグメント (source 縦 / 中央水平 / target 縦) 全てに衝突判定
+- 4 パターン (target-detour / source-detour / both-detour / shift-my) の迂回パスを生成
+- FlowEditor / SharedFlowViewer の obstacles 組み立てに diagonal 分岐を追加
+
+Spec: docs/superpowers/specs/2026-05-22-issue-346-diagonal-arrow-detour-design.md
+Plan: docs/superpowers/plans/2026-05-22-issue-346-diagonal-arrow-detour-plan.md
+
+Closes #346
+
+## Test plan
+- [ ] arrow-routing.test.ts 全 PASS (detector / collector / buildArrowPath 統合 / regression)
+- [ ] ALLFIT-コンシェルジュ flow で ガイド → 店舗詳細 が 一覧ページを貫通しない (Playwright 目視)
+- [ ] 既存 #314 (横方向) / #333 (縦方向) 迂回に regression なし
+- [ ] LCP 1 秒以内
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: CI watch & review request**
+
+```bash
+gh pr checks --watch
+```
+
+CI 全 pass 後、`@claude` レビュー依頼コメントを投稿 (CLAUDE.md workflow §8 参照)。
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage**: §4 detector / §5 collector / §6 呼び出し側 / §7 buildArrowPath / §8 テスト — 全て Task 1-19 でカバー。受け入れ基準 §9 は Task 19/20 で検証。
+- **Placeholder scan**: なし
+- **Type consistency**: `DiagonalDetourResult` のフィールド名 (`my`, `detourX`, `approachY`, `departY`, `sourceDetourX`, `targetDetourX`) は Task 6-12 / 13-14 で一貫
+- **Constants**: `DETOUR_MARGIN = 14`, `APPROACH_GAP = 14`, `DEPART_GAP = 14` は既存 (arrow-routing.ts:13-20) を流用

--- a/docs/superpowers/plans/2026-05-22-issue-346-diagonal-arrow-detour-plan.md
+++ b/docs/superpowers/plans/2026-05-22-issue-346-diagonal-arrow-detour-plan.md
@@ -14,12 +14,12 @@
 
 ## File Structure
 
-| File | Action | Responsibility |
-| --- | --- | --- |
-| `src/lib/arrow-routing.ts` | Modify | 新規 `collectDiagonalObstacles` / `detectDiagonalDetour` 追加、`buildArrowPath` の斜め分岐拡張 |
-| `src/lib/arrow-routing.test.ts` | Modify | 新規 detector / collector の単体テスト、`buildArrowPath` 統合テスト、regression テスト |
-| `src/features/editor/FlowEditor.tsx` | Modify | `aPath` の obstacles 組み立てに diagonal 分岐追加 (1 箇所) |
-| `src/features/shared/SharedFlowViewer.tsx` | Modify | `computeArrowPath` の obstacles 組み立てに diagonal 分岐追加 (1 箇所) |
+| File                                       | Action | Responsibility                                                                                 |
+| ------------------------------------------ | ------ | ---------------------------------------------------------------------------------------------- |
+| `src/lib/arrow-routing.ts`                 | Modify | 新規 `collectDiagonalObstacles` / `detectDiagonalDetour` 追加、`buildArrowPath` の斜め分岐拡張 |
+| `src/lib/arrow-routing.test.ts`            | Modify | 新規 detector / collector の単体テスト、`buildArrowPath` 統合テスト、regression テスト         |
+| `src/features/editor/FlowEditor.tsx`       | Modify | `aPath` の obstacles 組み立てに diagonal 分岐追加 (1 箇所)                                     |
+| `src/features/shared/SharedFlowViewer.tsx` | Modify | `computeArrowPath` の obstacles 組み立てに diagonal 分岐追加 (1 箇所)                          |
 
 ---
 
@@ -44,6 +44,7 @@
 ### Task 1: `collectDiagonalObstacles` の skeleton + from/to 除外
 
 **Files:**
+
 - Modify: `src/lib/arrow-routing.ts`
 - Test: `src/lib/arrow-routing.test.ts`
 
@@ -147,6 +148,7 @@ git commit -m "feat(#346): add collectDiagonalObstacles skeleton with from/to ex
 ### Task 2: `collectDiagonalObstacles` - source 列ストリップ収集
 
 **Files:**
+
 - Modify: `src/lib/arrow-routing.ts`
 - Test: `src/lib/arrow-routing.test.ts`
 
@@ -168,7 +170,7 @@ it('should collect source-column obstacle between source and target rows', () =>
 it('should not collect source-column nodes outside Z-path Y range', () => {
   const nodes: ObstacleNode[] = [
     { key: 'A', cx: 200, cy: 100 },
-    { key: 'B', cx: 200, cy: 50 },  // source 行より上 (out of range)
+    { key: 'B', cx: 200, cy: 50 }, // source 行より上 (out of range)
     { key: 'D', cx: 200, cy: 450 }, // target 行より下 (out of range)
     { key: 'C', cx: 600, cy: 400 },
   ]
@@ -222,6 +224,7 @@ git commit -m "feat(#346): collectDiagonalObstacles picks up source-column obsta
 ### Task 3: `collectDiagonalObstacles` - target 列ストリップ収集
 
 **Files:**
+
 - Modify: `src/lib/arrow-routing.ts`
 - Test: `src/lib/arrow-routing.test.ts`
 
@@ -249,13 +252,13 @@ Expected: FAIL — `[]` returned, expected `[{ x: 600, ... }]`
 `collectDiagonalObstacles` ループ内に分岐追加:
 
 ```ts
-    const onSourceCol = Math.abs(n.cx - fromCx) < bboxW / 2 + 2
-    const onTargetCol = Math.abs(n.cx - toCx) < bboxW / 2 + 2
-    const inZRangeY = n.cy > yLow + 1 && n.cy < yHigh - 1
-    if ((onSourceCol || onTargetCol) && inZRangeY) {
-      result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
-      continue
-    }
+const onSourceCol = Math.abs(n.cx - fromCx) < bboxW / 2 + 2
+const onTargetCol = Math.abs(n.cx - toCx) < bboxW / 2 + 2
+const inZRangeY = n.cy > yLow + 1 && n.cy < yHigh - 1
+if ((onSourceCol || onTargetCol) && inZRangeY) {
+  result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+  continue
+}
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
@@ -275,6 +278,7 @@ git commit -m "feat(#346): collectDiagonalObstacles picks up target-column obsta
 ### Task 4: `collectDiagonalObstacles` - 中央行ストリップ収集
 
 **Files:**
+
 - Modify: `src/lib/arrow-routing.ts`
 - Test: `src/lib/arrow-routing.test.ts`
 
@@ -294,7 +298,7 @@ it('should collect middle-row obstacle between source and target X', () => {
 it('should not collect nodes outside Z-path X range at middle row', () => {
   const nodes: ObstacleNode[] = [
     { key: 'A', cx: 200, cy: 100 },
-    { key: 'B', cx: 50, cy: 250 },  // source の左 (out of range)
+    { key: 'B', cx: 50, cy: 250 }, // source の左 (out of range)
     { key: 'D', cx: 750, cy: 250 }, // target の右 (out of range, 隣接列でもない)
     { key: 'C', cx: 600, cy: 400 },
   ]
@@ -311,22 +315,22 @@ Expected: FAIL — middle row node not collected
 - [ ] **Step 3: Update implementation**
 
 ```ts
-    const onSourceCol = Math.abs(n.cx - fromCx) < bboxW / 2 + 2
-    const onTargetCol = Math.abs(n.cx - toCx) < bboxW / 2 + 2
-    const inZRangeY = n.cy > yLow + 1 && n.cy < yHigh - 1
-    if ((onSourceCol || onTargetCol) && inZRangeY) {
-      result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
-      continue
-    }
-    const midY = (fromCy + toCy) / 2
-    const onMiddleRow = Math.abs(n.cy - midY) < bboxH / 2 + 2
-    const xLow = Math.min(fromCx, toCx)
-    const xHigh = Math.max(fromCx, toCx)
-    const inZRangeX = n.cx > xLow + 1 && n.cx < xHigh - 1
-    if (onMiddleRow && inZRangeX) {
-      result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
-      continue
-    }
+const onSourceCol = Math.abs(n.cx - fromCx) < bboxW / 2 + 2
+const onTargetCol = Math.abs(n.cx - toCx) < bboxW / 2 + 2
+const inZRangeY = n.cy > yLow + 1 && n.cy < yHigh - 1
+if ((onSourceCol || onTargetCol) && inZRangeY) {
+  result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+  continue
+}
+const midY = (fromCy + toCy) / 2
+const onMiddleRow = Math.abs(n.cy - midY) < bboxH / 2 + 2
+const xLow = Math.min(fromCx, toCx)
+const xHigh = Math.max(fromCx, toCx)
+const inZRangeX = n.cx > xLow + 1 && n.cx < xHigh - 1
+if (onMiddleRow && inZRangeX) {
+  result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+  continue
+}
 ```
 
 - [ ] **Step 4: Run tests to verify they pass**
@@ -346,6 +350,7 @@ git commit -m "feat(#346): collectDiagonalObstacles picks up middle-row obstacle
 ### Task 5: `collectDiagonalObstacles` - 隣接列 (左右1列) 収集
 
 **Files:**
+
 - Modify: `src/lib/arrow-routing.ts`
 - Test: `src/lib/arrow-routing.test.ts`
 
@@ -393,18 +398,18 @@ Expected: FAIL — adjacent column nodes not collected
 `collectDiagonalObstacles` 内のループに分岐追加:
 
 ```ts
-    const { nodes, fromKey, toKey, fromCx, fromCy, toCx, toCy, rowH, colW, bboxW, bboxH } = args
-    // ... 既存収集ロジックの後 ...
+const { nodes, fromKey, toKey, fromCx, fromCy, toCx, toCy, rowH, colW, bboxW, bboxH } = args
+// ... 既存収集ロジックの後 ...
 
-    const onSourceAdjacentCol =
-      Math.abs(n.cx - fromCx) > colW - bboxW / 2 && Math.abs(n.cx - fromCx) < colW + bboxW / 2
-    const onTargetAdjacentCol =
-      Math.abs(n.cx - toCx) > colW - bboxW / 2 && Math.abs(n.cx - toCx) < colW + bboxW / 2
-    const inExtendedY = n.cy >= yLow - rowH / 2 && n.cy <= yHigh + rowH / 2
-    if ((onSourceAdjacentCol || onTargetAdjacentCol) && inExtendedY) {
-      result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
-      continue
-    }
+const onSourceAdjacentCol =
+  Math.abs(n.cx - fromCx) > colW - bboxW / 2 && Math.abs(n.cx - fromCx) < colW + bboxW / 2
+const onTargetAdjacentCol =
+  Math.abs(n.cx - toCx) > colW - bboxW / 2 && Math.abs(n.cx - toCx) < colW + bboxW / 2
+const inExtendedY = n.cy >= yLow - rowH / 2 && n.cy <= yHigh + rowH / 2
+if ((onSourceAdjacentCol || onTargetAdjacentCol) && inExtendedY) {
+  result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+  continue
+}
 ```
 
 注: `rowH` と `colW` を関数先頭の destructure に追加すること。
@@ -426,6 +431,7 @@ git commit -m "feat(#346): collectDiagonalObstacles picks up adjacent-column obs
 ### Task 6: `detectDiagonalDetour` - null ガード (水平・垂直・空配列)
 
 **Files:**
+
 - Modify: `src/lib/arrow-routing.ts`
 - Test: `src/lib/arrow-routing.test.ts`
 
@@ -541,6 +547,7 @@ git commit -m "feat(#346): add detectDiagonalDetour skeleton with null guards"
 ### Task 7: `detectDiagonalDetour` - target-detour (右優先) を返す
 
 **Files:**
+
 - Modify: `src/lib/arrow-routing.ts`
 - Test: `src/lib/arrow-routing.test.ts`
 
@@ -558,7 +565,7 @@ it('should return target-detour when obstacle is in target column between my and
     kind: 'target-detour',
     my: 250,
     detourX: 600 + 76 + 14, // 690 (右迂回: 障害右端 + DETOUR_MARGIN)
-    approachY: 372 - 14,    // 358
+    approachY: 372 - 14, // 358
   })
 })
 ```
@@ -588,9 +595,7 @@ export function detectDiagonalDetour(
     const yLow = Math.min(s.y, my)
     const yHigh = Math.max(s.y, my)
     return (
-      Math.abs(b.x - s.x) < b.w / 2 + 2 &&
-      b.y - b.h / 2 < yHigh - 1 &&
-      b.y + b.h / 2 > yLow + 1
+      Math.abs(b.x - s.x) < b.w / 2 + 2 && b.y - b.h / 2 < yHigh - 1 && b.y + b.h / 2 > yLow + 1
     )
   })
 
@@ -599,9 +604,7 @@ export function detectDiagonalDetour(
     const yLow = Math.min(my, e.y)
     const yHigh = Math.max(my, e.y)
     return (
-      Math.abs(b.x - e.x) < b.w / 2 + 2 &&
-      b.y - b.h / 2 < yHigh - 1 &&
-      b.y + b.h / 2 > yLow + 1
+      Math.abs(b.x - e.x) < b.w / 2 + 2 && b.y - b.h / 2 < yHigh - 1 && b.y + b.h / 2 > yLow + 1
     )
   })
 
@@ -645,6 +648,7 @@ git commit -m "feat(#346): detectDiagonalDetour returns target-detour for target
 ### Task 8: `detectDiagonalDetour` - target-detour 左迂回 (右塞がり時)
 
 **Files:**
+
 - Modify: `src/lib/arrow-routing.ts`
 - Test: `src/lib/arrow-routing.test.ts`
 
@@ -685,6 +689,7 @@ Expected: 1個目 (左迂回) FAIL、2個目 (両塞がり右優先) PASS (既�
 - [ ] **Step 3: Verify left detour logic works (no code change needed)**
 
 Task 7 で実装した左右判定ロジックは既に正しく左迂回を返すはず。失敗テストの原因が `detourX` 計算式の符号ミスでないか確認:
+
 - `goRight = !rightBlocked || leftBlocked` → 右塞がり&左空きで `false`
 - `detourX = goRight ? max(右端)+14 : min(左端)-14` → 左迂回時は `600 - 76 - 14 = 510` ✓
 
@@ -707,6 +712,7 @@ git commit -m "test(#346): cover target-detour direction (left side, both-blocke
 ### Task 9: `detectDiagonalDetour` - source-detour (鏡像)
 
 **Files:**
+
 - Modify: `src/lib/arrow-routing.ts`
 - Test: `src/lib/arrow-routing.test.ts`
 
@@ -735,23 +741,23 @@ Expected: FAIL — `null` returned
 `detectDiagonalDetour` の `target-detour` 分岐の後に追加:
 
 ```ts
-  if (sourceColHits.length > 0 && targetColHits.length === 0) {
-    const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
-    const rightBlocked = sourceColHits.some((obs) =>
-      obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
-    )
-    const leftBlocked = sourceColHits.some((obs) =>
-      obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
-    )
-    const goRight = !rightBlocked || leftBlocked
-    const detourX = goRight
-      ? Math.max(...sourceColHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
-      : Math.min(...sourceColHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
-    const sign = Math.sign(my - s.y)
-    const halfDy = Math.abs(my - s.y) / 2
-    const departY = s.y + sign * Math.min(DEPART_GAP, halfDy)
-    return { kind: 'source-detour', departY, detourX, my }
-  }
+if (sourceColHits.length > 0 && targetColHits.length === 0) {
+  const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
+  const rightBlocked = sourceColHits.some((obs) =>
+    obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
+  )
+  const leftBlocked = sourceColHits.some((obs) =>
+    obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
+  )
+  const goRight = !rightBlocked || leftBlocked
+  const detourX = goRight
+    ? Math.max(...sourceColHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+    : Math.min(...sourceColHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+  const sign = Math.sign(my - s.y)
+  const halfDy = Math.abs(my - s.y) / 2
+  const departY = s.y + sign * Math.min(DEPART_GAP, halfDy)
+  return { kind: 'source-detour', departY, detourX, my }
+}
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
@@ -771,6 +777,7 @@ git commit -m "feat(#346): detectDiagonalDetour returns source-detour for source
 ### Task 10: `detectDiagonalDetour` - shift-my (中央水平のみ衝突)
 
 **Files:**
+
 - Modify: `src/lib/arrow-routing.ts`
 - Test: `src/lib/arrow-routing.test.ts`
 
@@ -856,6 +863,7 @@ git commit -m "feat(#346): detectDiagonalDetour returns shift-my for middle-row 
 ### Task 11: `detectDiagonalDetour` - shift-my エスカレーション → target-detour
 
 **Files:**
+
 - Modify: `src/lib/arrow-routing.ts`
 - Test: `src/lib/arrow-routing.test.ts`
 
@@ -920,6 +928,7 @@ git commit -m "feat(#346): detectDiagonalDetour escalates shift-my to target-det
 ### Task 12: `detectDiagonalDetour` - both-detour (両列衝突)
 
 **Files:**
+
 - Modify: `src/lib/arrow-routing.ts`
 - Test: `src/lib/arrow-routing.test.ts`
 
@@ -951,40 +960,40 @@ Expected: FAIL — 現状は `target-detour` が返る (sourceColHits も target
 `detectDiagonalDetour` の最初に `both-detour` 分岐を追加。`source-detour` / `target-detour` 分岐の **前** に挿入:
 
 ```ts
-  // 両列衝突 → 8 セグメント二重迂回
-  if (sourceColHits.length > 0 && targetColHits.length > 0) {
-    const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
-    // source 列の方向決定
-    const srcRightBlocked = sourceColHits.some((obs) =>
-      obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
-    )
-    const srcLeftBlocked = sourceColHits.some((obs) =>
-      obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
-    )
-    const srcGoRight = !srcRightBlocked || srcLeftBlocked
-    const sourceDetourX = srcGoRight
-      ? Math.max(...sourceColHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
-      : Math.min(...sourceColHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
-    // target 列の方向決定
-    const tgtRightBlocked = targetColHits.some((obs) =>
-      obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
-    )
-    const tgtLeftBlocked = targetColHits.some((obs) =>
-      obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
-    )
-    const tgtGoRight = !tgtRightBlocked || tgtLeftBlocked
-    const targetDetourX = tgtGoRight
-      ? Math.max(...targetColHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
-      : Math.min(...targetColHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
-    // depart / approach Y
-    const signS = Math.sign(my - s.y)
-    const halfDyS = Math.abs(my - s.y) / 2
-    const departY = s.y + signS * Math.min(DEPART_GAP, halfDyS)
-    const signE = Math.sign(e.y - my)
-    const halfDyE = Math.abs(e.y - my) / 2
-    const approachY = e.y - signE * Math.min(APPROACH_GAP, halfDyE)
-    return { kind: 'both-detour', departY, sourceDetourX, my, targetDetourX, approachY }
-  }
+// 両列衝突 → 8 セグメント二重迂回
+if (sourceColHits.length > 0 && targetColHits.length > 0) {
+  const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
+  // source 列の方向決定
+  const srcRightBlocked = sourceColHits.some((obs) =>
+    obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
+  )
+  const srcLeftBlocked = sourceColHits.some((obs) =>
+    obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
+  )
+  const srcGoRight = !srcRightBlocked || srcLeftBlocked
+  const sourceDetourX = srcGoRight
+    ? Math.max(...sourceColHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+    : Math.min(...sourceColHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+  // target 列の方向決定
+  const tgtRightBlocked = targetColHits.some((obs) =>
+    obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
+  )
+  const tgtLeftBlocked = targetColHits.some((obs) =>
+    obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
+  )
+  const tgtGoRight = !tgtRightBlocked || tgtLeftBlocked
+  const targetDetourX = tgtGoRight
+    ? Math.max(...targetColHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+    : Math.min(...targetColHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+  // depart / approach Y
+  const signS = Math.sign(my - s.y)
+  const halfDyS = Math.abs(my - s.y) / 2
+  const departY = s.y + signS * Math.min(DEPART_GAP, halfDyS)
+  const signE = Math.sign(e.y - my)
+  const halfDyE = Math.abs(e.y - my) / 2
+  const approachY = e.y - signE * Math.min(APPROACH_GAP, halfDyE)
+  return { kind: 'both-detour', departY, sourceDetourX, my, targetDetourX, approachY }
+}
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
@@ -1004,6 +1013,7 @@ git commit -m "feat(#346): detectDiagonalDetour returns both-detour for both-col
 ### Task 13: `buildArrowPath` - 斜め分岐に target-detour を統合
 
 **Files:**
+
 - Modify: `src/lib/arrow-routing.ts`
 - Test: `src/lib/arrow-routing.test.ts`
 
@@ -1045,15 +1055,15 @@ Expected: 1個目 FAIL (target-detour 未統合)、2個目 PASS
 `src/lib/arrow-routing.ts` の `buildArrowPath` 内、`detectVerticalDetour` 分岐 (line 221-235) の **後** に追加:
 
 ```ts
-    const dDetour = detectDiagonalDetour(s, e, obstacles)
-    if (dDetour) {
-      if (dDetour.kind === 'target-detour') {
-        const { my, detourX, approachY } = dDetour
-        const d = `M${s.x},${s.y} L${s.x},${my} L${detourX},${my} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
-        return { d, mx: (s.x + detourX) / 2, my }
-      }
-      // 後続タスクで source-detour / both-detour / shift-my 分岐を追加
-    }
+const dDetour = detectDiagonalDetour(s, e, obstacles)
+if (dDetour) {
+  if (dDetour.kind === 'target-detour') {
+    const { my, detourX, approachY } = dDetour
+    const d = `M${s.x},${s.y} L${s.x},${my} L${detourX},${my} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
+    return { d, mx: (s.x + detourX) / 2, my }
+  }
+  // 後続タスクで source-detour / both-detour / shift-my 分岐を追加
+}
 ```
 
 - [ ] **Step 4: Run tests to verify they pass**
@@ -1073,6 +1083,7 @@ git commit -m "feat(#346): buildArrowPath emits target-detour 6-segment path"
 ### Task 14: `buildArrowPath` - source-detour / both-detour / shift-my 統合
 
 **Files:**
+
 - Modify: `src/lib/arrow-routing.ts`
 - Test: `src/lib/arrow-routing.test.ts`
 
@@ -1093,9 +1104,7 @@ it('should produce 8-segment both-detour path when both columns blocked', () => 
   const Bs: Bbox = { x: 200, y: 250, w: 152, h: 56 }
   const Bt: Bbox = { x: 600, y: 250, w: 152, h: 56 }
   const r = buildArrowPath(s, e, fc, tc, [Bs, Bt])
-  expect(r.d).toBe(
-    'M200,128 L200,142 L290,142 L290,250 L690,250 L690,358 L600,358 L600,372',
-  )
+  expect(r.d).toBe('M200,128 L200,142 L290,142 L290,250 L690,250 L690,358 L600,358 L600,372')
   expect(r.mx).toBe((290 + 690) / 2)
   expect(r.my).toBe(250)
 })
@@ -1119,29 +1128,29 @@ Expected: 3 件 FAIL — 各 kind の分岐が未実装
 Task 13 で追加した `if (dDetour) { ... }` ブロックを以下に置き換え:
 
 ```ts
-    const dDetour = detectDiagonalDetour(s, e, obstacles)
-    if (dDetour) {
-      if (dDetour.kind === 'target-detour') {
-        const { my, detourX, approachY } = dDetour
-        const d = `M${s.x},${s.y} L${s.x},${my} L${detourX},${my} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
-        return { d, mx: (s.x + detourX) / 2, my }
-      }
-      if (dDetour.kind === 'source-detour') {
-        const { departY, detourX, my } = dDetour
-        const d = `M${s.x},${s.y} L${s.x},${departY} L${detourX},${departY} L${detourX},${my} L${e.x},${my} L${e.x},${e.y}`
-        return { d, mx: (detourX + e.x) / 2, my }
-      }
-      if (dDetour.kind === 'both-detour') {
-        const { departY, sourceDetourX, my, targetDetourX, approachY } = dDetour
-        const d = `M${s.x},${s.y} L${s.x},${departY} L${sourceDetourX},${departY} L${sourceDetourX},${my} L${targetDetourX},${my} L${targetDetourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
-        return { d, mx: (sourceDetourX + targetDetourX) / 2, my }
-      }
-      if (dDetour.kind === 'shift-my') {
-        const { my } = dDetour
-        const d = `M${s.x},${s.y} L${s.x},${my} L${e.x},${my} L${e.x},${e.y}`
-        return { d, mx: (s.x + e.x) / 2, my }
-      }
-    }
+const dDetour = detectDiagonalDetour(s, e, obstacles)
+if (dDetour) {
+  if (dDetour.kind === 'target-detour') {
+    const { my, detourX, approachY } = dDetour
+    const d = `M${s.x},${s.y} L${s.x},${my} L${detourX},${my} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
+    return { d, mx: (s.x + detourX) / 2, my }
+  }
+  if (dDetour.kind === 'source-detour') {
+    const { departY, detourX, my } = dDetour
+    const d = `M${s.x},${s.y} L${s.x},${departY} L${detourX},${departY} L${detourX},${my} L${e.x},${my} L${e.x},${e.y}`
+    return { d, mx: (detourX + e.x) / 2, my }
+  }
+  if (dDetour.kind === 'both-detour') {
+    const { departY, sourceDetourX, my, targetDetourX, approachY } = dDetour
+    const d = `M${s.x},${s.y} L${s.x},${departY} L${sourceDetourX},${departY} L${sourceDetourX},${my} L${targetDetourX},${my} L${targetDetourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
+    return { d, mx: (sourceDetourX + targetDetourX) / 2, my }
+  }
+  if (dDetour.kind === 'shift-my') {
+    const { my } = dDetour
+    const d = `M${s.x},${s.y} L${s.x},${my} L${e.x},${my} L${e.x},${e.y}`
+    return { d, mx: (s.x + e.x) / 2, my }
+  }
+}
 ```
 
 - [ ] **Step 4: Run tests to verify they pass**
@@ -1161,6 +1170,7 @@ git commit -m "feat(#346): buildArrowPath emits source/both/shift-my diagonal de
 ### Task 15: regression guard - 既存横方向/縦方向迂回への影響なし
 
 **Files:**
+
 - Test: `src/lib/arrow-routing.test.ts`
 
 - [ ] **Step 1: Write the failing test**
@@ -1213,6 +1223,7 @@ git commit -m "test(#346): add regression guards for #314 / #333 / undefined obs
 ### Task 16: Diamond ノードでの diagonal detour 動作確認
 
 **Files:**
+
 - Test: `src/lib/arrow-routing.test.ts`
 
 - [ ] **Step 1: Write the failing test**
@@ -1247,6 +1258,7 @@ git commit -m "test(#346): diagonal detour works with diamond-shape exit/entry p
 ### Task 17: `FlowEditor.aPath` に diagonal 分岐を追加
 
 **Files:**
+
 - Modify: `src/features/editor/FlowEditor.tsx`
 
 - [ ] **Step 1: Locate and update the obstacles assembly block**
@@ -1254,47 +1266,47 @@ git commit -m "test(#346): diagonal detour works with diamond-shape exit/entry p
 `src/features/editor/FlowEditor.tsx` の `aPath` 関数内、現 1397-1423 行付近の `obstacles` 組み立て分岐に `else` 節を追加:
 
 ```ts
-    // 同一行/同一レーン/斜め配置のときに obstacles を組み立てる（迂回判定用）
-    let obstacles: Bbox[] | undefined
-    if (fri === tri) {
-      obstacles = collectObstacles({
-        nodes: obstacleNodes,
-        fromKey: arrow.from,
-        toKey: arrow.to,
-        fromCx: from.x,
-        toCx: to.x,
-        rowY: from.y,
-        rowH: RH,
-        bboxW: TW,
-        bboxH: TH,
-      })
-    } else if (fli === tli) {
-      obstacles = collectVerticalObstacles({
-        nodes: obstacleNodes,
-        fromKey: arrow.from,
-        toKey: arrow.to,
-        fromCy: from.y,
-        toCy: to.y,
-        colX: from.x,
-        colW: LW + G,
-        bboxW: TW,
-        bboxH: TH,
-      })
-    } else {
-      obstacles = collectDiagonalObstacles({
-        nodes: obstacleNodes,
-        fromKey: arrow.from,
-        toKey: arrow.to,
-        fromCx: from.x,
-        fromCy: from.y,
-        toCx: to.x,
-        toCy: to.y,
-        rowH: RH,
-        colW: LW + G,
-        bboxW: TW,
-        bboxH: TH,
-      })
-    }
+// 同一行/同一レーン/斜め配置のときに obstacles を組み立てる（迂回判定用）
+let obstacles: Bbox[] | undefined
+if (fri === tri) {
+  obstacles = collectObstacles({
+    nodes: obstacleNodes,
+    fromKey: arrow.from,
+    toKey: arrow.to,
+    fromCx: from.x,
+    toCx: to.x,
+    rowY: from.y,
+    rowH: RH,
+    bboxW: TW,
+    bboxH: TH,
+  })
+} else if (fli === tli) {
+  obstacles = collectVerticalObstacles({
+    nodes: obstacleNodes,
+    fromKey: arrow.from,
+    toKey: arrow.to,
+    fromCy: from.y,
+    toCy: to.y,
+    colX: from.x,
+    colW: LW + G,
+    bboxW: TW,
+    bboxH: TH,
+  })
+} else {
+  obstacles = collectDiagonalObstacles({
+    nodes: obstacleNodes,
+    fromKey: arrow.from,
+    toKey: arrow.to,
+    fromCx: from.x,
+    fromCy: from.y,
+    toCx: to.x,
+    toCy: to.y,
+    rowH: RH,
+    colW: LW + G,
+    bboxW: TW,
+    bboxH: TH,
+  })
+}
 ```
 
 ファイル先頭の import に `collectDiagonalObstacles` を追加:
@@ -1328,6 +1340,7 @@ git commit -m "feat(#346): wire collectDiagonalObstacles into FlowEditor.aPath"
 ### Task 18: `SharedFlowViewer.computeArrowPath` に diagonal 分岐を追加
 
 **Files:**
+
 - Modify: `src/features/shared/SharedFlowViewer.tsx`
 
 - [ ] **Step 1: Locate and update the obstacles assembly block**
@@ -1386,6 +1399,7 @@ git commit -m "feat(#346): wire collectDiagonalObstacles into SharedFlowViewer"
 ### Task 19: 実画面検証 (Playwright / 目視)
 
 **Files:**
+
 - スクリーンショット保存: `.screenshots/issue-346-after.png`
 
 - [ ] **Step 1: 開発サーバー起動**
@@ -1419,6 +1433,7 @@ Chrome DevTools の Performance タブで LCP < 1秒 を確認。超過してい
 ### Task 20: 最終チェックと PR 作成準備
 
 **Files:**
+
 - なし (CI/CD と git 操作のみ)
 
 - [ ] **Step 1: 最新 main と同期**

--- a/docs/superpowers/specs/2026-05-22-issue-346-diagonal-arrow-detour-design.md
+++ b/docs/superpowers/specs/2026-05-22-issue-346-diagonal-arrow-detour-design.md
@@ -145,6 +145,8 @@ M(s.x, s.y)
  → L(e.x, e.y)
 ```
 
+- **左右塞がり判定の相互排除**: `sourceDetourX` の方向判定 (`pickDetourX`) では `targetColHits` をブロッカー候補から除外し、`targetDetourX` の判定では `sourceColHits` を除外する。反対側列の障害は対応する迂回パスで既に回避済みであり、Y 重なりによる相互ブロッキング (誤った全方向左偏向) を防ぐため。
+
 ### `shift-my` の幾何 (4 セグ維持)
 
 ```

--- a/docs/superpowers/specs/2026-05-22-issue-346-diagonal-arrow-detour-design.md
+++ b/docs/superpowers/specs/2026-05-22-issue-346-diagonal-arrow-detour-design.md
@@ -1,0 +1,342 @@
+# issue #346: 斜め配置矢印 Z字パスの中間行ノード貫通修正 — 設計
+
+- 関連 issue: [#346](https://github.com/tomohirof/flowline/issues/346)
+- 関連既存実装: #314 (水平方向迂回), #333 (垂直方向迂回)
+- 対象ファイル: `src/lib/arrow-routing.ts`, `src/features/editor/FlowEditor.tsx`, `src/features/shared/SharedFlowViewer.tsx`, `src/lib/arrow-routing.test.ts`
+
+## 1. 背景
+
+斜め配置 (異行 × 異レーン) の矢印で `buildArrowPath` が生成する Z字パスが、中間行・target 列にあるノードを貫通する。
+
+### 再現例
+
+- 矢印: `ガイド` (row1, lane `ユーザー(2)`) → `店舗詳細` (row3, lane `ユーザー` parent)
+- s = ガイド底 (`(source_lane_x, source_row_y + hh)`)
+- e = 店舗詳細上 (`(target_lane_x, target_row_y - hh)`)
+- 両方とも縦出口 → Z字パス
+- `my = (s.y + e.y) / 2` ≈ 中間行 row2 の中心 Y
+- 第3セグメント `(e.x, my) → (e.x, e.y)` が、target 列 (`ユーザー` parent) の row2 にある `一覧ページ` を貫通
+
+### 根本原因
+
+`src/lib/arrow-routing.ts`:
+
+- `detectDetour` / `detectVerticalDetour` は水平/垂直直線 (`|dx| < 2` または `|dy| < 2`) のみ発動
+- 斜め矢印は `buildArrowPath` 内の Z字分岐で衝突判定なくパス生成
+
+`src/features/editor/FlowEditor.tsx:1397-1423`:
+
+- `fri === tri` または `fli === tli` のときのみ obstacles を組み立て
+- 斜め配置では `obstacles = undefined` となり迂回判定がそもそも走らない
+
+`my` シフトだけでは解決不能: 第3セグメントは target 列上の縦移動なので、`my` を上下に動かしても target 列上の障害は依然として貫通する。target 列を物理的に迂回する必要がある。
+
+## 2. 期待挙動
+
+- 斜め矢印で Z字パス 3 セグメント (source 縦 / 中央水平 / target 縦) のいずれかが障害ノードと衝突するとき、それを避けるパスを生成
+- 障害なしのケースは従来 Z字パスを維持
+- 同一行 (#314) / 同一レーン (#333) の挙動には regression なし
+- エディタと共有ビューアで同じ挙動
+- Diamond ノード・bidirectional 矢印でも崩れない
+
+## 3. アーキテクチャ
+
+```
+arrow-routing.ts
+├── collectObstacles            (既存 / 同一行)
+├── collectVerticalObstacles    (既存 / 同一レーン)
+├── collectDiagonalObstacles    (新規 / 異行×異レーン)
+├── detectDetour                (既存 / 水平直線)
+├── detectVerticalDetour        (既存 / 垂直直線)
+├── detectDiagonalDetour        (新規 / Z字パス全3セグメント)
+└── buildArrowPath              (修正 / 斜め分岐に迂回判定を追加)
+
+FlowEditor.aPath / SharedFlowViewer.computeArrowPath
+└── obstacles 組み立て分岐に `else { obstacles = collectDiagonalObstacles(...) }` を追加
+```
+
+### 設計原則
+
+- 既存の `collectObstacles` / `collectVerticalObstacles` / `detectDetour` / `detectVerticalDetour` API・実装には触れない (regression リスク隔離)
+- 新規ロジックは `Diagonal` 専用関数として独立、テストも独立
+- `buildArrowPath` の斜め分岐 (現状: Z字 / L字パス) を拡張し、`obstacles` が渡され `detectDiagonalDetour` が結果を返したときのみ迂回パスを生成
+- 共有ビューアは `buildArrowPath` を経由するため、呼び出し側 2 箇所の修正で済む
+
+## 4. detector 仕様
+
+### `detectDiagonalDetour`
+
+```ts
+type DiagonalDetourResult =
+  | { kind: 'shift-my'; my: number }
+  | { kind: 'target-detour'; my: number; detourX: number; approachY: number }
+  | { kind: 'source-detour'; departY: number; detourX: number; my: number }
+  | {
+      kind: 'both-detour'
+      departY: number
+      sourceDetourX: number
+      my: number
+      targetDetourX: number
+      approachY: number
+    }
+  | null
+
+function detectDiagonalDetour(s: Point, e: Point, obstacles: Bbox[]): DiagonalDetourResult
+```
+
+### 判定ロジック
+
+1. **斜めガード**: `|dx| < 2 || |dy| < 2` なら null を返す (既存 detector の領域)
+2. **初期 my を計算**: `my = (s.y + e.y) / 2`
+3. **3 セグメント衝突判定**:
+   - `sourceColHit`: X が source 列 (`|b.x - s.x| < b.w/2 + 2`) で Y が `[min(s.y, my) + 1, max(s.y, my) - 1]` の範囲にある障害
+   - `targetColHit`: X が target 列 (`|b.x - e.x| < b.w/2 + 2`) で Y が `[min(my, e.y) + 1, max(my, e.y) - 1]` の範囲にある障害
+   - `middleRowHit`: Y が `|b.y - my| < b.h/2 + 2` で X が `[min(s.x, e.x) + 1, max(s.x, e.x) - 1]` の範囲にある障害
+4. **優先順位 (上から順)**:
+   - すべて none → null
+   - `sourceColHit && targetColHit` → `both-detour`
+   - `targetColHit` → `target-detour`
+   - `sourceColHit` → `source-detour`
+   - `middleRowHit` のみ → `shift-my`
+
+### `target-detour` の幾何
+
+```
+M(s.x, s.y)
+ → L(s.x, my)                   # source 縦
+ → L(targetDetourX, my)         # 中央水平 (target 側に延長)
+ → L(targetDetourX, approachY)  # target 列を回避する縦
+ → L(e.x, approachY)            # target に向かって水平
+ → L(e.x, e.y)                  # target に縦進入
+```
+
+- `targetDetourX`:
+  - 右優先: target 列障害の Y 重なりするノードが直右に存在しないか、または直左にも存在する → 右
+  - その他 → 左
+  - `goRight ? max(障害右端) + DETOUR_MARGIN : min(障害左端) - DETOUR_MARGIN`
+- `approachY = e.y - sign(e.y - my) * APPROACH_GAP` (target 直前で水平切り返し)
+  - `Math.abs(e.y - my) / 2` で clamp (自己交差防止、既存 detour と同じ)
+- 中央 X セグメントが他の障害と衝突する場合は my をシフト (後述)
+
+### `source-detour` の幾何 (鏡像)
+
+```
+M(s.x, s.y)
+ → L(s.x, departY)
+ → L(sourceDetourX, departY)
+ → L(sourceDetourX, my)
+ → L(e.x, my)
+ → L(e.x, e.y)
+```
+
+- `sourceDetourX`: source 列障害の左右塞がり判定で右優先
+- `departY = s.y + sign(my - s.y) * DEPART_GAP`、`Math.abs(my - s.y) / 2` で clamp
+
+### `both-detour` の幾何 (8 セグ)
+
+```
+M(s.x, s.y)
+ → L(s.x, departY)
+ → L(sourceDetourX, departY)
+ → L(sourceDetourX, my)
+ → L(targetDetourX, my)
+ → L(targetDetourX, approachY)
+ → L(e.x, approachY)
+ → L(e.x, e.y)
+```
+
+### `shift-my` の幾何 (4 セグ維持)
+
+```
+M(s.x, s.y) → L(s.x, my') → L(e.x, my') → L(e.x, e.y)
+```
+
+- `my'`: 中央障害群の最上端 - DETOUR_MARGIN または最下端 + DETOUR_MARGIN
+- 下優先 (`detectDetour` と同方針)
+- ガード: `my'` が `[min(s.y, e.y) + bboxH/2 + 1, max(s.y, e.y) - bboxH/2 - 1]` を逸脱する場合は `shift-my` を諦め、`middleRowHit` の障害群を `targetColHit` として再評価して `target-detour` にフォールバック (中央障害は概ね target 列寄りに分布するため target 側迂回が自然)
+
+### 方向決定の規約 (既存と整合)
+
+- target/source 列迂回: **右優先** (#333 と同じ)
+- 中央 my-shift: **下優先** (#314 と同じ)
+
+## 5. collector 仕様
+
+### `collectDiagonalObstacles`
+
+```ts
+interface CollectDiagonalObstaclesArgs {
+  nodes: ObstacleNode[]
+  fromKey: string
+  toKey: string
+  fromCx: number
+  fromCy: number
+  toCx: number
+  toCy: number
+  rowH: number
+  colW: number
+  bboxW: number
+  bboxH: number
+}
+
+export function collectDiagonalObstacles(args: CollectDiagonalObstaclesArgs): Bbox[]
+```
+
+### 収集対象
+
+`from`/`to` 自身を除外したうえで、以下のいずれかに該当するノードを返す:
+
+1. **source 列ストリップ**: `|n.cx - fromCx| < bboxW/2 + 2` かつ `n.cy` が `(min(fromCy, toCy) + 1, max(fromCy, toCy) - 1)` の範囲
+2. **target 列ストリップ**: `|n.cx - toCx| < bboxW/2 + 2` かつ `n.cy` が `(min(fromCy, toCy) + 1, max(fromCy, toCy) - 1)` の範囲
+3. **中央行ストリップ**: `|n.cy - (fromCy + toCy) / 2| < bboxH/2 + 2` かつ `n.cx` が `(min(fromCx, toCx) + 1, max(fromCx, toCx) - 1)` の範囲
+4. **source 隣接列 (左右1列)**: `|n.cx - fromCx| > colW - bboxW/2 && |n.cx - fromCx| < colW + bboxW/2` かつ `n.cy` が `[min(fromCy, toCy) - rowH/2, max(fromCy, toCy) + rowH/2]` の範囲 (source 迂回方向判定用、Z字パス Y 範囲 + 半行分まで)
+5. **target 隣接列 (左右1列)**: `|n.cx - toCx| > colW - bboxW/2 && |n.cx - toCx| < colW + bboxW/2` かつ `n.cy` が同 Y 範囲 (target 迂回方向判定用)
+
+collector は「広めに集める」設計で、detector 側で `bboxW/2`・`colW` 閾値による再フィルタを行う。
+
+返却 Bbox は `{ x: n.cx, y: n.cy, w: bboxW, h: bboxH }` で `collectObstacles` と同じ shape。
+
+## 6. 呼び出し側変更
+
+### `src/features/editor/FlowEditor.tsx`
+
+`aPath` (現 1397-1423 行) の obstacles 組み立て分岐に `else` 節を追加:
+
+```ts
+let obstacles: Bbox[] | undefined
+if (fri === tri) {
+  obstacles = collectObstacles({ ... })           // 既存
+} else if (fli === tli) {
+  obstacles = collectVerticalObstacles({ ... })   // 既存
+} else {
+  obstacles = collectDiagonalObstacles({
+    nodes: obstacleNodes,
+    fromKey: arrow.from,
+    toKey: arrow.to,
+    fromCx: from.x,
+    fromCy: from.y,
+    toCx: to.x,
+    toCy: to.y,
+    rowH: RH,
+    colW: LW + G,
+    bboxW: TW,
+    bboxH: TH,
+  })
+}
+```
+
+### `src/features/shared/SharedFlowViewer.tsx`
+
+同じ構造で `computeArrowPath` (現 117-162 行) に `else` 節を追加。
+
+## 7. `buildArrowPath` の変更
+
+斜め分岐 (現 244-262 行 の `} else { ... }`) の前、つまり obstacles チェックの後ろに追加:
+
+```ts
+if (obstacles && obstacles.length > 0) {
+  // ... 既存の detectDetour / detectVerticalDetour 分岐 ...
+
+  const dDetour = detectDiagonalDetour(s, e, obstacles)
+  if (dDetour) {
+    // kind 別に SVG パス生成
+    // (target-detour / source-detour / both-detour / shift-my)
+    return { d, mx, my }
+  }
+}
+```
+
+ラベル位置 `mx, my`:
+
+- `target-detour`: `mx = (s.x + targetDetourX) / 2`, `my = my`
+- `source-detour`: `mx = (sourceDetourX + e.x) / 2`, `my = my`
+- `both-detour`: `mx = (sourceDetourX + targetDetourX) / 2`, `my = my`
+- `shift-my`: `mx = (s.x + e.x) / 2`, `my = my'`
+
+`my` の表記は detector が返す値 (シフト後または初期 `(s.y + e.y) / 2`) をそのまま使う。
+
+## 8. テスト計画
+
+### `detectDiagonalDetour` 単体テスト
+
+- `should return null when arrow is horizontal (|dy| < 2)`
+- `should return null when arrow is vertical (|dx| < 2)`
+- `should return null when no obstacles intersect Z-path`
+- `should return target-detour when obstacle in target column between my and e.y` (**core ケース**)
+- `should return target-detour with left-side detourX when target column blocked on right`
+- `should prefer right detour when both sides of target column are blocked`
+- `should return source-detour when obstacle in source column between s.y and my`
+- `should return shift-my when only middle horizontal segment is blocked`
+- `should escalate to target-detour when shift-my exceeds row bounds`
+- `should return both-detour when source and target columns both have obstacles`
+- `should return null with empty obstacles array`
+
+### `collectDiagonalObstacles` 単体テスト
+
+- `should exclude from/to nodes themselves`
+- `should collect source-column obstacles between rows`
+- `should collect target-column obstacles between rows`
+- `should collect adjacent-column obstacles around source and target`
+- `should collect middle-row obstacles between source and target X`
+- `should not collect nodes outside the Z-path corridor`
+- `should preserve bbox dimensions (w=bboxW, h=bboxH)`
+- `should return empty array when no candidate nodes`
+
+### `buildArrowPath` 統合テスト
+
+- `should produce 6-segment target-detour path for diagonal arrow with target-column obstacle` (**bug 再現**)
+- `should produce 6-segment source-detour path (mirror)`
+- `should produce 4-segment shift-my path for diagonal arrow with middle obstacle`
+- `should produce 8-segment both-detour path when both columns blocked`
+- `should produce default Z-path when no obstacles (regression guard)`
+- `should produce default Z-path when obstacles array is undefined`
+- `should not affect horizontal arrow detour (regression guard for #314)`
+- `should not affect vertical arrow detour (regression guard for #333)`
+
+### Diamond ノード
+
+- `should handle diagonal detour when source is diamond`
+- `should handle diagonal detour when target is diamond`
+
+### Playwright / 目視確認
+
+- 実データ (`ALLFIT-コンシェルジュ` flow) で ガイド → 店舗詳細 矢印が 一覧ページを貫通しないこと
+- スクリーンショット保存先: `.screenshots/issue-346-before.png` / `.screenshots/issue-346-after.png`
+- 他の既存矢印 (横方向迂回 #314、縦方向迂回 #333、通常 Z字) に regression がないこと
+- LCP 1 秒以内
+
+### `~/.claude/rules/testing.md` 準拠
+
+- 空配列・undefined のエッジケース網羅
+- 重複障害ノード (同じ X/Y) でも安定動作
+- 0/負/極大の dx/dy ガード
+- 命名規則: `[Unit] should [expected behavior] when [condition]`
+- クリティカルパス (detector / collector) は 100% カバレッジ目標
+
+## 9. 受け入れ基準
+
+- [ ] `ALLFIT-コンシェルジュ` flow で ガイド → 店舗詳細 の矢印が 一覧ページを避けて描画される
+- [ ] 斜め矢印 + 障害なし のケースで従来 Z字パス維持
+- [ ] #314 (横方向) の挙動に regression なし
+- [ ] #333 (縦方向) の挙動に regression なし
+- [ ] Diamond ノード・bidirectional 矢印の斜め配置でも崩れない
+- [ ] エディタと共有ビューアで同じ挙動
+- [ ] LCP 1 秒以内
+- [ ] 全テスト pass / Playwright 目視確認
+
+## 10. 既知の懸念と対応
+
+| 懸念 | 対応 |
+| --- | --- |
+| Z字パス 3 セグメント全てに衝突判定 | 優先順位ベースで 1〜2 セグメントの修正に集約。最悪 8 セグの `both-detour` で全カバー |
+| my シフトの上下限ガード | source/target 行を侵食しないよう `[s.y+bboxH/2, e.y-bboxH/2]` で clamp、超過時は target-detour 昇格 |
+| 既存 collector のスコープ拡張 | 既存関数は触らず、新規 `collectDiagonalObstacles` で独立カバー |
+| Diamond / bidirectional 対応 | テスト追加で検証。bbox は既存と同じ `TW × TH` |
+| 共有ビューアとの整合 | `arrow-routing.ts` に判定を寄せ、呼び出し側 (`FlowEditor.aPath` / `SharedFlowViewer.computeArrowPath`) は collector 呼び出しのみ差し替え |
+| パフォーマンス | `obstacleNodes` は既に 1 回収集済。collector は O(N)、detector は O(M) (M = 候補障害数)、全体 O(N + arrows × M) で実用上問題なし |
+
+## 11. 関連 issue
+
+- #314: 矢印迂回 (横方向) — 実装済 (CLOSED)
+- #333: 矢印迂回 (縦方向) — open / 作業中
+- #328: depart 脚クリアランス — 縦版にも同じ regression リスク、別途対応

--- a/docs/superpowers/specs/2026-05-22-issue-346-diagonal-arrow-detour-design.md
+++ b/docs/superpowers/specs/2026-05-22-issue-346-diagonal-arrow-detour-design.md
@@ -328,14 +328,14 @@ if (obstacles && obstacles.length > 0) {
 
 ## 10. 既知の懸念と対応
 
-| 懸念 | 対応 |
-| --- | --- |
-| Z字パス 3 セグメント全てに衝突判定 | 優先順位ベースで 1〜2 セグメントの修正に集約。最悪 8 セグの `both-detour` で全カバー |
-| my シフトの上下限ガード | source/target 行を侵食しないよう `[s.y+bboxH/2, e.y-bboxH/2]` で clamp、超過時は target-detour 昇格 |
-| 既存 collector のスコープ拡張 | 既存関数は触らず、新規 `collectDiagonalObstacles` で独立カバー |
-| Diamond / bidirectional 対応 | テスト追加で検証。bbox は既存と同じ `TW × TH` |
-| 共有ビューアとの整合 | `arrow-routing.ts` に判定を寄せ、呼び出し側 (`FlowEditor.aPath` / `SharedFlowViewer.computeArrowPath`) は collector 呼び出しのみ差し替え |
-| パフォーマンス | `obstacleNodes` は既に 1 回収集済。collector は O(N)、detector は O(M) (M = 候補障害数)、全体 O(N + arrows × M) で実用上問題なし |
+| 懸念                               | 対応                                                                                                                                     |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Z字パス 3 セグメント全てに衝突判定 | 優先順位ベースで 1〜2 セグメントの修正に集約。最悪 8 セグの `both-detour` で全カバー                                                     |
+| my シフトの上下限ガード            | source/target 行を侵食しないよう `[s.y+bboxH/2, e.y-bboxH/2]` で clamp、超過時は target-detour 昇格                                      |
+| 既存 collector のスコープ拡張      | 既存関数は触らず、新規 `collectDiagonalObstacles` で独立カバー                                                                           |
+| Diamond / bidirectional 対応       | テスト追加で検証。bbox は既存と同じ `TW × TH`                                                                                            |
+| 共有ビューアとの整合               | `arrow-routing.ts` に判定を寄せ、呼び出し側 (`FlowEditor.aPath` / `SharedFlowViewer.computeArrowPath`) は collector 呼び出しのみ差し替え |
+| パフォーマンス                     | `obstacleNodes` は既に 1 回収集済。collector は O(N)、detector は O(M) (M = 候補障害数)、全体 O(N + arrows × M) で実用上問題なし         |
 
 ## 11. 関連 issue
 

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -35,14 +35,7 @@ import { toBlob } from 'html-to-image'
 import { pickPixelRatio, buildExportSvg } from './png-export'
 import { calcLaneWidth } from './calcLaneWidth'
 import { NodeLabelText } from '../shared/NodeLabelText'
-import {
-  DS,
-  collectObstacles,
-  collectVerticalObstacles,
-  collectDiagonalObstacles,
-  type Bbox,
-  type ObstacleNode,
-} from '../../lib/arrow-routing'
+import { DS, buildObstacles, type Bbox, type ObstacleNode } from '../../lib/arrow-routing'
 import { useToast } from './hooks/useToast'
 import { ToastList } from './components/Toast'
 import { I, Ico } from './components/EditorIcons'
@@ -1396,46 +1389,21 @@ export default function FlowEditor({
     const to = ct(tli, tri)
 
     // 同一行/同一レーン/斜め配置に応じて obstacles を組み立てる（迂回判定用）
-    let obstacles: Bbox[] | undefined
-    if (fri === tri) {
-      obstacles = collectObstacles({
-        nodes: obstacleNodes,
-        fromKey: arrow.from,
-        toKey: arrow.to,
-        fromCx: from.x,
-        toCx: to.x,
-        rowY: from.y,
-        rowH: RH,
-        bboxW: TW,
-        bboxH: TH,
-      })
-    } else if (fli === tli) {
-      obstacles = collectVerticalObstacles({
-        nodes: obstacleNodes,
-        fromKey: arrow.from,
-        toKey: arrow.to,
-        fromCy: from.y,
-        toCy: to.y,
-        colX: from.x,
-        colW: LW + G,
-        bboxW: TW,
-        bboxH: TH,
-      })
-    } else {
-      obstacles = collectDiagonalObstacles({
-        nodes: obstacleNodes,
-        fromKey: arrow.from,
-        toKey: arrow.to,
-        fromCx: from.x,
-        fromCy: from.y,
-        toCx: to.x,
-        toCy: to.y,
-        rowH: RH,
-        colW: LW + G,
-        bboxW: TW,
-        bboxH: TH,
-      })
-    }
+    const obstacles: Bbox[] = buildObstacles({
+      nodes: obstacleNodes,
+      fromKey: arrow.from,
+      toKey: arrow.to,
+      fromCx: from.x,
+      fromCy: from.y,
+      toCx: to.x,
+      toCy: to.y,
+      sameRow: fri === tri,
+      sameLane: fli === tli,
+      rowH: RH,
+      colW: LW + G,
+      bboxW: TW,
+      bboxH: TH,
+    })
 
     return calcArrowPath(
       from,

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -39,6 +39,7 @@ import {
   DS,
   collectObstacles,
   collectVerticalObstacles,
+  collectDiagonalObstacles,
   type Bbox,
   type ObstacleNode,
 } from '../../lib/arrow-routing'
@@ -1394,7 +1395,7 @@ export default function FlowEditor({
     const from = ct(fli, fri)
     const to = ct(tli, tri)
 
-    // 同一行/同一レーンのときに obstacles を組み立てる（迂回判定用）
+    // 同一行/同一レーン/斜め配置に応じて obstacles を組み立てる（迂回判定用）
     let obstacles: Bbox[] | undefined
     if (fri === tri) {
       obstacles = collectObstacles({
@@ -1416,6 +1417,20 @@ export default function FlowEditor({
         fromCy: from.y,
         toCy: to.y,
         colX: from.x,
+        colW: LW + G,
+        bboxW: TW,
+        bboxH: TH,
+      })
+    } else {
+      obstacles = collectDiagonalObstacles({
+        nodes: obstacleNodes,
+        fromKey: arrow.from,
+        toKey: arrow.to,
+        fromCx: from.x,
+        fromCy: from.y,
+        toCx: to.x,
+        toCy: to.y,
+        rowH: RH,
         colW: LW + G,
         bboxW: TW,
         bboxH: TH,

--- a/src/features/shared/SharedFlowViewer.tsx
+++ b/src/features/shared/SharedFlowViewer.tsx
@@ -13,6 +13,7 @@ import {
   buildArrowPath,
   collectObstacles,
   collectVerticalObstacles,
+  collectDiagonalObstacles,
   DS,
   type Point,
   type Bbox,
@@ -130,7 +131,7 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
     const s = exitPt(f, t, hw, hh, RH, fromNode.shape as 'diamond' | undefined)
     const e = entryPt(t, f, hw, hh, RH, toNode.shape as 'diamond' | undefined)
 
-    // 同一行/同一レーンのときに obstacles を組み立てる（迂回判定用）
+    // 同一行/同一レーン/斜め配置に応じて obstacles を組み立てる（迂回判定用）
     let obstacles: Bbox[] | undefined
     if (fromNode.rowIndex === toNode.rowIndex) {
       obstacles = collectObstacles({
@@ -152,6 +153,20 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
         fromCy: f.y,
         toCy: t.y,
         colX: f.x,
+        colW: LW + G,
+        bboxW: TW,
+        bboxH: TH,
+      })
+    } else {
+      obstacles = collectDiagonalObstacles({
+        nodes: obstacleNodes,
+        fromKey: fromNode.id,
+        toKey: toNode.id,
+        fromCx: f.x,
+        fromCy: f.y,
+        toCx: t.x,
+        toCy: t.y,
+        rowH: RH,
         colW: LW + G,
         bboxW: TW,
         bboxH: TH,

--- a/src/features/shared/SharedFlowViewer.tsx
+++ b/src/features/shared/SharedFlowViewer.tsx
@@ -11,9 +11,7 @@ import {
   exitPt,
   entryPt,
   buildArrowPath,
-  collectObstacles,
-  collectVerticalObstacles,
-  collectDiagonalObstacles,
+  buildObstacles,
   DS,
   type Point,
   type Bbox,
@@ -132,46 +130,21 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
     const e = entryPt(t, f, hw, hh, RH, toNode.shape as 'diamond' | undefined)
 
     // 同一行/同一レーン/斜め配置に応じて obstacles を組み立てる（迂回判定用）
-    let obstacles: Bbox[] | undefined
-    if (fromNode.rowIndex === toNode.rowIndex) {
-      obstacles = collectObstacles({
-        nodes: obstacleNodes,
-        fromKey: fromNode.id,
-        toKey: toNode.id,
-        fromCx: f.x,
-        toCx: t.x,
-        rowY: f.y,
-        rowH: RH,
-        bboxW: TW,
-        bboxH: TH,
-      })
-    } else if (fromNode.laneId === toNode.laneId) {
-      obstacles = collectVerticalObstacles({
-        nodes: obstacleNodes,
-        fromKey: fromNode.id,
-        toKey: toNode.id,
-        fromCy: f.y,
-        toCy: t.y,
-        colX: f.x,
-        colW: LW + G,
-        bboxW: TW,
-        bboxH: TH,
-      })
-    } else {
-      obstacles = collectDiagonalObstacles({
-        nodes: obstacleNodes,
-        fromKey: fromNode.id,
-        toKey: toNode.id,
-        fromCx: f.x,
-        fromCy: f.y,
-        toCx: t.x,
-        toCy: t.y,
-        rowH: RH,
-        colW: LW + G,
-        bboxW: TW,
-        bboxH: TH,
-      })
-    }
+    const obstacles: Bbox[] = buildObstacles({
+      nodes: obstacleNodes,
+      fromKey: fromNode.id,
+      toKey: toNode.id,
+      fromCx: f.x,
+      fromCy: f.y,
+      toCx: t.x,
+      toCy: t.y,
+      sameRow: fromNode.rowIndex === toNode.rowIndex,
+      sameLane: fromNode.laneId === toNode.laneId,
+      rowH: RH,
+      colW: LW + G,
+      bboxW: TW,
+      bboxH: TH,
+    })
 
     return buildArrowPath(s, e, f, t, obstacles)
   }

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -605,9 +605,7 @@ describe('buildArrowPath - 斜め迂回（異行×異レーン）', () => {
     const Bs: Bbox = { x: 200, y: 250, w: 152, h: 56 }
     const Bt: Bbox = { x: 600, y: 250, w: 152, h: 56 }
     const r = buildArrowPath(s, e, fc, tc, [Bs, Bt])
-    expect(r.d).toBe(
-      'M200,128 L200,142 L290,142 L290,250 L690,250 L690,358 L600,358 L600,372',
-    )
+    expect(r.d).toBe('M200,128 L200,142 L290,142 L290,250 L690,250 L690,358 L600,358 L600,372')
     expect(r.mx).toBe((290 + 690) / 2)
     expect(r.my).toBe(250)
   })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -591,4 +591,25 @@ describe('collectDiagonalObstacles', () => {
     const r = collectDiagonalObstacles({ nodes, ...baseArgs })
     expect(r).toEqual([])
   })
+
+  it('should collect source-column obstacle between source and target rows', () => {
+    const nodes: ObstacleNode[] = [
+      { key: 'A', cx: 200, cy: 100 },
+      { key: 'B', cx: 200, cy: 250 },
+      { key: 'C', cx: 600, cy: 400 },
+    ]
+    const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+    expect(r).toEqual([{ x: 200, y: 250, w: 152, h: 56 }])
+  })
+
+  it('should not collect source-column nodes outside Z-path Y range', () => {
+    const nodes: ObstacleNode[] = [
+      { key: 'A', cx: 200, cy: 100 },
+      { key: 'B', cx: 200, cy: 50 },
+      { key: 'D', cx: 200, cy: 450 },
+      { key: 'C', cx: 600, cy: 400 },
+    ]
+    const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+    expect(r).toEqual([])
+  })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -787,4 +787,12 @@ describe('detectDiagonalDetour', () => {
       my: 250 + 28 + 14, // 292 (下優先: 障害下端 + DETOUR_MARGIN)
     })
   })
+
+  it('should escalate to target-detour when shift-my would exceed row bounds', () => {
+    const sNarrow = { x: 200, y: 128 }
+    const eNarrow = { x: 600, y: 172 }
+    const B: Bbox = { x: 400, y: 150, w: 152, h: 56 }
+    const r = detectDiagonalDetour(sNarrow, eNarrow, [B])
+    expect(r?.kind).toBe('target-detour')
+  })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -731,4 +731,15 @@ describe('detectDiagonalDetour', () => {
     const farAway: Bbox = { x: 50, y: 50, w: 152, h: 56 }
     expect(detectDiagonalDetour(s, e, [farAway])).toBeNull()
   })
+
+  it('should return target-detour when obstacle is in target column between my and e.y', () => {
+    const B: Bbox = { x: 600, y: 250, w: 152, h: 56 }
+    const r = detectDiagonalDetour(s, e, [B])
+    expect(r).toEqual({
+      kind: 'target-detour',
+      my: 250,
+      detourX: 600 + 76 + 14, // 690 (右迂回: 障害右端 + DETOUR_MARGIN)
+      approachY: 372 - 14, // 358
+    })
+  })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -4,6 +4,7 @@ import {
   collectObstacles,
   collectVerticalObstacles,
   collectDiagonalObstacles,
+  detectDiagonalDetour,
   type Bbox,
   type ObstacleNode,
 } from './arrow-routing'
@@ -701,5 +702,33 @@ describe('collectDiagonalObstacles', () => {
     expect(r).toContainEqual({ x: 200, y: 250, w: 152, h: 56 })
     expect(r).toContainEqual({ x: 400, y: 250, w: 152, h: 56 })
     expect(r).toContainEqual({ x: 600, y: 250, w: 152, h: 56 })
+  })
+})
+
+describe('detectDiagonalDetour', () => {
+  const s = { x: 200, y: 128 }
+  const e = { x: 600, y: 372 }
+
+  it('should return null when arrow is horizontal (|dy| < 2)', () => {
+    const r = detectDiagonalDetour({ x: 200, y: 200 }, { x: 600, y: 201 }, [
+      { x: 400, y: 200, w: 152, h: 56 },
+    ])
+    expect(r).toBeNull()
+  })
+
+  it('should return null when arrow is vertical (|dx| < 2)', () => {
+    const r = detectDiagonalDetour({ x: 200, y: 100 }, { x: 201, y: 400 }, [
+      { x: 200, y: 250, w: 152, h: 56 },
+    ])
+    expect(r).toBeNull()
+  })
+
+  it('should return null with empty obstacles array', () => {
+    expect(detectDiagonalDetour(s, e, [])).toBeNull()
+  })
+
+  it('should return null when no obstacles intersect Z-path', () => {
+    const farAway: Bbox = { x: 50, y: 50, w: 152, h: 56 }
+    expect(detectDiagonalDetour(s, e, [farAway])).toBeNull()
   })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -622,4 +622,25 @@ describe('collectDiagonalObstacles', () => {
     const r = collectDiagonalObstacles({ nodes, ...baseArgs })
     expect(r).toEqual([{ x: 600, y: 250, w: 152, h: 56 }])
   })
+
+  it('should collect middle-row obstacle between source and target X', () => {
+    const nodes: ObstacleNode[] = [
+      { key: 'A', cx: 200, cy: 100 },
+      { key: 'B', cx: 400, cy: 250 },
+      { key: 'C', cx: 600, cy: 400 },
+    ]
+    const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+    expect(r).toEqual([{ x: 400, y: 250, w: 152, h: 56 }])
+  })
+
+  it('should not collect nodes outside Z-path X range at middle row', () => {
+    const nodes: ObstacleNode[] = [
+      { key: 'A', cx: 200, cy: 100 },
+      { key: 'B', cx: 50, cy: 250 },
+      { key: 'D', cx: 750, cy: 250 },
+      { key: 'C', cx: 600, cy: 400 },
+    ]
+    const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+    expect(r).toEqual([])
+  })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -767,4 +767,15 @@ describe('detectDiagonalDetour', () => {
       approachY: 358,
     })
   })
+
+  it('should return source-detour when obstacle is in source column between s.y and my', () => {
+    const B: Bbox = { x: 200, y: 250, w: 152, h: 56 }
+    const r = detectDiagonalDetour(s, e, [B])
+    expect(r).toEqual({
+      kind: 'source-detour',
+      departY: 128 + 14, // 142
+      detourX: 200 + 76 + 14, // 290 (右優先)
+      my: 250,
+    })
+  })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -649,7 +649,7 @@ describe('buildArrowPath - 斜め迂回（異行×異レーン）', () => {
     const eDia = { x: 600, y: 366 } // approx 中心 (600,400) - DS(34) 上
     const B: Bbox = { x: 600, y: 250, w: 152, h: 56 } // target 列障害
     const r = buildArrowPath(sDia, eDia, { x: 200, y: 100 }, { x: 600, y: 400 }, [B])
-    expect(r.d).toMatch(/^M200,134 L200,250 L690,250 L690,\d+ L600,\d+ L600,366$/)
+    expect(r.d).toBe('M200,134 L200,250 L690,250 L690,352 L600,352 L600,366')
   })
 })
 

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -619,6 +619,30 @@ describe('buildArrowPath - 斜め迂回（異行×異レーン）', () => {
     expect(r.mx).toBe(400)
     expect(r.my).toBe(292)
   })
+
+  it('should not affect horizontal arrow detour (regression guard for #314)', () => {
+    const sH = { x: 276, y: 200 }
+    const eH = { x: 524, y: 200 }
+    const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(sH, eH, { x: 200, y: 200 }, { x: 600, y: 200 }, [B])
+    expect(r.d).toBe('M276,200 L290,200 L290,242 L510,242 L510,200 L524,200')
+  })
+
+  it('should not affect vertical arrow detour (regression guard for #333)', () => {
+    const sV = { x: 200, y: 128 }
+    const eV = { x: 200, y: 372 }
+    const B: Bbox = { x: 200, y: 250, w: 152, h: 56 }
+    const r = buildArrowPath(sV, eV, { x: 200, y: 100 }, { x: 200, y: 400 }, [B])
+    // 既存 detectVerticalDetour による 6 セグ右迂回
+    expect(r.d).toContain('M200,128')
+    expect(r.d).toContain('L200,372')
+    expect(r.d).toMatch(/L290,\d+/) // 右迂回 detourX = 200+76+14 = 290
+  })
+
+  it('should produce default Z-path when obstacles array is undefined (diagonal)', () => {
+    const r = buildArrowPath(s, e, fc, tc)
+    expect(r.d).toBe('M200,128 L200,250 L600,250 L600,372')
+  })
 })
 
 describe('collectDiagonalObstacles', () => {

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -795,4 +795,18 @@ describe('detectDiagonalDetour', () => {
     const r = detectDiagonalDetour(sNarrow, eNarrow, [B])
     expect(r?.kind).toBe('target-detour')
   })
+
+  it('should return both-detour when source and target columns both have obstacles', () => {
+    const Bs: Bbox = { x: 200, y: 250, w: 152, h: 56 }
+    const Bt: Bbox = { x: 600, y: 250, w: 152, h: 56 }
+    const r = detectDiagonalDetour(s, e, [Bs, Bt])
+    expect(r).toEqual({
+      kind: 'both-detour',
+      departY: 142,
+      sourceDetourX: 290,
+      my: 250,
+      targetDetourX: 690,
+      approachY: 358,
+    })
+  })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -612,4 +612,14 @@ describe('collectDiagonalObstacles', () => {
     const r = collectDiagonalObstacles({ nodes, ...baseArgs })
     expect(r).toEqual([])
   })
+
+  it('should collect target-column obstacle between source and target rows', () => {
+    const nodes: ObstacleNode[] = [
+      { key: 'A', cx: 200, cy: 100 },
+      { key: 'B', cx: 600, cy: 250 },
+      { key: 'C', cx: 600, cy: 400 },
+    ]
+    const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+    expect(r).toEqual([{ x: 600, y: 250, w: 152, h: 56 }])
+  })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -570,6 +570,26 @@ describe('collectVerticalObstacles', () => {
   })
 })
 
+describe('buildArrowPath - 斜め迂回（異行×異レーン）', () => {
+  const s = { x: 200, y: 128 }
+  const e = { x: 600, y: 372 }
+  const fc = { x: 200, y: 100 }
+  const tc = { x: 600, y: 400 }
+
+  it('should produce 6-segment target-detour path when obstacle in target column (core bug case)', () => {
+    const B: Bbox = { x: 600, y: 250, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B])
+    expect(r.d).toBe('M200,128 L200,250 L690,250 L690,358 L600,358 L600,372')
+    expect(r.mx).toBe((200 + 690) / 2)
+    expect(r.my).toBe(250)
+  })
+
+  it('should produce default Z-path when no obstacles intersect (diagonal)', () => {
+    const r = buildArrowPath(s, e, fc, tc, [])
+    expect(r.d).toBe('M200,128 L200,250 L600,250 L600,372')
+  })
+})
+
 describe('collectDiagonalObstacles', () => {
   const baseArgs = {
     fromKey: 'A',

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -742,4 +742,29 @@ describe('detectDiagonalDetour', () => {
       approachY: 372 - 14, // 358
     })
   })
+
+  it('should return target-detour with left-side detourX when target column is right-blocked', () => {
+    const B: Bbox = { x: 600, y: 250, w: 152, h: 56 }
+    const R: Bbox = { x: 800, y: 250, w: 152, h: 56 }
+    const r = detectDiagonalDetour(s, e, [B, R])
+    expect(r).toEqual({
+      kind: 'target-detour',
+      my: 250,
+      detourX: 600 - 76 - 14, // 510 (左迂回)
+      approachY: 358,
+    })
+  })
+
+  it('should prefer right detour when both sides of target column are blocked', () => {
+    const B: Bbox = { x: 600, y: 250, w: 152, h: 56 }
+    const R: Bbox = { x: 800, y: 250, w: 152, h: 56 }
+    const L: Bbox = { x: 400, y: 250, w: 152, h: 56 }
+    const r = detectDiagonalDetour(s, e, [B, R, L])
+    expect(r).toEqual({
+      kind: 'target-detour',
+      my: 250,
+      detourX: 690, // 右優先
+      approachY: 358,
+    })
+  })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -362,12 +362,16 @@ describe('buildArrowPath - 縦方向迂回（同一レーン）', () => {
     expect(r.d).toBe('M200,228 L200,572')
   })
 
-  it('斜め方向（dx >= 2）→ 既存の Z/L 字ロジック（縦迂回しない）', () => {
+  it('斜め方向（dx >= 2）→ detectVerticalDetour は発火せず detectDiagonalDetour 経路へ', () => {
     const sDiag = { x: 200, y: 228 }
     const eDiag = { x: 300, y: 572 }
     const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
     const r = buildArrowPath(sDiag, eDiag, { x: 200, y: 200 }, { x: 300, y: 600 }, [B])
-    expect(r.d).not.toContain('L290,242')
+    // detectVerticalDetour は |dx| >= 2 で null を返す → 縦迂回固有の my=(s.y+e.y)/2 と
+    // detourX 同値の 6 セグ縦迂回パターンにはならない。
+    // detectDiagonalDetour による source-detour に流れる（B は source 列 (200) 上、target 列 (300)
+    // は障害なし）。
+    expect(r.d).toBe('M200,228 L200,242 L290,242 L290,400 L300,400 L300,572')
   })
 
   it('始終点が同じ Y（自己参照） → inCol 空 → 直線', () => {
@@ -587,6 +591,33 @@ describe('buildArrowPath - 斜め迂回（異行×異レーン）', () => {
   it('should produce default Z-path when no obstacles intersect (diagonal)', () => {
     const r = buildArrowPath(s, e, fc, tc, [])
     expect(r.d).toBe('M200,128 L200,250 L600,250 L600,372')
+  })
+
+  it('should produce 6-segment source-detour path (mirror)', () => {
+    const B: Bbox = { x: 200, y: 250, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B])
+    expect(r.d).toBe('M200,128 L200,142 L290,142 L290,250 L600,250 L600,372')
+    expect(r.mx).toBe((290 + 600) / 2)
+    expect(r.my).toBe(250)
+  })
+
+  it('should produce 8-segment both-detour path when both columns blocked', () => {
+    const Bs: Bbox = { x: 200, y: 250, w: 152, h: 56 }
+    const Bt: Bbox = { x: 600, y: 250, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [Bs, Bt])
+    expect(r.d).toBe(
+      'M200,128 L200,142 L290,142 L290,250 L690,250 L690,358 L600,358 L600,372',
+    )
+    expect(r.mx).toBe((290 + 690) / 2)
+    expect(r.my).toBe(250)
+  })
+
+  it('should produce 4-segment shift-my path when only middle horizontal segment is blocked', () => {
+    const B: Bbox = { x: 400, y: 250, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B])
+    expect(r.d).toBe('M200,128 L200,292 L600,292 L600,372')
+    expect(r.mx).toBe(400)
+    expect(r.my).toBe(292)
   })
 })
 

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -3,6 +3,7 @@ import {
   buildArrowPath,
   collectObstacles,
   collectVerticalObstacles,
+  collectDiagonalObstacles,
   type Bbox,
   type ObstacleNode,
 } from './arrow-routing'
@@ -565,5 +566,29 @@ describe('collectVerticalObstacles', () => {
       bboxH: TH,
     })
     expect(result).toEqual([])
+  })
+})
+
+describe('collectDiagonalObstacles', () => {
+  const baseArgs = {
+    fromKey: 'A',
+    toKey: 'C',
+    fromCx: 200,
+    fromCy: 100,
+    toCx: 600,
+    toCy: 400,
+    rowH: 84,
+    colW: 200,
+    bboxW: 152,
+    bboxH: 56,
+  }
+
+  it('should exclude from/to nodes themselves when only from/to exist', () => {
+    const nodes: ObstacleNode[] = [
+      { key: 'A', cx: 200, cy: 100 },
+      { key: 'C', cx: 600, cy: 400 },
+    ]
+    const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+    expect(r).toEqual([])
   })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -682,4 +682,24 @@ describe('collectDiagonalObstacles', () => {
     const r = collectDiagonalObstacles({ nodes, ...baseArgs })
     expect(r).toEqual([])
   })
+
+  it('should return empty array when nodes is empty', () => {
+    const r = collectDiagonalObstacles({ nodes: [], ...baseArgs })
+    expect(r).toEqual([])
+  })
+
+  it('should collect multiple obstacles matching different rules simultaneously', () => {
+    const nodes: ObstacleNode[] = [
+      { key: 'A', cx: 200, cy: 100 },
+      { key: 'C', cx: 600, cy: 400 },
+      { key: 'Bs', cx: 200, cy: 250 }, // source 列 ストリップ
+      { key: 'Bm', cx: 400, cy: 250 }, // 中央行 ストリップ
+      { key: 'Bt', cx: 600, cy: 250 }, // target 列 ストリップ
+    ]
+    const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+    expect(r).toHaveLength(3)
+    expect(r).toContainEqual({ x: 200, y: 250, w: 152, h: 56 })
+    expect(r).toContainEqual({ x: 400, y: 250, w: 152, h: 56 })
+    expect(r).toContainEqual({ x: 600, y: 250, w: 152, h: 56 })
+  })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -778,4 +778,13 @@ describe('detectDiagonalDetour', () => {
       my: 250,
     })
   })
+
+  it('should return shift-my when only middle horizontal segment is blocked', () => {
+    const B: Bbox = { x: 400, y: 250, w: 152, h: 56 }
+    const r = detectDiagonalDetour(s, e, [B])
+    expect(r).toEqual({
+      kind: 'shift-my',
+      my: 250 + 28 + 14, // 292 (下優先: 障害下端 + DETOUR_MARGIN)
+    })
+  })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -634,10 +634,49 @@ describe('collectDiagonalObstacles', () => {
   })
 
   it('should not collect nodes outside Z-path X range at middle row', () => {
+    // 中央行 Y (=250) だが、source 列・target 列・隣接列のいずれにも該当しない X 位置
+    // (fromCx=200, toCx=600, colW=200, bboxW=152)
+    //   source col:        cx in (122, 278)
+    //   target col:        cx in (522, 678)
+    //   source adjacent:   |cx-200| in (124, 276) → cx in (-76, 76) ∪ (324, 476)
+    //   target adjacent:   |cx-600| in (124, 276) → cx in (324, 476) ∪ (724, 876)
+    //   middle-row Z(X):   cx in (201, 599)
+    // cx=100: 隣接列バンド外 (76 < 100 < 122)、source 列外、middle-row Z 範囲外
+    // cx=700: 隣接列バンド外 (678 < 700 < 724)、target 列外、middle-row Z 範囲外
     const nodes: ObstacleNode[] = [
       { key: 'A', cx: 200, cy: 100 },
-      { key: 'B', cx: 50, cy: 250 },
-      { key: 'D', cx: 750, cy: 250 },
+      { key: 'B', cx: 100, cy: 250 },
+      { key: 'D', cx: 700, cy: 250 },
+      { key: 'C', cx: 600, cy: 400 },
+    ]
+    const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+    expect(r).toEqual([])
+  })
+
+  it('should collect source-adjacent-column obstacle within extended Y range', () => {
+    const nodes: ObstacleNode[] = [
+      { key: 'A', cx: 200, cy: 100 },
+      { key: 'B', cx: 400, cy: 100 },
+      { key: 'C', cx: 600, cy: 400 },
+    ]
+    const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+    expect(r).toContainEqual({ x: 400, y: 100, w: 152, h: 56 })
+  })
+
+  it('should collect target-adjacent-column obstacle for direction decision', () => {
+    const nodes: ObstacleNode[] = [
+      { key: 'A', cx: 200, cy: 100 },
+      { key: 'B', cx: 800, cy: 400 },
+      { key: 'C', cx: 600, cy: 400 },
+    ]
+    const r = collectDiagonalObstacles({ nodes, ...baseArgs })
+    expect(r).toContainEqual({ x: 800, y: 400, w: 152, h: 56 })
+  })
+
+  it('should not collect adjacent-column nodes outside extended Y range', () => {
+    const nodes: ObstacleNode[] = [
+      { key: 'A', cx: 200, cy: 100 },
+      { key: 'B', cx: 400, cy: 800 },
       { key: 'C', cx: 600, cy: 400 },
     ]
     const r = collectDiagonalObstacles({ nodes, ...baseArgs })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -643,6 +643,14 @@ describe('buildArrowPath - 斜め迂回（異行×異レーン）', () => {
     const r = buildArrowPath(s, e, fc, tc)
     expect(r.d).toBe('M200,128 L200,250 L600,250 L600,372')
   })
+
+  it('should handle diagonal detour when source/target points come from diamond shape', () => {
+    const sDia = { x: 200, y: 134 } // approx 中心 (200,100) + DS(34) 下
+    const eDia = { x: 600, y: 366 } // approx 中心 (600,400) - DS(34) 上
+    const B: Bbox = { x: 600, y: 250, w: 152, h: 56 } // target 列障害
+    const r = buildArrowPath(sDia, eDia, { x: 200, y: 100 }, { x: 600, y: 400 }, [B])
+    expect(r.d).toMatch(/^M200,134 L200,250 L690,250 L690,\d+ L600,\d+ L600,366$/)
+  })
 })
 
 describe('collectDiagonalObstacles', () => {

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -398,6 +398,15 @@ export function collectDiagonalObstacles(args: CollectDiagonalObstaclesArgs): Bb
       result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
       continue
     }
+    const midY = (fromCy + toCy) / 2
+    const onMiddleRow = Math.abs(n.cy - midY) < bboxH / 2 + 2
+    const xLow = Math.min(fromCx, toCx)
+    const xHigh = Math.max(fromCx, toCx)
+    const inZRangeX = n.cx > xLow + 1 && n.cx < xHigh - 1
+    if (onMiddleRow && inZRangeX) {
+      result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+      continue
+    }
   }
   return result
 }

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -395,6 +395,21 @@ export const buildArrowPath = (
         const d = `M${s.x},${s.y} L${s.x},${my} L${detourX},${my} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
         return { d, mx: (s.x + detourX) / 2, my }
       }
+      if (dDetour.kind === 'source-detour') {
+        const { departY, detourX, my } = dDetour
+        const d = `M${s.x},${s.y} L${s.x},${departY} L${detourX},${departY} L${detourX},${my} L${e.x},${my} L${e.x},${e.y}`
+        return { d, mx: (detourX + e.x) / 2, my }
+      }
+      if (dDetour.kind === 'both-detour') {
+        const { departY, sourceDetourX, my, targetDetourX, approachY } = dDetour
+        const d = `M${s.x},${s.y} L${s.x},${departY} L${sourceDetourX},${departY} L${sourceDetourX},${my} L${targetDetourX},${my} L${targetDetourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
+        return { d, mx: (sourceDetourX + targetDetourX) / 2, my }
+      }
+      if (dDetour.kind === 'shift-my') {
+        const { my } = dDetour
+        const d = `M${s.x},${s.y} L${s.x},${my} L${e.x},${my} L${e.x},${e.y}`
+        return { d, mx: (s.x + e.x) / 2, my }
+      }
     }
   }
 

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -195,6 +195,42 @@ export function detectDiagonalDetour(
     return { kind: 'source-detour', departY, detourX, my }
   }
 
+  // 中央水平セグメント衝突: Y ≈ my で X が源-標的間
+  const middleRowHits = obstacles.filter((b) => {
+    const xLow = Math.min(s.x, e.x)
+    const xHigh = Math.max(s.x, e.x)
+    return (
+      Math.abs(b.y - my) < b.h / 2 + 2 &&
+      b.x - b.w / 2 < xHigh - 1 &&
+      b.x + b.w / 2 > xLow + 1
+    )
+  })
+
+  if (middleRowHits.length > 0 && sourceColHits.length === 0 && targetColHits.length === 0) {
+    const xOverlap = (a: Bbox, b: Bbox) => Math.abs(a.x - b.x) < (a.w + b.w) / 2
+    const downBlocked = middleRowHits.some((obs) =>
+      obstacles.some((b) => b.y > obs.y + 1 && xOverlap(obs, b)),
+    )
+    const upBlocked = middleRowHits.some((obs) =>
+      obstacles.some((b) => b.y < obs.y - 1 && xOverlap(obs, b)),
+    )
+    const goDown = !downBlocked || upBlocked
+    const shiftedMy = goDown
+      ? Math.max(...middleRowHits.map((o) => o.y + o.h / 2)) + DETOUR_MARGIN
+      : Math.min(...middleRowHits.map((o) => o.y - o.h / 2)) - DETOUR_MARGIN
+
+    // ガード: shiftedMy が source 行 / target 行を侵食しないこと
+    const yLow = Math.min(s.y, e.y)
+    const yHigh = Math.max(s.y, e.y)
+    const bboxHEst = middleRowHits[0].h
+    const lo = yLow + bboxHEst / 2 + 1
+    const hi = yHigh - bboxHEst / 2 - 1
+    if (shiftedMy >= lo && shiftedMy <= hi) {
+      return { kind: 'shift-my', my: shiftedMy }
+    }
+    // 範囲外 → Task 11 で target-detour 昇格
+  }
+
   return null
 }
 

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -133,6 +133,50 @@ export function detectDiagonalDetour(
 ): DiagonalDetourResult | null {
   if (Math.abs(e.x - s.x) < 2 || Math.abs(e.y - s.y) < 2) return null
   if (obstacles.length === 0) return null
+
+  const my = (s.y + e.y) / 2
+
+  // source 列衝突: source 縦セグメント (s.y → my) と重なる障害
+  const sourceColHits = obstacles.filter((b) => {
+    const yLow = Math.min(s.y, my)
+    const yHigh = Math.max(s.y, my)
+    return (
+      Math.abs(b.x - s.x) < b.w / 2 + 2 &&
+      b.y - b.h / 2 < yHigh - 1 &&
+      b.y + b.h / 2 > yLow + 1
+    )
+  })
+
+  // target 列衝突: target 縦セグメント (my → e.y) と重なる障害
+  const targetColHits = obstacles.filter((b) => {
+    const yLow = Math.min(my, e.y)
+    const yHigh = Math.max(my, e.y)
+    return (
+      Math.abs(b.x - e.x) < b.w / 2 + 2 &&
+      b.y - b.h / 2 < yHigh - 1 &&
+      b.y + b.h / 2 > yLow + 1
+    )
+  })
+
+  if (targetColHits.length > 0 && sourceColHits.length === 0) {
+    // 方向決定: target 列障害の左右塞がり判定
+    const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
+    const rightBlocked = targetColHits.some((obs) =>
+      obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
+    )
+    const leftBlocked = targetColHits.some((obs) =>
+      obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
+    )
+    const goRight = !rightBlocked || leftBlocked
+    const detourX = goRight
+      ? Math.max(...targetColHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+      : Math.min(...targetColHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+    const sign = Math.sign(e.y - my)
+    const halfDy = Math.abs(e.y - my) / 2
+    const approachY = e.y - sign * Math.min(APPROACH_GAP, halfDy)
+    return { kind: 'target-detour', my, detourX, approachY }
+  }
+
   return null
 }
 

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -19,6 +19,11 @@ const APPROACH_GAP = 14
 // APPROACH_GAP と対称設計（同値）で、始点側もノード端から少し横に進んでから下降させる。
 const DEPART_GAP = 14
 
+// Bbox 同士の X 軸重なり判定 (中心間距離が半径合計より小)
+const xOverlap = (a: Bbox, b: Bbox): boolean => Math.abs(a.x - b.x) < (a.w + b.w) / 2
+// Bbox 同士の Y 軸重なり判定 (中心間距離が半径合計より小)
+const yOverlap = (a: Bbox, b: Bbox): boolean => Math.abs(a.y - b.y) < (a.h + b.h) / 2
+
 function detectDetour(s: Point, e: Point, obstacles: Bbox[]): { detourY: number } | null {
   // 水平直線でなければ迂回しない
   if (Math.abs(e.y - s.y) >= 2) return null
@@ -41,7 +46,6 @@ function detectDetour(s: Point, e: Point, obstacles: Bbox[]): { detourY: number 
   // 前提: obstacles 配列には呼び出し側で「同一行＋直上行＋直下行のみ」をフィルタ済み
   // のノードが入っていること（collectObstacles ヘルパーがこれを保証する）。Y 距離の
   // 厳密チェックを省略しているのはこの前提のため。
-  const xOverlap = (a: Bbox, b: Bbox) => Math.abs(a.x - b.x) < (a.w + b.w) / 2
   const downBlocked = inRow.some((obs) =>
     obstacles.some((b) => b.y > obs.y + 1 && xOverlap(obs, b)),
   )
@@ -83,7 +87,6 @@ function detectVerticalDetour(s: Point, e: Point, obstacles: Bbox[]): { detourX:
 
   // 左右塞がり判定（Y 重なりするノードが直左/直右に存在するか）
   // 前提: obstacles 配列には呼び出し側で「同一列＋直左列＋直右列のみ」をフィルタ済み
-  const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
   const rightBlocked = inCol.some((obs) =>
     obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
   )
@@ -123,7 +126,6 @@ type DiagonalDetourResult =
  * ため、both-detour では呼び出し側が反対側列の hits を除外した blockers を渡す。
  */
 function pickDetourX(hits: Bbox[], blockers: Bbox[]): number {
-  const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
   const rightBlocked = hits.some((obs) => blockers.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)))
   const leftBlocked = hits.some((obs) => blockers.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)))
   const goRight = !rightBlocked || leftBlocked
@@ -215,7 +217,6 @@ export function detectDiagonalDetour(
 
   // 到達条件: sourceColHits / targetColHits は共に空 (上方の if ブロックが早期 return している)
   if (middleRowHits.length > 0) {
-    const xOverlap = (a: Bbox, b: Bbox) => Math.abs(a.x - b.x) < (a.w + b.w) / 2
     const downBlocked = middleRowHits.some((obs) =>
       obstacles.some((b) => b.y > obs.y + 1 && xOverlap(obs, b)),
     )

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -407,14 +407,19 @@ export function collectDiagonalObstacles(args: CollectDiagonalObstaclesArgs): Bb
       result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
       continue
     }
+    // 隣接列は同一列を除外 (colW <= bboxW の縮退ケース防御。
+    // collectObstacles / collectVerticalObstacles と同じ防御パターン)
     const onSourceAdjacentCol =
-      Math.abs(n.cx - fromCx) > colW - bboxW / 2 && Math.abs(n.cx - fromCx) < colW + bboxW / 2
+      !onSourceCol &&
+      Math.abs(n.cx - fromCx) > colW - bboxW / 2 &&
+      Math.abs(n.cx - fromCx) < colW + bboxW / 2
     const onTargetAdjacentCol =
-      Math.abs(n.cx - toCx) > colW - bboxW / 2 && Math.abs(n.cx - toCx) < colW + bboxW / 2
+      !onTargetCol &&
+      Math.abs(n.cx - toCx) > colW - bboxW / 2 &&
+      Math.abs(n.cx - toCx) < colW + bboxW / 2
     const inExtendedY = n.cy >= yLow - rowH / 2 && n.cy <= yHigh + rowH / 2
     if ((onSourceAdjacentCol || onTargetAdjacentCol) && inExtendedY) {
       result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
-      continue
     }
   }
   return result

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -228,7 +228,21 @@ export function detectDiagonalDetour(
     if (shiftedMy >= lo && shiftedMy <= hi) {
       return { kind: 'shift-my', my: shiftedMy }
     }
-    // 範囲外 → Task 11 で target-detour 昇格
+    // 範囲外 → 中央障害を targetColHit 扱いで target-detour に昇格
+    const escRightBlocked = middleRowHits.some((obs) =>
+      obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
+    )
+    const escLeftBlocked = middleRowHits.some((obs) =>
+      obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
+    )
+    const escGoRight = !escRightBlocked || escLeftBlocked
+    const escDetourX = escGoRight
+      ? Math.max(...middleRowHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+      : Math.min(...middleRowHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+    const escSign = Math.sign(e.y - my)
+    const escHalfDy = Math.abs(e.y - my) / 2
+    const escApproachY = e.y - escSign * Math.min(APPROACH_GAP, escHalfDy)
+    return { kind: 'target-detour', my, detourX: escDetourX, approachY: escApproachY }
   }
 
   return null

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -102,6 +102,40 @@ function detectVerticalDetour(s: Point, e: Point, obstacles: Bbox[]): { detourX:
   return { detourX }
 }
 
+type DiagonalDetourResult =
+  | { kind: 'shift-my'; my: number }
+  | { kind: 'target-detour'; my: number; detourX: number; approachY: number }
+  | { kind: 'source-detour'; departY: number; detourX: number; my: number }
+  | {
+      kind: 'both-detour'
+      departY: number
+      sourceDetourX: number
+      my: number
+      targetDetourX: number
+      approachY: number
+    }
+
+/**
+ * 斜め配置矢印 (異行×異レーン) の Z字パス 3 セグメント (source 縦/中央水平/target 縦) と
+ * 障害ノードの衝突を判定し、迂回パスを記述する DiagonalDetourResult を返す。
+ * 障害なしまたは斜めでない (水平・垂直直線) ときは null を返す。
+ *
+ * 優先順位:
+ *   sourceColHit && targetColHit → 'both-detour' (8 セグ)
+ *   targetColHit                 → 'target-detour' (6 セグ、core ケース)
+ *   sourceColHit                 → 'source-detour' (6 セグ、鏡像)
+ *   middleRowHit のみ             → 'shift-my' (4 セグ維持)
+ */
+export function detectDiagonalDetour(
+  s: Point,
+  e: Point,
+  obstacles: Bbox[],
+): DiagonalDetourResult | null {
+  if (Math.abs(e.x - s.x) < 2 || Math.abs(e.y - s.y) < 2) return null
+  if (obstacles.length === 0) return null
+  return null
+}
+
 interface ArrowPath {
   d: string
   mx: number

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -158,9 +158,10 @@ export function detectDiagonalDetour(
     )
   })
 
+  const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
+
   if (targetColHits.length > 0 && sourceColHits.length === 0) {
     // 方向決定: target 列障害の左右塞がり判定
-    const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
     const rightBlocked = targetColHits.some((obs) =>
       obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
     )
@@ -175,6 +176,23 @@ export function detectDiagonalDetour(
     const halfDy = Math.abs(e.y - my) / 2
     const approachY = e.y - sign * Math.min(APPROACH_GAP, halfDy)
     return { kind: 'target-detour', my, detourX, approachY }
+  }
+
+  if (sourceColHits.length > 0 && targetColHits.length === 0) {
+    const rightBlocked = sourceColHits.some((obs) =>
+      obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
+    )
+    const leftBlocked = sourceColHits.some((obs) =>
+      obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
+    )
+    const goRight = !rightBlocked || leftBlocked
+    const detourX = goRight
+      ? Math.max(...sourceColHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+      : Math.min(...sourceColHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+    const sign = Math.sign(my - s.y)
+    const halfDy = Math.abs(my - s.y) / 2
+    const departY = s.y + sign * Math.min(DEPART_GAP, halfDy)
+    return { kind: 'source-detour', departY, detourX, my }
   }
 
   return null

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -385,10 +385,18 @@ interface CollectDiagonalObstaclesArgs {
  * from/to 自身と Z字パスから離れたノードは除外する。
  */
 export function collectDiagonalObstacles(args: CollectDiagonalObstaclesArgs): Bbox[] {
-  const { nodes, fromKey, toKey } = args
+  const { nodes, fromKey, toKey, fromCx, fromCy, toCx, toCy, bboxW, bboxH } = args
+  const yLow = Math.min(fromCy, toCy)
+  const yHigh = Math.max(fromCy, toCy)
   const result: Bbox[] = []
   for (const n of nodes) {
     if (n.key === fromKey || n.key === toKey) continue
+    const onSourceCol = Math.abs(n.cx - fromCx) < bboxW / 2 + 2
+    const inZRangeY = n.cy > yLow + 1 && n.cy < yHigh - 1
+    if (onSourceCol && inZRangeY) {
+      result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+      continue
+    }
   }
   return result
 }

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -385,7 +385,7 @@ interface CollectDiagonalObstaclesArgs {
  * from/to 自身と Z字パスから離れたノードは除外する。
  */
 export function collectDiagonalObstacles(args: CollectDiagonalObstaclesArgs): Bbox[] {
-  const { nodes, fromKey, toKey, fromCx, fromCy, toCx, toCy, bboxW, bboxH } = args
+  const { nodes, fromKey, toKey, fromCx, fromCy, toCx, toCy, rowH, colW, bboxW, bboxH } = args
   const yLow = Math.min(fromCy, toCy)
   const yHigh = Math.max(fromCy, toCy)
   const result: Bbox[] = []
@@ -404,6 +404,15 @@ export function collectDiagonalObstacles(args: CollectDiagonalObstaclesArgs): Bb
     const xHigh = Math.max(fromCx, toCx)
     const inZRangeX = n.cx > xLow + 1 && n.cx < xHigh - 1
     if (onMiddleRow && inZRangeX) {
+      result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
+      continue
+    }
+    const onSourceAdjacentCol =
+      Math.abs(n.cx - fromCx) > colW - bboxW / 2 && Math.abs(n.cx - fromCx) < colW + bboxW / 2
+    const onTargetAdjacentCol =
+      Math.abs(n.cx - toCx) > colW - bboxW / 2 && Math.abs(n.cx - toCx) < colW + bboxW / 2
+    const inExtendedY = n.cy >= yLow - rowH / 2 && n.cy <= yHigh + rowH / 2
+    if ((onSourceAdjacentCol || onTargetAdjacentCol) && inExtendedY) {
       result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
       continue
     }

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -364,3 +364,31 @@ export function collectVerticalObstacles(args: CollectVerticalObstaclesArgs): Bb
   }
   return result
 }
+
+interface CollectDiagonalObstaclesArgs {
+  nodes: ObstacleNode[]
+  fromKey: string
+  toKey: string
+  fromCx: number
+  fromCy: number
+  toCx: number
+  toCy: number
+  rowH: number
+  colW: number
+  bboxW: number
+  bboxH: number
+}
+
+/**
+ * 斜め配置矢印 (異行×異レーン) の Z字パスに沿った障害ノードを bbox 配列で返す。
+ * source 列・target 列・中央行・各列の隣接列を広めに収集し、detector 側で再フィルタする。
+ * from/to 自身と Z字パスから離れたノードは除外する。
+ */
+export function collectDiagonalObstacles(args: CollectDiagonalObstaclesArgs): Bbox[] {
+  const { nodes, fromKey, toKey } = args
+  const result: Bbox[] = []
+  for (const n of nodes) {
+    if (n.key === fromKey || n.key === toKey) continue
+  }
+  return result
+}

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -387,6 +387,15 @@ export const buildArrowPath = (
       const d = `M${s.x},${s.y} L${s.x},${departY} L${detourX},${departY} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
       return { d, mx: detourX, my: (s.y + e.y) / 2 }
     }
+
+    const dDetour = detectDiagonalDetour(s, e, obstacles)
+    if (dDetour) {
+      if (dDetour.kind === 'target-detour') {
+        const { my, detourX, approachY } = dDetour
+        const d = `M${s.x},${s.y} L${s.x},${my} L${detourX},${my} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
+        return { d, mx: (s.x + detourX) / 2, my }
+      }
+    }
   }
 
   let d: string

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -116,6 +116,37 @@ type DiagonalDetourResult =
     }
 
 /**
+ * 右優先で迂回 X を決定する。hits 中のいずれかが Y 重なりするブロッカーを直右に持てば右塞がり、
+ * 直左に持てば左塞がり。両塞がりなら右優先 (#333 と整合)。
+ *
+ * blockers は方向判定対象のブロッカー候補。target/source 列同士の相互ブロッキングを防ぐ
+ * ため、both-detour では呼び出し側が反対側列の hits を除外した blockers を渡す。
+ */
+function pickDetourX(hits: Bbox[], blockers: Bbox[]): number {
+  const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
+  const rightBlocked = hits.some((obs) =>
+    blockers.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
+  )
+  const leftBlocked = hits.some((obs) =>
+    blockers.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
+  )
+  const goRight = !rightBlocked || leftBlocked
+  return goRight
+    ? Math.max(...hits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+    : Math.min(...hits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+}
+
+/**
+ * 始点 from から終点 to に向けて gap 分だけオフセットした値を返す。
+ * 自己交差防止のため |to - from| / 2 で clamp。depart Y / approach Y / X の計算で共通化。
+ */
+function clampOffset(from: number, to: number, gap: number): number {
+  const sign = Math.sign(to - from)
+  const halfDist = Math.abs(to - from) / 2
+  return from + sign * Math.min(gap, halfDist)
+}
+
+/**
  * 斜め配置矢印 (異行×異レーン) の Z字パス 3 セグメント (source 縦/中央水平/target 縦) と
  * 障害ノードの衝突を判定し、迂回パスを記述する DiagonalDetourResult を返す。
  * 障害なしまたは斜めでない (水平・垂直直線) ときは null を返す。
@@ -158,80 +189,28 @@ export function detectDiagonalDetour(
     )
   })
 
-  const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
-
   if (sourceColHits.length > 0 && targetColHits.length > 0) {
-    // both-detour では source / target 列それぞれの迂回方向を独立に判定する。
-    // 反対側列の障害（既に対応する迂回で回避済み）を blocking に含めると
-    // 誤った方向選択が発生するため、相互に除外する。
-    const sourceIds = new Set(sourceColHits)
+    // 相互ブロッキング回避: 反対側列の hits は方向判定から除外。対応する迂回パスで既に回避済み。
     const targetIds = new Set(targetColHits)
+    const sourceIds = new Set(sourceColHits)
     const srcBlockers = obstacles.filter((b) => !targetIds.has(b))
     const tgtBlockers = obstacles.filter((b) => !sourceIds.has(b))
-
-    const srcRightBlocked = sourceColHits.some((obs) =>
-      srcBlockers.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
-    )
-    const srcLeftBlocked = sourceColHits.some((obs) =>
-      srcBlockers.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
-    )
-    const srcGoRight = !srcRightBlocked || srcLeftBlocked
-    const sourceDetourX = srcGoRight
-      ? Math.max(...sourceColHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
-      : Math.min(...sourceColHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
-
-    const tgtRightBlocked = targetColHits.some((obs) =>
-      tgtBlockers.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
-    )
-    const tgtLeftBlocked = targetColHits.some((obs) =>
-      tgtBlockers.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
-    )
-    const tgtGoRight = !tgtRightBlocked || tgtLeftBlocked
-    const targetDetourX = tgtGoRight
-      ? Math.max(...targetColHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
-      : Math.min(...targetColHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
-
-    const signS = Math.sign(my - s.y)
-    const halfDyS = Math.abs(my - s.y) / 2
-    const departY = s.y + signS * Math.min(DEPART_GAP, halfDyS)
-    const signE = Math.sign(e.y - my)
-    const halfDyE = Math.abs(e.y - my) / 2
-    const approachY = e.y - signE * Math.min(APPROACH_GAP, halfDyE)
+    const sourceDetourX = pickDetourX(sourceColHits, srcBlockers)
+    const targetDetourX = pickDetourX(targetColHits, tgtBlockers)
+    const departY = clampOffset(s.y, my, DEPART_GAP)
+    const approachY = clampOffset(e.y, my, APPROACH_GAP)
     return { kind: 'both-detour', departY, sourceDetourX, my, targetDetourX, approachY }
   }
 
   if (targetColHits.length > 0 && sourceColHits.length === 0) {
-    // 方向決定: target 列障害の左右塞がり判定
-    const rightBlocked = targetColHits.some((obs) =>
-      obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
-    )
-    const leftBlocked = targetColHits.some((obs) =>
-      obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
-    )
-    const goRight = !rightBlocked || leftBlocked
-    const detourX = goRight
-      ? Math.max(...targetColHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
-      : Math.min(...targetColHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
-    const sign = Math.sign(e.y - my)
-    const halfDy = Math.abs(e.y - my) / 2
-    const approachY = e.y - sign * Math.min(APPROACH_GAP, halfDy)
+    const detourX = pickDetourX(targetColHits, obstacles)
+    const approachY = clampOffset(e.y, my, APPROACH_GAP)
     return { kind: 'target-detour', my, detourX, approachY }
   }
 
   if (sourceColHits.length > 0 && targetColHits.length === 0) {
-    const rightBlocked = sourceColHits.some((obs) =>
-      obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
-    )
-    const leftBlocked = sourceColHits.some((obs) =>
-      obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
-    )
-    const goRight = !rightBlocked || leftBlocked
-    const detourX = goRight
-      ? Math.max(...sourceColHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
-      : Math.min(...sourceColHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
-    const sign = Math.sign(my - s.y)
-    const halfDy = Math.abs(my - s.y) / 2
-    const departY = s.y + sign * Math.min(DEPART_GAP, halfDy)
+    const detourX = pickDetourX(sourceColHits, obstacles)
+    const departY = clampOffset(s.y, my, DEPART_GAP)
     return { kind: 'source-detour', departY, detourX, my }
   }
 
@@ -269,20 +248,9 @@ export function detectDiagonalDetour(
       return { kind: 'shift-my', my: shiftedMy }
     }
     // 範囲外 → 中央障害を targetColHit 扱いで target-detour に昇格
-    const escRightBlocked = middleRowHits.some((obs) =>
-      obstacles.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
-    )
-    const escLeftBlocked = middleRowHits.some((obs) =>
-      obstacles.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
-    )
-    const escGoRight = !escRightBlocked || escLeftBlocked
-    const escDetourX = escGoRight
-      ? Math.max(...middleRowHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
-      : Math.min(...middleRowHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
-    const escSign = Math.sign(e.y - my)
-    const escHalfDy = Math.abs(e.y - my) / 2
-    const escApproachY = e.y - escSign * Math.min(APPROACH_GAP, escHalfDy)
-    return { kind: 'target-detour', my, detourX: escDetourX, approachY: escApproachY }
+    const detourX = pickDetourX(middleRowHits, obstacles)
+    const approachY = clampOffset(e.y, my, APPROACH_GAP)
+    return { kind: 'target-detour', my, detourX, approachY }
   }
 
   return null

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -390,25 +390,31 @@ export const buildArrowPath = (
 
     const dDetour = detectDiagonalDetour(s, e, obstacles)
     if (dDetour) {
-      if (dDetour.kind === 'target-detour') {
-        const { my, detourX, approachY } = dDetour
-        const d = `M${s.x},${s.y} L${s.x},${my} L${detourX},${my} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
-        return { d, mx: (s.x + detourX) / 2, my }
-      }
-      if (dDetour.kind === 'source-detour') {
-        const { departY, detourX, my } = dDetour
-        const d = `M${s.x},${s.y} L${s.x},${departY} L${detourX},${departY} L${detourX},${my} L${e.x},${my} L${e.x},${e.y}`
-        return { d, mx: (detourX + e.x) / 2, my }
-      }
-      if (dDetour.kind === 'both-detour') {
-        const { departY, sourceDetourX, my, targetDetourX, approachY } = dDetour
-        const d = `M${s.x},${s.y} L${s.x},${departY} L${sourceDetourX},${departY} L${sourceDetourX},${my} L${targetDetourX},${my} L${targetDetourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
-        return { d, mx: (sourceDetourX + targetDetourX) / 2, my }
-      }
-      if (dDetour.kind === 'shift-my') {
-        const { my } = dDetour
-        const d = `M${s.x},${s.y} L${s.x},${my} L${e.x},${my} L${e.x},${e.y}`
-        return { d, mx: (s.x + e.x) / 2, my }
+      switch (dDetour.kind) {
+        case 'target-detour': {
+          const { my, detourX, approachY } = dDetour
+          const d = `M${s.x},${s.y} L${s.x},${my} L${detourX},${my} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
+          return { d, mx: (s.x + detourX) / 2, my }
+        }
+        case 'source-detour': {
+          const { departY, detourX, my } = dDetour
+          const d = `M${s.x},${s.y} L${s.x},${departY} L${detourX},${departY} L${detourX},${my} L${e.x},${my} L${e.x},${e.y}`
+          return { d, mx: (detourX + e.x) / 2, my }
+        }
+        case 'both-detour': {
+          const { departY, sourceDetourX, my, targetDetourX, approachY } = dDetour
+          const d = `M${s.x},${s.y} L${s.x},${departY} L${sourceDetourX},${departY} L${sourceDetourX},${my} L${targetDetourX},${my} L${targetDetourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
+          return { d, mx: (sourceDetourX + targetDetourX) / 2, my }
+        }
+        case 'shift-my': {
+          const { my } = dDetour
+          const d = `M${s.x},${s.y} L${s.x},${my} L${e.x},${my} L${e.x},${e.y}`
+          return { d, mx: (s.x + e.x) / 2, my }
+        }
+        default: {
+          const _exhaustive: never = dDetour
+          throw new Error(`Unhandled DiagonalDetourResult kind: ${(_exhaustive as { kind: string }).kind}`)
+        }
       }
     }
   }

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -392,8 +392,9 @@ export function collectDiagonalObstacles(args: CollectDiagonalObstaclesArgs): Bb
   for (const n of nodes) {
     if (n.key === fromKey || n.key === toKey) continue
     const onSourceCol = Math.abs(n.cx - fromCx) < bboxW / 2 + 2
+    const onTargetCol = Math.abs(n.cx - toCx) < bboxW / 2 + 2
     const inZRangeY = n.cy > yLow + 1 && n.cy < yHigh - 1
-    if (onSourceCol && inZRangeY) {
+    if ((onSourceCol || onTargetCol) && inZRangeY) {
       result.push({ x: n.cx, y: n.cy, w: bboxW, h: bboxH })
       continue
     }

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -600,3 +600,81 @@ export function collectDiagonalObstacles(args: CollectDiagonalObstaclesArgs): Bb
   }
   return result
 }
+
+interface BuildObstaclesArgs {
+  nodes: ObstacleNode[]
+  fromKey: string
+  toKey: string
+  fromCx: number
+  fromCy: number
+  toCx: number
+  toCy: number
+  sameRow: boolean
+  sameLane: boolean
+  rowH: number
+  colW: number
+  bboxW: number
+  bboxH: number
+}
+
+/**
+ * 矢印の幾何状態 (同一行 / 同一レーン / 斜め配置) に応じて obstacles を組み立てる。
+ * FlowEditor / SharedFlowViewer の重複を吸収。返り値は detectDetour / detectVerticalDetour /
+ * detectDiagonalDetour にそのまま渡せる Bbox 配列。
+ */
+export function buildObstacles(args: BuildObstaclesArgs): Bbox[] {
+  const {
+    nodes,
+    fromKey,
+    toKey,
+    fromCx,
+    fromCy,
+    toCx,
+    toCy,
+    sameRow,
+    sameLane,
+    rowH,
+    colW,
+    bboxW,
+    bboxH,
+  } = args
+  if (sameRow) {
+    return collectObstacles({
+      nodes,
+      fromKey,
+      toKey,
+      fromCx,
+      toCx,
+      rowY: fromCy,
+      rowH,
+      bboxW,
+      bboxH,
+    })
+  }
+  if (sameLane) {
+    return collectVerticalObstacles({
+      nodes,
+      fromKey,
+      toKey,
+      fromCy,
+      toCy,
+      colX: fromCx,
+      colW,
+      bboxW,
+      bboxH,
+    })
+  }
+  return collectDiagonalObstacles({
+    nodes,
+    fromKey,
+    toKey,
+    fromCx,
+    fromCy,
+    toCx,
+    toCy,
+    rowH,
+    colW,
+    bboxW,
+    bboxH,
+  })
+}

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -213,7 +213,8 @@ export function detectDiagonalDetour(
     return Math.abs(b.y - my) < b.h / 2 + 2 && b.x - b.w / 2 < xHigh - 1 && b.x + b.w / 2 > xLow + 1
   })
 
-  if (middleRowHits.length > 0 && sourceColHits.length === 0 && targetColHits.length === 0) {
+  // 到達条件: sourceColHits / targetColHits は共に空 (上方の if ブロックが早期 return している)
+  if (middleRowHits.length > 0) {
     const xOverlap = (a: Bbox, b: Bbox) => Math.abs(a.x - b.x) < (a.w + b.w) / 2
     const downBlocked = middleRowHits.some((obs) =>
       obstacles.some((b) => b.y > obs.y + 1 && xOverlap(obs, b)),

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -124,12 +124,8 @@ type DiagonalDetourResult =
  */
 function pickDetourX(hits: Bbox[], blockers: Bbox[]): number {
   const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
-  const rightBlocked = hits.some((obs) =>
-    blockers.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
-  )
-  const leftBlocked = hits.some((obs) =>
-    blockers.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
-  )
+  const rightBlocked = hits.some((obs) => blockers.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)))
+  const leftBlocked = hits.some((obs) => blockers.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)))
   const goRight = !rightBlocked || leftBlocked
   return goRight
     ? Math.max(...hits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
@@ -172,9 +168,7 @@ export function detectDiagonalDetour(
     const yLow = Math.min(s.y, my)
     const yHigh = Math.max(s.y, my)
     return (
-      Math.abs(b.x - s.x) < b.w / 2 + 2 &&
-      b.y - b.h / 2 < yHigh - 1 &&
-      b.y + b.h / 2 > yLow + 1
+      Math.abs(b.x - s.x) < b.w / 2 + 2 && b.y - b.h / 2 < yHigh - 1 && b.y + b.h / 2 > yLow + 1
     )
   })
 
@@ -183,9 +177,7 @@ export function detectDiagonalDetour(
     const yLow = Math.min(my, e.y)
     const yHigh = Math.max(my, e.y)
     return (
-      Math.abs(b.x - e.x) < b.w / 2 + 2 &&
-      b.y - b.h / 2 < yHigh - 1 &&
-      b.y + b.h / 2 > yLow + 1
+      Math.abs(b.x - e.x) < b.w / 2 + 2 && b.y - b.h / 2 < yHigh - 1 && b.y + b.h / 2 > yLow + 1
     )
   })
 
@@ -218,11 +210,7 @@ export function detectDiagonalDetour(
   const middleRowHits = obstacles.filter((b) => {
     const xLow = Math.min(s.x, e.x)
     const xHigh = Math.max(s.x, e.x)
-    return (
-      Math.abs(b.y - my) < b.h / 2 + 2 &&
-      b.x - b.w / 2 < xHigh - 1 &&
-      b.x + b.w / 2 > xLow + 1
-    )
+    return Math.abs(b.y - my) < b.h / 2 + 2 && b.x - b.w / 2 < xHigh - 1 && b.x + b.w / 2 > xLow + 1
   })
 
   if (middleRowHits.length > 0 && sourceColHits.length === 0 && targetColHits.length === 0) {
@@ -413,7 +401,9 @@ export const buildArrowPath = (
         }
         default: {
           const _exhaustive: never = dDetour
-          throw new Error(`Unhandled DiagonalDetourResult kind: ${(_exhaustive as { kind: string }).kind}`)
+          throw new Error(
+            `Unhandled DiagonalDetourResult kind: ${(_exhaustive as { kind: string }).kind}`,
+          )
         }
       }
     }

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -160,6 +160,46 @@ export function detectDiagonalDetour(
 
   const yOverlap = (a: Bbox, b: Bbox) => Math.abs(a.y - b.y) < (a.h + b.h) / 2
 
+  if (sourceColHits.length > 0 && targetColHits.length > 0) {
+    // both-detour では source / target 列それぞれの迂回方向を独立に判定する。
+    // 反対側列の障害（既に対応する迂回で回避済み）を blocking に含めると
+    // 誤った方向選択が発生するため、相互に除外する。
+    const sourceIds = new Set(sourceColHits)
+    const targetIds = new Set(targetColHits)
+    const srcBlockers = obstacles.filter((b) => !targetIds.has(b))
+    const tgtBlockers = obstacles.filter((b) => !sourceIds.has(b))
+
+    const srcRightBlocked = sourceColHits.some((obs) =>
+      srcBlockers.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
+    )
+    const srcLeftBlocked = sourceColHits.some((obs) =>
+      srcBlockers.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
+    )
+    const srcGoRight = !srcRightBlocked || srcLeftBlocked
+    const sourceDetourX = srcGoRight
+      ? Math.max(...sourceColHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+      : Math.min(...sourceColHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+
+    const tgtRightBlocked = targetColHits.some((obs) =>
+      tgtBlockers.some((b) => b.x > obs.x + 1 && yOverlap(obs, b)),
+    )
+    const tgtLeftBlocked = targetColHits.some((obs) =>
+      tgtBlockers.some((b) => b.x < obs.x - 1 && yOverlap(obs, b)),
+    )
+    const tgtGoRight = !tgtRightBlocked || tgtLeftBlocked
+    const targetDetourX = tgtGoRight
+      ? Math.max(...targetColHits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+      : Math.min(...targetColHits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+
+    const signS = Math.sign(my - s.y)
+    const halfDyS = Math.abs(my - s.y) / 2
+    const departY = s.y + signS * Math.min(DEPART_GAP, halfDyS)
+    const signE = Math.sign(e.y - my)
+    const halfDyE = Math.abs(e.y - my) / 2
+    const approachY = e.y - signE * Math.min(APPROACH_GAP, halfDyE)
+    return { kind: 'both-detour', departY, sourceDetourX, my, targetDetourX, approachY }
+  }
+
   if (targetColHits.length > 0 && sourceColHits.length === 0) {
     // 方向決定: target 列障害の左右塞がり判定
     const rightBlocked = targetColHits.some((obs) =>


### PR DESCRIPTION
## Summary
- 斜め配置 (異行×異レーン) の Z字矢印が target 列の中間行ノードを貫通するバグを修正
- 新規 `collectDiagonalObstacles` / `detectDiagonalDetour` を `arrow-routing.ts` に追加 (既存 #314 / #333 のロジックには非侵襲)
- Z字パス 3 セグメント (source 縦 / 中央水平 / target 縦) 全てに衝突判定を入れ、4 種類の迂回パターンに分岐:
  - `target-detour` (6 セグ): target 列に障害 — **本 issue の core ケース**
  - `source-detour` (6 セグ): source 列に障害 (鏡像)
  - `both-detour` (8 セグ): 両列に障害
  - `shift-my` (4 セグ): 中央水平のみ衝突 (Z字を維持して `my` を上下シフト)
- `FlowEditor.aPath` / `SharedFlowViewer.computeArrowPath` の obstacles 組み立てに diagonal 分岐を追加
- 23 commits, +9 detector / +12 collector / +9 path tests (合計 +30 tests)

### Design / Plan
- Spec: `docs/superpowers/specs/2026-05-22-issue-346-diagonal-arrow-detour-design.md`
- Plan: `docs/superpowers/plans/2026-05-22-issue-346-diagonal-arrow-detour-plan.md`

Closes #346

## Test plan
- [x] `arrow-routing.test.ts` 全 PASS (72/72): detector / collector / buildArrowPath 統合 / regression guards / Diamond / mutual-blocker exclusion
- [x] フル test suite (1606 passed / 1 skipped) green
- [x] `tsc --noEmit` clean, `npm run build` success
- [ ] 本番デプロイ後、ALLFIT-コンシェルジュ flow (https://flowline.six1.jp/flows/951c20ca-2430-495b-af6d-068795a93c60) で ガイド → 店舗詳細 矢印が 一覧ページを貫通しないことを目視確認
- [ ] 既存 #314 (横方向迂回) / #333 (縦方向迂回) の挙動に regression が無いことを目視確認
- [ ] LCP 1秒以内

## Notes
- `buildArrowPath` の diagonal 分岐は `switch (kind)` + `never` exhaustiveness assertion で型安全に拡張
- `both-detour` の左右塞がり判定で反対側列の hits を除外 (相互ブロッキング誤検出を防止) — spec doc にも明記
- ユニットテストは exact SVG 座標を pin しており、math 的な正しさは fully verified
- 視覚検証は production deploy 後に bug 再現データで確認予定 (local の `/try` モードでは Playwright synthetic event が React handler に届かず再現困難)

🤖 Generated with [Claude Code](https://claude.com/claude-code)