### PR TITLE
feat(#354): show project name badge on dashboard flow cards

### DIFF
--- a/docs/plans/2026-05-22-flowcard-project-badge-design.md
+++ b/docs/plans/2026-05-22-flowcard-project-badge-design.md
@@ -89,14 +89,14 @@ sharedProjects ─────┘
 
 ## エラーハンドリング / エッジケース
 
-| ケース                                                  | 挙動              |
-| ------------------------------------------------------- | ----------------- |
-| `flow.projectId === null`                               | バッジ非表示      |
-| `flow.projectId` が `projects` / `sharedProjects` 両方にない | バッジ非表示      |
-| `flow.projectId` が `sharedProjects` のみに存在         | 共有プロジェクト名を表示 |
-| `selectedNav.startsWith('project:')`                    | バッジ非表示（冗長のため） |
-| プロジェクト名が極端に長い                              | `ellipsis` + `title` 属性でフル名 |
-| `selectedNav === 'trash'`                               | バッジ非表示（trash は別ロジック） |
+| ケース                                                       | 挙動                               |
+| ------------------------------------------------------------ | ---------------------------------- |
+| `flow.projectId === null`                                    | バッジ非表示                       |
+| `flow.projectId` が `projects` / `sharedProjects` 両方にない | バッジ非表示                       |
+| `flow.projectId` が `sharedProjects` のみに存在              | 共有プロジェクト名を表示           |
+| `selectedNav.startsWith('project:')`                         | バッジ非表示（冗長のため）         |
+| プロジェクト名が極端に長い                                   | `ellipsis` + `title` 属性でフル名  |
+| `selectedNav === 'trash'`                                    | バッジ非表示（trash は別ロジック） |
 
 ## テスト戦略
 

--- a/docs/plans/2026-05-22-flowcard-project-badge-design.md
+++ b/docs/plans/2026-05-22-flowcard-project-badge-design.md
@@ -1,0 +1,139 @@
+# FlowCard プロジェクト名バッジ表示 — Design
+
+- **Issue**: [#354](https://github.com/tomohirof/flowline/issues/354)
+- **Date**: 2026-05-22
+
+## 目的
+
+ダッシュボードの「最近」「すべてのファイル」ビューにおいて、各フローカード／リスト行にプロジェクト名バッジを表示し、フローの所属を一目で識別できるようにする。
+
+## スコープ
+
+### 対象
+
+- 「最近」「すべてのファイル」のグリッドビュー / リストビュー
+- 共有プロジェクト所属のフロー
+
+### 非対象
+
+- プロジェクトビュー絞り込み中（バッジ非表示）
+- 共有タブ、ゴミ箱
+- バッジクリックでの絞り込みナビゲート（別 issue 起票）
+
+## アーキテクチャ
+
+### コンポーネント構成
+
+```
+Dashboard.tsx
+├─ projectsById: Map<string, string>  (useMemo, projects + sharedProjects のマージ)
+├─ resolveProjectName(projectId, selectedNav): string | undefined
+│   - selectedNav.startsWith('project:') → undefined
+│   - projectId == null → undefined
+│   - Map にない → undefined
+│   - 該当あり → name
+├─ <FlowCard projectName={resolved} />            (グリッド)
+└─ <ProjectBadge name={resolved} />               (リスト、インラインで配置)
+
+FlowCard.tsx
+├─ props: { ..., projectName?: string }
+└─ .meta 行内に <ProjectBadge name={projectName} /> をレンダー（shareBadge の前）
+
+ProjectBadge.tsx   (新規)
+├─ props: { name: string | undefined }
+└─ name が undefined / 空文字 なら null を返す
+```
+
+### 責務分離
+
+- **`ProjectBadge`**: 純粋表示コンポーネント。受け取った `name` を中性色バッジとしてレンダー。長すぎる名前は `ellipsis` で省略し、`title` 属性でフル名をホバー表示。
+- **`FlowCard`**: `projectName` を受け取り `ProjectBadge` を配置するだけ。プロジェクト解決ロジックは持たない。
+- **`Dashboard`**: プロジェクト解決と表示判定の責務を集約。`useMemo` で `projectsById` Map を構築し、各カードに事前解決した文字列を渡す。
+
+## データフロー
+
+```
+projects(自分所有) ─┐
+                    ├─ useMemo → projectsById: Map<id, name>
+sharedProjects ─────┘
+                                ↓
+                    resolveProjectName(flow.projectId, selectedNav)
+                                ↓
+                    string | undefined
+                                ↓
+                    <FlowCard projectName={...} /> or <ProjectBadge name={...} />
+```
+
+## デザイン仕様
+
+### `ProjectBadge` スタイル
+
+- 背景: `#f1f3f5`（ライトグレー）
+- 文字色: `#525860`（ミッドグレー）
+- フォントサイズ: `10px`（既存 shareBadge と統一）
+- パディング: `1px 6px`
+- border-radius: `4px`
+- `max-width: 120px`
+- `overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap`
+- `display: inline-flex`, `align-items: center`
+
+### バッジ配置
+
+`.meta` 行内に左から順に:
+
+```
+[laneDots] [updatedAt] [ProjectBadge?] [ShareBadge?]
+```
+
+リストビューでも同様に、タイトル横の既存 `shareBadge` の **前** に配置。
+
+## エラーハンドリング / エッジケース
+
+| ケース                                                  | 挙動              |
+| ------------------------------------------------------- | ----------------- |
+| `flow.projectId === null`                               | バッジ非表示      |
+| `flow.projectId` が `projects` / `sharedProjects` 両方にない | バッジ非表示      |
+| `flow.projectId` が `sharedProjects` のみに存在         | 共有プロジェクト名を表示 |
+| `selectedNav.startsWith('project:')`                    | バッジ非表示（冗長のため） |
+| プロジェクト名が極端に長い                              | `ellipsis` + `title` 属性でフル名 |
+| `selectedNav === 'trash'`                               | バッジ非表示（trash は別ロジック） |
+
+## テスト戦略
+
+### `ProjectBadge.test.tsx`（新規）
+
+- `name` 指定時にテキスト表示される
+- `name` が `undefined` の時に `null` を返す
+- `title` 属性に `name` がセットされる
+- `data-testid="project-badge"` が付与される
+
+### `FlowCard.test.tsx`
+
+- `projectName` 指定時にバッジが表示される
+- `projectName` が未指定の場合バッジが表示されない
+- バッジは shareBadge の前に配置される（DOM 順序）
+
+### `Dashboard.test.tsx`
+
+- `projectId` が `projects` に存在 → バッジ表示
+- `projectId === null` → バッジ非表示
+- `projectId` が `sharedProjects` のみに存在 → バッジ表示
+- `projectId` がどこにも存在しない → バッジ非表示
+- `selectedNav === 'project:xxx'` → バッジ非表示
+- リストビュー (`viewMode === 'list'`) でもバッジ表示
+
+## パフォーマンス考慮
+
+- `projectsById` は `useMemo` で構築（`projects` または `sharedProjects` が変わった時のみ再計算）
+- 各カードでのプロジェクト名解決は O(1)
+- LCP 1秒以内維持
+
+## 受け入れ条件
+
+- [ ] 「最近」「すべてのファイル」のグリッド・リスト両ビューで、プロジェクトに紐付くフローにプロジェクト名バッジが表示される
+- [ ] 共有プロジェクト所属のフローも対応
+- [ ] 未分類フロー（`projectId === null`）にはバッジが出ない
+- [ ] プロジェクトビュー絞り込み中はバッジが出ない
+- [ ] 長いプロジェクト名で見切れず ellipsis 表示
+- [ ] テストが追加されすべて pass
+- [ ] LCP 1秒以内を維持

--- a/src/features/dashboard/Dashboard.test.tsx
+++ b/src/features/dashboard/Dashboard.test.tsx
@@ -1448,4 +1448,201 @@ describe('Dashboard', () => {
       expect(screen.getByTestId('project-members-btn')).toBeInTheDocument()
     })
   })
+
+  describe('project badge on flow card (#354)', () => {
+    const flowInP1 = {
+      id: 'flow-p1',
+      title: 'プロジェクトP1のフロー',
+      themeId: 'cloud',
+      shareToken: null,
+      projectId: 'p1',
+      createdAt: '2026-01-15T10:00:00Z',
+      updatedAt: '2026-01-15T10:00:00Z',
+    }
+    const flowInShared = {
+      id: 'flow-shared',
+      title: '共有プロジェクトのフロー',
+      themeId: 'cloud',
+      shareToken: null,
+      projectId: 'shared-p1',
+      createdAt: '2026-01-15T10:00:00Z',
+      updatedAt: '2026-01-15T10:00:00Z',
+    }
+    const flowUncategorized = {
+      id: 'flow-unc',
+      title: '未分類フロー',
+      themeId: 'cloud',
+      shareToken: null,
+      projectId: null,
+      createdAt: '2026-01-15T10:00:00Z',
+      updatedAt: '2026-01-15T10:00:00Z',
+    }
+    const flowOrphan = {
+      id: 'flow-orphan',
+      title: '削除済みプロジェクトのフロー',
+      themeId: 'cloud',
+      shareToken: null,
+      projectId: 'deleted-project-id',
+      createdAt: '2026-01-15T10:00:00Z',
+      updatedAt: '2026-01-15T10:00:00Z',
+    }
+
+    it('should show project badge for owned project flow', async () => {
+      mockFetchProjects.mockResolvedValueOnce({
+        projects: [
+          {
+            id: 'p1',
+            name: 'プロジェクトA',
+            createdAt: '2026-01-01T00:00:00Z',
+            updatedAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      })
+      mockApiFetch.mockResolvedValueOnce({ flows: [flowInP1] })
+
+      renderDashboard()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('flow-card-flow-p1')).toBeInTheDocument()
+      })
+      const card = screen.getByTestId('flow-card-flow-p1')
+      const badge = card.querySelector('[data-testid="project-badge"]')
+      expect(badge).not.toBeNull()
+      expect(badge!.textContent).toBe('プロジェクトA')
+    })
+
+    it('should show project badge for shared project flow', async () => {
+      mockFetchProjects.mockResolvedValueOnce({ projects: [] })
+      sharedProjectsFetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          projects: [
+            {
+              id: 'shared-p1',
+              name: '共有プロジェクトX',
+              ownerName: 'Alice',
+            },
+          ],
+        }),
+      )
+      mockApiFetch.mockResolvedValueOnce({ flows: [flowInShared] })
+
+      renderDashboard()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('flow-card-flow-shared')).toBeInTheDocument()
+      })
+      await waitFor(() => {
+        const card = screen.getByTestId('flow-card-flow-shared')
+        const badge = card.querySelector('[data-testid="project-badge"]')
+        expect(badge).not.toBeNull()
+        expect(badge!.textContent).toBe('共有プロジェクトX')
+      })
+    })
+
+    it('should not show project badge for uncategorized flow', async () => {
+      mockFetchProjects.mockResolvedValueOnce({
+        projects: [
+          {
+            id: 'p1',
+            name: 'プロジェクトA',
+            createdAt: '2026-01-01T00:00:00Z',
+            updatedAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      })
+      mockApiFetch.mockResolvedValueOnce({ flows: [flowUncategorized] })
+
+      renderDashboard()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('flow-card-flow-unc')).toBeInTheDocument()
+      })
+      const card = screen.getByTestId('flow-card-flow-unc')
+      expect(card.querySelector('[data-testid="project-badge"]')).toBeNull()
+    })
+
+    it('should not show project badge when projectId does not match any project (deleted)', async () => {
+      mockFetchProjects.mockResolvedValueOnce({ projects: [] })
+      mockApiFetch.mockResolvedValueOnce({ flows: [flowOrphan] })
+
+      renderDashboard()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('flow-card-flow-orphan')).toBeInTheDocument()
+      })
+      const card = screen.getByTestId('flow-card-flow-orphan')
+      expect(card.querySelector('[data-testid="project-badge"]')).toBeNull()
+    })
+
+    it('should not show project badge when in project view (project:xxx)', async () => {
+      mockFetchProjects.mockResolvedValueOnce({
+        projects: [
+          {
+            id: 'p1',
+            name: 'プロジェクトA',
+            createdAt: '2026-01-01T00:00:00Z',
+            updatedAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      })
+      // 初期 fetch (recent)
+      mockApiFetch.mockResolvedValueOnce({ flows: [flowInP1] })
+      // プロジェクトクリック後の filtered fetch
+      mockApiFetch.mockResolvedValueOnce({ flows: [flowInP1] })
+
+      renderDashboard()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('flow-card-flow-p1')).toBeInTheDocument()
+      })
+
+      // プロジェクト選択前: バッジ表示
+      expect(
+        screen.getByTestId('flow-card-flow-p1').querySelector('[data-testid="project-badge"]'),
+      ).not.toBeNull()
+
+      await userEvent.click(screen.getByTestId('project-item-p1'))
+
+      await waitFor(() => {
+        expect(mockApiFetch).toHaveBeenCalledWith('/flows?projectId=p1')
+      })
+      // プロジェクトビュー中はバッジ非表示
+      await waitFor(() => {
+        const card = screen.getByTestId('flow-card-flow-p1')
+        expect(card.querySelector('[data-testid="project-badge"]')).toBeNull()
+      })
+    })
+
+    it('should show project badge in list view', async () => {
+      const user = userEvent.setup()
+      mockFetchProjects.mockResolvedValueOnce({
+        projects: [
+          {
+            id: 'p1',
+            name: 'プロジェクトA',
+            createdAt: '2026-01-01T00:00:00Z',
+            updatedAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      })
+      mockApiFetch.mockResolvedValueOnce({ flows: [flowInP1] })
+
+      renderDashboard()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('flow-card-flow-p1')).toBeInTheDocument()
+      })
+
+      // リストビューに切り替え
+      await user.click(screen.getByTestId('view-list-button'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('dashboard-list')).toBeInTheDocument()
+      })
+      const row = screen.getByTestId('flow-card-flow-p1')
+      const badge = row.querySelector('[data-testid="project-badge"]')
+      expect(badge).not.toBeNull()
+      expect(badge!.textContent).toBe('プロジェクトA')
+    })
+  })
 })

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../lib/api'
 import type { FlowListResponse, FlowSummary, FlowDetailResponse, Project } from '../editor/types'
 import { FlowCard } from './FlowCard'
+import { ProjectBadge } from './ProjectBadge'
 import { FlowContextMenu } from './FlowContextMenu'
 import { DashboardTopBar } from './DashboardTopBar'
 import { DashboardSidebar } from './DashboardSidebar'
@@ -231,6 +232,24 @@ export function Dashboard() {
     }
     return sortedFlows
   }, [selectedNav, sortedFlows])
+
+  // プロジェクトID→名前の解決マップ（自分所有 + 共有プロジェクトをマージ）
+  const projectsById = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const p of projects) map.set(p.id, p.name)
+    for (const p of sharedProjects) map.set(p.id, p.name)
+    return map
+  }, [projects, sharedProjects])
+
+  // フローのプロジェクト名を解決。プロジェクトビュー中／未分類／削除済みは undefined。
+  const resolveProjectName = useCallback(
+    (projectId: string | null): string | undefined => {
+      if (!projectId) return undefined
+      if (selectedNav.startsWith('project:')) return undefined
+      return projectsById.get(projectId)
+    },
+    [projectsById, selectedNav],
+  )
 
   const handleCreateProject = async () => {
     const name = prompt(t('dashboard:project.promptName'))
@@ -729,6 +748,7 @@ export function Dashboard() {
                       isHovered={hoveredId === flow.id}
                       onHover={setHoveredId}
                       renamingId={renamingId}
+                      projectName={resolveProjectName(flow.projectId)}
                     />
                   ))}
                 </div>
@@ -757,6 +777,7 @@ export function Dashboard() {
                         >
                           {flow.title}
                         </Link>
+                        <ProjectBadge name={resolveProjectName(flow.projectId)} />
                         {flow.shareToken && (
                           <span
                             data-testid={`share-badge-${flow.id}`}

--- a/src/features/dashboard/FlowCard.test.tsx
+++ b/src/features/dashboard/FlowCard.test.tsx
@@ -52,6 +52,7 @@ describe('FlowCard', () => {
     isHovered: false,
     onHover: vi.fn(),
     renamingId: null as string | null,
+    projectName: undefined as string | undefined,
   }
 
   function renderCard(overrides: Partial<typeof defaultProps> = {}) {
@@ -101,6 +102,40 @@ describe('FlowCard', () => {
   it('should not show share badge when flow has no shareToken', () => {
     renderCard()
     expect(screen.queryByTestId('share-badge-flow-1')).not.toBeInTheDocument()
+  })
+
+  // --- プロジェクトバッジ (#354) ---
+
+  it('should show project badge when projectName is provided', () => {
+    renderCard({ projectName: 'プロジェクトA' })
+    expect(screen.getByTestId('project-badge')).toBeInTheDocument()
+    expect(screen.getByText('プロジェクトA')).toBeInTheDocument()
+  })
+
+  it('should not show project badge when projectName is undefined', () => {
+    renderCard()
+    expect(screen.queryByTestId('project-badge')).not.toBeInTheDocument()
+  })
+
+  it('should not show project badge when projectName is empty string', () => {
+    renderCard({ projectName: '' })
+    expect(screen.queryByTestId('project-badge')).not.toBeInTheDocument()
+  })
+
+  it('should render project badge before share badge in DOM order', () => {
+    const flowWithShare: FlowSummary = { ...baseFlow, shareToken: 'token-abc' }
+    renderCard({
+      flow: flowWithShare,
+      projectName: 'プロジェクトA',
+    })
+    const card = screen.getByTestId('flow-card-flow-1')
+    const projectBadge = card.querySelector('[data-testid="project-badge"]')
+    const shareBadge = card.querySelector('[data-testid="share-badge-flow-1"]')
+    expect(projectBadge).not.toBeNull()
+    expect(shareBadge).not.toBeNull()
+    const pos =
+      projectBadge!.compareDocumentPosition(shareBadge!) & Node.DOCUMENT_POSITION_FOLLOWING
+    expect(pos).toBeTruthy()
   })
 
   // --- 削除 ---

--- a/src/features/dashboard/FlowCard.tsx
+++ b/src/features/dashboard/FlowCard.tsx
@@ -5,6 +5,7 @@ import type { FlowSummary } from '../editor/types'
 import { PALETTES } from '../editor/theme-constants'
 import { formatRelativeTime } from '../../utils/formatRelativeTime'
 import { FlowThumbnail } from './FlowThumbnail'
+import { ProjectBadge } from './ProjectBadge'
 import styles from './FlowCard.module.css'
 
 interface FlowCardProps {
@@ -18,6 +19,7 @@ interface FlowCardProps {
   renamingId: string | null
   isTrash?: boolean
   onRestore?: (id: string) => void
+  projectName?: string
 }
 
 const DEFAULT_LANE_COUNT = 3
@@ -34,6 +36,7 @@ export function FlowCard({
   renamingId,
   isTrash = false,
   onRestore,
+  projectName,
 }: FlowCardProps) {
   const { t, i18n } = useTranslation(['dashboard', 'common'])
   const isRenaming = renamingId === flow.id
@@ -198,6 +201,7 @@ export function FlowCard({
                   time: formatRelativeTime(flow.updatedAt, i18n.language),
                 })}
           </span>
+          <ProjectBadge name={projectName} />
           {flow.shareToken && (
             <span data-testid={`share-badge-${flow.id}`} className={styles.shareBadge}>
               {t('dashboard:action.shared')}

--- a/src/features/dashboard/ProjectBadge.module.css
+++ b/src/features/dashboard/ProjectBadge.module.css
@@ -1,0 +1,13 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 10px;
+  color: #525860;
+  background: #f1f3f5;
+  padding: 1px 6px;
+  border-radius: 4px;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/features/dashboard/ProjectBadge.test.tsx
+++ b/src/features/dashboard/ProjectBadge.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { ProjectBadge } from './ProjectBadge'
+
+describe('ProjectBadge', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('should render project name when name is provided', () => {
+    render(<ProjectBadge name="プロジェクトA" />)
+    expect(screen.getByText('プロジェクトA')).toBeInTheDocument()
+  })
+
+  it('should render with data-testid="project-badge"', () => {
+    render(<ProjectBadge name="プロジェクトA" />)
+    expect(screen.getByTestId('project-badge')).toBeInTheDocument()
+  })
+
+  it('should set title attribute to full name (for ellipsis hover)', () => {
+    render(<ProjectBadge name="REFINVERSE Group, Inc." />)
+    const badge = screen.getByTestId('project-badge')
+    expect(badge).toHaveAttribute('title', 'REFINVERSE Group, Inc.')
+  })
+
+  it('should return null when name is undefined', () => {
+    const { container } = render(<ProjectBadge name={undefined} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('should return null when name is empty string', () => {
+    const { container } = render(<ProjectBadge name="" />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/src/features/dashboard/ProjectBadge.tsx
+++ b/src/features/dashboard/ProjectBadge.tsx
@@ -1,0 +1,14 @@
+import styles from './ProjectBadge.module.css'
+
+interface Props {
+  name: string | undefined
+}
+
+export function ProjectBadge({ name }: Props) {
+  if (!name) return null
+  return (
+    <span data-testid="project-badge" className={styles.badge} title={name}>
+      {name}
+    </span>
+  )
+}


### PR DESCRIPTION
## Summary
- Closes #354
- ダッシュボードの「最近」「すべてのファイル」グリッド/リスト両ビューで、フローが所属するプロジェクト名を中性色バッジとして表示
- `ProjectBadge` コンポーネントを切り出し、`FlowCard` と Dashboard リストビューで再利用
- `useMemo` で `projectsById` Map を構築（自分所有 + 共有プロジェクトをマージ）
- 「プロジェクトビュー絞り込み中」「未分類」「削除済みプロジェクト」ではバッジ非表示

## Visual
- バッジ配置: `[laneDots] [updatedAt] [ProjectBadge?] [ShareBadge?]`（所属 → 状態属性の情報階層）
- スタイル: 背景 \`#f1f3f5\` / 文字 \`#525860\` / max-width: 120px / ellipsis + title

## Test plan
- [x] `ProjectBadge.test.tsx`: 表示/非表示/title 属性/空文字フォールバック (5 tests)
- [x] `FlowCard.test.tsx`: projectName 有無/DOM順序 (4 tests追加)
- [x] `Dashboard.test.tsx`: 自分所有/共有/未分類/削除済み/プロジェクトビュー/リストビュー (6 tests追加)
- [x] 全テスト pass: 1645 passed
- [x] 実画面検証: Playwright でバッジ表示確認（グリッド・リスト両ビュー）
- [x] LCP 60ms (基準: 1秒以内)

## Acceptance Criteria
- [x] 「最近」「すべてのファイル」のグリッド・リスト両ビューでバッジ表示
- [x] 共有プロジェクト所属のフローも対応
- [x] 未分類フローにはバッジ非表示
- [x] プロジェクトビュー絞り込み中はバッジ非表示
- [x] 長いプロジェクト名で ellipsis 表示
- [x] テスト追加 & 全 pass
- [x] LCP 1秒以内維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)