### PR TITLE
refactor(#356): unify SharedFlowViewer arrow path via calcArrowPath

### DIFF
--- a/docs/superpowers/plans/2026-05-22-shared-calcarrowpath-plan.md
+++ b/docs/superpowers/plans/2026-05-22-shared-calcarrowpath-plan.md
@@ -1,0 +1,176 @@
+# SharedFlowViewer calcArrowPath 統一 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** SharedFlowViewer の矢印パス計算を FlowEditor と同じ `calcArrowPath` ラッパー経由に統一する。
+
+**Architecture:** `src/features/shared/SharedFlowViewer.tsx:computeArrowPath` 内の `exitPt → entryPt → buildArrowPath` 直呼び出しを `calcArrowPath` 1 呼び出しに置換。obstacles 計算はそのまま残す（`calcArrowPath` は obstacles を受け取る）。
+
+**Tech Stack:** TypeScript, React, Vitest
+
+**Spec:** [docs/superpowers/specs/2026-05-22-shared-calcarrowpath-design.md](../specs/2026-05-22-shared-calcarrowpath-design.md)
+
+**Issue:** #356
+
+---
+
+## Task 1: SharedFlowViewer の computeArrowPath 置換
+
+**Files:**
+
+- Modify: `src/features/shared/SharedFlowViewer.tsx`
+
+- [ ] **Step 1: imports を更新**
+
+`src/features/shared/SharedFlowViewer.tsx` の 10-19 行目（arrow-routing からの import 群）を以下に変更:
+
+Before:
+
+```ts
+import {
+  exitPt,
+  entryPt,
+  buildArrowPath,
+  buildObstacles,
+  DS,
+  type Point,
+  type Bbox,
+  type ObstacleNode,
+} from '../../lib/arrow-routing'
+```
+
+After:
+
+```ts
+import {
+  buildObstacles,
+  DS,
+  type Point,
+  type Bbox,
+  type ObstacleNode,
+} from '../../lib/arrow-routing'
+import { calcArrowPath } from '../../lib/flow-engine'
+```
+
+- [ ] **Step 2: computeArrowPath 本体を置換**
+
+`computeArrowPath` 関数の 129-138 行目および 157 行目を変更。
+
+Before（129-138 行目）:
+
+```ts
+const s = exitPt(
+  f,
+  t,
+  hw,
+  hh,
+  RH,
+  fromNode.shape as 'diamond' | undefined,
+  arrow.fromSide ?? undefined,
+)
+const e = entryPt(t, f, hw, hh, RH, toNode.shape as 'diamond' | undefined)
+```
+
+これら 10 行を削除する（変数 `s`, `e` も不要になる）。
+
+Before（157 行目）:
+
+```ts
+return buildArrowPath(s, e, f, t, obstacles)
+```
+
+After（157 行目相当）:
+
+```ts
+return calcArrowPath(
+  f,
+  t,
+  {
+    hw,
+    hh,
+    rh: RH,
+    fromShape: fromNode.shape as 'diamond' | undefined,
+    toShape: toNode.shape as 'diamond' | undefined,
+    fromSide: arrow.fromSide ?? undefined,
+  },
+  obstacles,
+)
+```
+
+`buildObstacles({...})` の呼び出し（141-155 行目）はそのまま残す。
+
+- [ ] **Step 3: 型チェック pass**
+
+Run: `npx tsc -b --pretty`
+Expected: エラーなし。
+
+- [ ] **Step 4: 既存テスト pass**
+
+Run: `npm test`
+Expected: 全テスト pass。
+
+- [ ] **Step 5: ビルド pass**
+
+Run: `npm run build`
+Expected: ビルド成功。
+
+- [ ] **Step 6: prettier フォーマット**
+
+Run: `npx prettier --write src/features/shared/SharedFlowViewer.tsx`
+Expected: フォーマット適用（または既に整形済みなら no-op）。
+
+---
+
+## Task 2: 共有ビュー目視確認
+
+**Files:** なし
+
+- [ ] **Step 1: dev サーバ起動 & ログイン**
+
+`npm run dev:frontend` → ブラウザで `.env.local` の `E2E_USER_EMAIL`/`E2E_USER_PASSWORD` を使ってログイン。
+
+- [ ] **Step 2: 矢印を含むフローを開く**
+
+ダッシュボードから矢印を含む flow を選択してエディタを開く。
+
+- [ ] **Step 3: エディタの矢印描画スクリーンショット**
+
+`.screenshots/356-editor-arrows-after.png` に保存。
+
+- [ ] **Step 4: 同じ flow の共有 URL を開く**
+
+エディタで「共有」→ URL コピー → 別タブで開く。
+
+- [ ] **Step 5: 共有ビューの矢印描画スクリーンショット**
+
+`.screenshots/356-shared-arrows-after.png` に保存。
+
+- [ ] **Step 6: 2 枚を比較**
+
+エディタと共有ビューで矢印のパス・位置・角度がすべて完全一致していることを確認。  
+特に: ひし形ノードを含む矢印で `fromSide` が指定されている場合、両者で同じ頂点から出ていること。
+
+- [ ] **Step 7: LCP 確認**
+
+DevTools Performance で LCP を測定。1 秒以内であることを確認。
+
+---
+
+## Task 3: コミット & PR & レビュー
+
+CLAUDE.md workflow Step 7-9 に従う:
+
+- `git pull origin main --rebase && npm test`
+- commit（メッセージ: `refactor(#356): unify SharedFlowViewer arrow path via calcArrowPath`）
+- push & `gh pr create`
+- `gh pr checks --watch`
+- `@claude` レビュー依頼
+- レビュー判定が [C:承認OK] になるまでループ
+
+## Task 4: Merge & Cleanup
+
+CLAUDE.md workflow Step 10-11:
+
+- `gh pr merge --merge`
+- main 更新、デプロイ確認
+- worktree remove + branch -d

--- a/docs/superpowers/specs/2026-05-22-shared-calcarrowpath-design.md
+++ b/docs/superpowers/specs/2026-05-22-shared-calcarrowpath-design.md
@@ -1,0 +1,81 @@
+# SharedFlowViewer の矢印描画を calcArrowPath に統一
+
+- 関連 issue: #356
+- 関連 PR: #352 (#349)
+- 関連バグ: #69（共有ビュー描画とエディタの不整合）
+
+## 背景
+
+`SharedFlowViewer.tsx:129-157` は `exitPt → entryPt → buildArrowPath` を直接呼び出している。一方 `FlowEditor.tsx` は同じ 3 呼び出しを `calcArrowPath` ラッパー（`src/lib/flow-engine.ts:35-46`）に集約済み。
+
+機能上の問題はないが、将来 `calcArrowPath` の内部に変更があった場合 SharedFlowViewer 側が追従漏れを起こすリスクがある。実際 #69 で同種の不整合バグの実績あり。
+
+## 目標
+
+- SharedFlowViewer も `calcArrowPath` 経由で矢印パスを計算するよう統一
+- 描画結果は完全一致（リグレッションなし）
+
+## 非目標
+
+- `buildObstacles` 周りの変更。`calcArrowPath` は `obstacles?: Bbox[]` を受け取る薄いラッパーなので、obstacles 構築ロジックはこれまで通り呼び出し側に残す。
+- `DS` 定数の扱い変更（diamond polygon points で `SharedFlowViewer:375` が引き続き使用）。
+
+## 変更内容
+
+### Before（SharedFlowViewer.tsx:129-157 抜粋）
+
+```ts
+const s = exitPt(
+  f,
+  t,
+  hw,
+  hh,
+  RH,
+  fromNode.shape as 'diamond' | undefined,
+  arrow.fromSide ?? undefined,
+)
+const e = entryPt(t, f, hw, hh, RH, toNode.shape as 'diamond' | undefined)
+// ... buildObstacles({...})
+return buildArrowPath(s, e, f, t, obstacles)
+```
+
+### After
+
+```ts
+// ... buildObstacles({...}) は変更なし
+return calcArrowPath(
+  f,
+  t,
+  {
+    hw,
+    hh,
+    rh: RH,
+    fromShape: fromNode.shape as 'diamond' | undefined,
+    toShape: toNode.shape as 'diamond' | undefined,
+    fromSide: arrow.fromSide ?? undefined,
+  },
+  obstacles,
+)
+```
+
+### import の整理
+
+`src/features/shared/SharedFlowViewer.tsx` のトップレベル import から `exitPt`, `entryPt`, `buildArrowPath` を削除（未使用となる）。`buildObstacles`, `DS`, `Point`, `Bbox`, `ObstacleNode` は引き続き使用するため残す。
+
+`calcArrowPath` を `../../lib/flow-engine` から import。
+
+## 検証
+
+- 既存テスト（vitest）全 pass
+- 共有 URL を開いて矢印描画がエディタと完全一致することを目視確認
+- `npm run build` / `npx tsc -b` pass
+- LCP 1 秒以内（リファクタなので変化なし想定）
+
+## 影響範囲
+
+- 変更: `src/features/shared/SharedFlowViewer.tsx` のみ
+- 行数: imports 3 行削除 + 1 行追加、関数本体 ~10 行 → 1 関数呼び出しに置換
+
+## 工数
+
+30 分以内

--- a/src/features/shared/SharedFlowViewer.tsx
+++ b/src/features/shared/SharedFlowViewer.tsx
@@ -8,15 +8,13 @@ import styles from './SharedFlowViewer.module.css'
 import { NodeLabelText } from './NodeLabelText'
 import { calcLaneWidth } from '../editor/calcLaneWidth'
 import {
-  exitPt,
-  entryPt,
-  buildArrowPath,
   buildObstacles,
   DS,
   type Point,
   type Bbox,
   type ObstacleNode,
 } from '../../lib/arrow-routing'
+import { calcArrowPath } from '../../lib/flow-engine'
 import { formatRelativeTime } from '../../lib/relative-time'
 import { isGroupSub, isGroupParent, getGroupWidth } from '../../lib/lane-group-utils'
 import { parseNote, measureMemoHeight, MEMO_W } from '../editor/memo-utils'
@@ -126,17 +124,6 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
     const t = ct(tli, toNode.rowIndex)
     const hw = TW / 2,
       hh = TH / 2
-    const s = exitPt(
-      f,
-      t,
-      hw,
-      hh,
-      RH,
-      fromNode.shape as 'diamond' | undefined,
-      arrow.fromSide ?? undefined,
-    )
-    const e = entryPt(t, f, hw, hh, RH, toNode.shape as 'diamond' | undefined)
-
     // 同一行/同一レーン/斜め配置に応じて obstacles を組み立てる（迂回判定用）
     const obstacles: Bbox[] = buildObstacles({
       nodes: obstacleNodes,
@@ -154,7 +141,19 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
       bboxH: TH,
     })
 
-    return buildArrowPath(s, e, f, t, obstacles)
+    return calcArrowPath(
+      f,
+      t,
+      {
+        hw,
+        hh,
+        rh: RH,
+        fromShape: fromNode.shape as 'diamond' | undefined,
+        toShape: toNode.shape as 'diamond' | undefined,
+        fromSide: arrow.fromSide ?? undefined,
+      },
+      obstacles,
+    )
   }
 
   const arrowPaths = flow.arrows


### PR DESCRIPTION
## Summary
- `SharedFlowViewer.computeArrowPath` 内の `exitPt → entryPt → buildArrowPath` 直呼び出しを `calcArrowPath` ラッパー経由に統一
- FlowEditor と同じコードパスを通るため、#69 と同種の divergence バグを構造的に防止
- `buildObstacles` の obstacles 構築ロジックはそのまま残す（`calcArrowPath` は obstacles を受け取る）

## なぜ機械的等価か
`calcArrowPath` ([src/lib/flow-engine.ts:35-46](../blob/main/src/lib/flow-engine.ts#L35-L46)) は内部で同じ 3 関数を同じ順序・同じ引数で呼ぶ薄いラッパー:

```ts
const s = exitPt(f, t, config.hw, config.hh, config.rh, config.fromShape, config.fromSide)
const e = entryPt(t, f, config.hw, config.hh, config.rh, config.toShape)
return buildArrowPath(s, e, f, t, obstacles)
```

`src/features/shared/SharedFlowViewer.tsx` の置換前後でこの 3 呼び出しの引数は完全一致。

## Test plan
- [x] `npm test` 全 1645 テスト pass
- [x] `npm run build` vite ビルド成功
- [x] `npx tsc -b` 型チェック pass
- [x] `npx prettier --check` フォーマット OK
- [x] `calcArrowPath` の挙動は `flow-engine.test.ts` の 10 ケース（diamond fromSide 含む）でカバー済み
- [ ] 共有 URL でエディタと矢印描画完全一致を目視確認 _（ローカル wrangler API auth が 500 エラーで未実施。リファクタが機械的等価かつテスト網羅性が高いため低リスクと判断。Cloudflare Pages preview で確認推奨）_

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)