### PR TITLE
feat(#355): add toSide and rectangle side support

### DIFF
--- a/api/lib/flow-transform.ts
+++ b/api/lib/flow-transform.ts
@@ -55,6 +55,7 @@ export interface ArrowRow {
   dash: string | null
   bidirectional: number | null
   from_side: ArrowSide | null
+  to_side: ArrowSide | null
   created_at: string
   updated_at: string
 }
@@ -113,6 +114,7 @@ export function toArrow(row: ArrowRow) {
     dash: row.dash,
     bidirectional: row.bidirectional === 1,
     fromSide: row.from_side,
+    toSide: row.to_side,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }

--- a/api/lib/validators.ts
+++ b/api/lib/validators.ts
@@ -35,6 +35,7 @@ const arrowSchema = z.object({
   dash: z.string().nullable().optional(),
   bidirectional: z.boolean().optional(),
   fromSide: z.enum(['top', 'right', 'bottom', 'left']).nullable().optional(),
+  toSide: z.enum(['top', 'right', 'bottom', 'left']).nullable().optional(),
 })
 
 export const createFlowSchema = z.object({

--- a/api/routes/flows.ts
+++ b/api/routes/flows.ts
@@ -288,7 +288,7 @@ flows.post('/', async (c) => {
     statements.push(
       db
         .prepare(
-          'INSERT INTO arrows (id, flow_id, from_node_id, to_node_id, comment, color, dash, bidirectional, from_side) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+          'INSERT INTO arrows (id, flow_id, from_node_id, to_node_id, comment, color, dash, bidirectional, from_side, to_side) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
         )
         .bind(
           arrow.id,
@@ -300,6 +300,7 @@ flows.post('/', async (c) => {
           arrow.dash ?? null,
           arrow.bidirectional ? 1 : 0,
           arrow.fromSide ?? null,
+          arrow.toSide ?? null,
         ),
     )
   }
@@ -444,7 +445,7 @@ flows.put('/:id', async (c) => {
         statements.push(
           db
             .prepare(
-              'INSERT INTO arrows (id, flow_id, from_node_id, to_node_id, comment, color, dash, bidirectional, from_side) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+              'INSERT INTO arrows (id, flow_id, from_node_id, to_node_id, comment, color, dash, bidirectional, from_side, to_side) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             )
             .bind(
               arrow.id,
@@ -456,6 +457,7 @@ flows.put('/:id', async (c) => {
               arrow.dash ?? null,
               arrow.bidirectional ? 1 : 0,
               arrow.fromSide ?? null,
+              arrow.toSide ?? null,
             ),
         )
       }

--- a/docs/superpowers/plans/2026-05-22-toside-rect-plan.md
+++ b/docs/superpowers/plans/2026-05-22-toside-rect-plan.md
@@ -1,0 +1,724 @@
+# toSide + 四角形ノード side 指定 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 矢印に `toSide` を追加し、四角形ノードでも `fromSide`/`toSide` を honor するようにする。UI に「入口側」セレクタを追加。
+
+**Architecture:**
+
+- `shared/ArrowSide` 型を使い回し、`InternalArrow.toSide` フィールドを追加
+- `exitPt` / `entryPt` の四角形分岐にも fromSide / toSide 早期 return を入れる
+- `deriveToSide = deriveFromSide`（数学的に同一）
+- DB に `to_side TEXT` カラム追加、API ラウンドトリップ完備
+- RightPanel の「出口側」 diamond ガードを撤廃、「入口側」セクションを追加
+
+**Tech Stack:** TypeScript, React, Vitest, Cloudflare Workers D1, Zod, i18next
+
+**Spec:** [docs/superpowers/specs/2026-05-22-toside-rect-design.md](../specs/2026-05-22-toside-rect-design.md)
+
+**Issue:** #355
+
+---
+
+## Task 1: arrow-routing 拡張（TDD）
+
+**Files:**
+
+- Modify: `src/lib/arrow-routing.ts`
+- Modify: `src/lib/arrow-routing.test.ts`
+
+### Step 1: 失敗するテストを書く（exitPt 四角形 + fromSide）
+
+`src/lib/arrow-routing.test.ts` の `exitPt` describe ブロック内に追加:
+
+```ts
+describe('exitPt 四角形ノード fromSide honor', () => {
+  const c = { x: 100, y: 100 }
+  const o = { x: 200, y: 100 } // 任意の相手位置
+  const hw = 50,
+    hh = 25,
+    rh = 84
+  it('四角形 + fromSide=top → 上辺中央', () => {
+    expect(exitPt(c, o, hw, hh, rh, undefined, 'top')).toEqual({ x: 100, y: 75 })
+  })
+  it('四角形 + fromSide=right → 右辺中央', () => {
+    expect(exitPt(c, o, hw, hh, rh, undefined, 'right')).toEqual({ x: 150, y: 100 })
+  })
+  it('四角形 + fromSide=bottom → 下辺中央', () => {
+    expect(exitPt(c, o, hw, hh, rh, undefined, 'bottom')).toEqual({ x: 100, y: 125 })
+  })
+  it('四角形 + fromSide=left → 左辺中央', () => {
+    expect(exitPt(c, o, hw, hh, rh, undefined, 'left')).toEqual({ x: 50, y: 100 })
+  })
+  it('四角形 + fromSide=undefined → 既存の auto ロジック (右向き)', () => {
+    // dx > 0 で水平方向 → 右辺
+    expect(exitPt(c, o, hw, hh, rh, undefined, undefined)).toEqual({ x: 150, y: 100 })
+  })
+})
+```
+
+Run: `npx vitest run src/lib/arrow-routing.test.ts -t "exitPt 四角形ノード fromSide honor"`
+Expected: 4 件 FAIL（"toEqual" assertion 不一致、auto ケースは現状ロジックで PASS）
+
+### Step 2: 失敗するテストを書く（entryPt toSide）
+
+同じく `arrow-routing.test.ts` に追加:
+
+```ts
+describe('entryPt toSide honor', () => {
+  const c = { x: 100, y: 100 }
+  const o = { x: 200, y: 100 }
+  const hw = 50,
+    hh = 25,
+    rh = 84
+  it('四角形 + toSide=top → 上辺中央', () => {
+    expect(entryPt(c, o, hw, hh, rh, undefined, 'top')).toEqual({ x: 100, y: 75 })
+  })
+  it('四角形 + toSide=right → 右辺中央', () => {
+    expect(entryPt(c, o, hw, hh, rh, undefined, 'right')).toEqual({ x: 150, y: 100 })
+  })
+  it('四角形 + toSide=bottom → 下辺中央', () => {
+    expect(entryPt(c, o, hw, hh, rh, undefined, 'bottom')).toEqual({ x: 100, y: 125 })
+  })
+  it('四角形 + toSide=left → 左辺中央', () => {
+    expect(entryPt(c, o, hw, hh, rh, undefined, 'left')).toEqual({ x: 50, y: 100 })
+  })
+  it('diamond + toSide=top → 上頂点 (DS)', () => {
+    expect(entryPt(c, o, hw, hh, rh, 'diamond', 'top')).toEqual({ x: 100, y: 100 - 30 })
+  })
+  it('diamond + toSide=left → 左頂点 (DS)', () => {
+    expect(entryPt(c, o, hw, hh, rh, 'diamond', 'left')).toEqual({ x: 100 - 30, y: 100 })
+  })
+  it('toSide=undefined → 既存 auto ロジック (左向きから来る場合は右辺)', () => {
+    // o.x > c.x → 既存ロジック (dy~0, dx>0 → 右辺)
+    expect(entryPt(c, o, hw, hh, rh, undefined, undefined)).toEqual({ x: 150, y: 100 })
+  })
+})
+```
+
+注: `DS` は `src/lib/arrow-routing.ts` の定数（=30）。テストファイル冒頭の import から取得可能。
+
+Run: `npx vitest run src/lib/arrow-routing.test.ts -t "entryPt toSide honor"`
+Expected: テスト宣言箇所で TypeScript エラー（entryPt は現状 6 引数）。compile-time fail。
+
+### Step 3: 失敗するテストを書く（deriveToSide）
+
+```ts
+describe('deriveToSide', () => {
+  it('deriveFromSide と同一の結果を返す', () => {
+    const origin = { x: 110, y: 90 }
+    const center = { x: 100, y: 100 }
+    expect(deriveToSide(origin, center)).toBe(deriveFromSide(origin, center))
+  })
+  it('右上にドロップ → "top"（|dy| > |dx| かつ dy<0）', () => {
+    expect(deriveToSide({ x: 105, y: 70 }, { x: 100, y: 100 })).toBe('top')
+  })
+  it('右下にドロップ → "right"（|dx| > |dy|）', () => {
+    expect(deriveToSide({ x: 140, y: 110 }, { x: 100, y: 100 })).toBe('right')
+  })
+})
+```
+
+Run: 同上
+Expected: `deriveToSide` 未定義で fail
+
+### Step 4: 実装
+
+`src/lib/arrow-routing.ts` の `exitPt` を以下のように変更:
+
+```ts
+export const exitPt = (
+  c: Point,
+  o: Point,
+  hw: number,
+  hh: number,
+  rh: number,
+  shape?: 'diamond',
+  fromSide?: ArrowSide,
+): Point => {
+  const dx = o.x - c.x,
+    dy = o.y - c.y
+
+  if (shape === 'diamond') {
+    if (fromSide === 'top') return { x: c.x, y: c.y - DS }
+    if (fromSide === 'right') return { x: c.x + DS, y: c.y }
+    if (fromSide === 'bottom') return { x: c.x, y: c.y + DS }
+    if (fromSide === 'left') return { x: c.x - DS, y: c.y }
+    if (Math.abs(dx) < 1 && dy > 0) return { x: c.x, y: c.y + DS }
+    if (Math.abs(dx) < 1 && dy <= 0) return { x: c.x, y: c.y - DS }
+    if (dx >= 0) return { x: c.x + DS, y: c.y }
+    return { x: c.x - DS, y: c.y }
+  }
+
+  // 四角形でも fromSide があれば優先
+  if (fromSide === 'top') return { x: c.x, y: c.y - hh }
+  if (fromSide === 'right') return { x: c.x + hw, y: c.y }
+  if (fromSide === 'bottom') return { x: c.x, y: c.y + hh }
+  if (fromSide === 'left') return { x: c.x - hw, y: c.y }
+
+  // 同位置
+  if (Math.abs(dx) < 1 && Math.abs(dy) < 1) return { x: c.x, y: c.y + hh }
+  // 下方向
+  if (dy > rh * 0.3) return { x: c.x, y: c.y + hh }
+  // 上方向
+  if (dy < -rh * 0.3) return { x: c.x + (dx >= 0 ? hw : -hw), y: c.y }
+  // 水平方向
+  if (Math.abs(dx) > 1) return { x: c.x + (dx > 0 ? hw : -hw), y: c.y }
+  // フォールバック
+  return { x: c.x, y: c.y + hh }
+}
+```
+
+`entryPt` を以下のように変更:
+
+```ts
+export const entryPt = (
+  c: Point,
+  o: Point,
+  hw: number,
+  hh: number,
+  rh: number,
+  shape?: 'diamond',
+  toSide?: ArrowSide,
+): Point => {
+  const dx = o.x - c.x,
+    dy = o.y - c.y
+
+  if (shape === 'diamond') {
+    if (toSide === 'top') return { x: c.x, y: c.y - DS }
+    if (toSide === 'right') return { x: c.x + DS, y: c.y }
+    if (toSide === 'bottom') return { x: c.x, y: c.y + DS }
+    if (toSide === 'left') return { x: c.x - DS, y: c.y }
+    if (dy < -rh * 0.3) return { x: c.x, y: c.y - DS }
+    if (dy > rh * 0.3) return { x: c.x, y: c.y + DS }
+    if (dx > 0) return { x: c.x + DS, y: c.y }
+    return { x: c.x - DS, y: c.y }
+  }
+
+  // 四角形でも toSide があれば優先
+  if (toSide === 'top') return { x: c.x, y: c.y - hh }
+  if (toSide === 'right') return { x: c.x + hw, y: c.y }
+  if (toSide === 'bottom') return { x: c.x, y: c.y + hh }
+  if (toSide === 'left') return { x: c.x - hw, y: c.y }
+
+  // 同位置
+  if (Math.abs(dx) < 1 && Math.abs(dy) < 1) return { x: c.x, y: c.y - hh }
+  // 上方向から
+  if (dy < -rh * 0.3) return { x: c.x, y: c.y - hh }
+  // 下方向から
+  if (dy > rh * 0.3) return { x: c.x + (dx >= 0 ? hw : -hw), y: c.y }
+  // 水平方向
+  if (Math.abs(dx) > 1) return { x: c.x + (dx > 0 ? hw : -hw), y: c.y }
+  // フォールバック
+  return { x: c.x, y: c.y - hh }
+}
+```
+
+`deriveToSide` を `deriveFromSide` の直後に追加:
+
+```ts
+/** ドロップ点とターゲットノード中心から接続先 side を判定する。deriveFromSide と同一ロジック。 */
+export const deriveToSide = deriveFromSide
+```
+
+### Step 5: 全テスト pass を確認
+
+Run: `npm test`
+Expected: 既存全テスト + 新規 14 テスト pass
+
+### Step 6: コミット
+
+```bash
+git add src/lib/arrow-routing.ts src/lib/arrow-routing.test.ts
+git commit -m "feat(#355): extend exitPt/entryPt to honor fromSide/toSide for rectangles + add deriveToSide"
+```
+
+---
+
+## Task 2: flow-engine.ts の calcArrowPath 拡張（TDD）
+
+**Files:**
+
+- Modify: `src/lib/flow-engine.ts`
+- Modify: `src/lib/flow-engine.test.ts`
+
+### Step 1: 失敗するテストを書く
+
+`src/lib/flow-engine.test.ts` の `describe('calcArrowPath', ...)` 内に追加:
+
+```ts
+it('toSide=top で四角形ターゲットの上辺に入る', () => {
+  const from = { x: 100, y: 50 }
+  const to = { x: 200, y: 200 }
+  const result = calcArrowPath(from, to, {
+    hw: 50,
+    hh: 25,
+    rh: 84,
+    toSide: 'top' as const,
+  })
+  // path d 文字列に上辺中央 (200, 175) が含まれること
+  expect(result.d).toMatch(/200[,\s]175/)
+})
+
+it('diamond の toSide=left を尊重する', () => {
+  const from = { x: 100, y: 50 }
+  const to = { x: 200, y: 100 }
+  const result = calcArrowPath(from, to, {
+    hw: 50,
+    hh: 25,
+    rh: 84,
+    toShape: 'diamond' as const,
+    toSide: 'left' as const,
+  })
+  // DS=30 → 左頂点 (170, 100)
+  expect(result.d).toMatch(/170[,\s]100/)
+})
+```
+
+Run: `npx vitest run src/lib/flow-engine.test.ts -t "calcArrowPath"`
+Expected: TypeScript エラー（ArrowConfig に toSide なし）→ fail
+
+### Step 2: 実装
+
+`src/lib/flow-engine.ts` の `ArrowConfig` を変更:
+
+```ts
+interface ArrowConfig {
+  hw: number
+  hh: number
+  rh: number
+  fromShape?: 'diamond'
+  toShape?: 'diamond'
+  fromSide?: ArrowSide
+  toSide?: ArrowSide // 新規
+}
+```
+
+`calcArrowPath` 内部の `entryPt` 呼び出し:
+
+```ts
+const e = entryPt(t, f, config.hw, config.hh, config.rh, config.toShape, config.toSide)
+```
+
+### Step 3: テスト pass 確認
+
+Run: `npx vitest run src/lib/flow-engine.test.ts`
+Expected: 新規 2 テスト含めて pass
+
+### Step 4: コミット
+
+```bash
+git add src/lib/flow-engine.ts src/lib/flow-engine.test.ts
+git commit -m "feat(#355): plumb toSide through calcArrowPath ArrowConfig"
+```
+
+---
+
+## Task 3: InternalArrow に toSide 追加 + DB マイグレーション
+
+**Files:**
+
+- Modify: `src/lib/types.ts`
+- Create: `migrations/0014_arrow_to_side.sql`
+
+### Step 1: 型に toSide を追加
+
+`src/lib/types.ts` の `InternalArrow` に行を追加:
+
+```ts
+export interface InternalArrow {
+  id: string
+  from: string
+  to: string
+  comment: string
+  color?: string
+  dash?: string
+  bidirectional?: boolean
+  /** 接続元ノードのどの頂点/辺から線を出すか。未指定なら自動。 */
+  fromSide?: ArrowSide
+  /** 接続先ノードのどの頂点/辺に線を入れるか。未指定なら自動。 */
+  toSide?: ArrowSide
+}
+```
+
+### Step 2: マイグレーションファイル作成
+
+Create `migrations/0014_arrow_to_side.sql`:
+
+```sql
+-- Issue #355: 矢印に入口側 (toSide) を持たせる
+-- diamond/四角形どちらでも意味を持つ。NULL は自動（既存ロジック）。
+ALTER TABLE arrows ADD COLUMN to_side TEXT;
+```
+
+### Step 3: 型チェック pass
+
+Run: `npx tsc -b --pretty`
+Expected: エラーなし
+
+### Step 4: コミット
+
+```bash
+git add src/lib/types.ts migrations/0014_arrow_to_side.sql
+git commit -m "feat(#355): add toSide field to InternalArrow + DB migration"
+```
+
+---
+
+## Task 4: API ラウンドトリップ対応
+
+**Files:**
+
+- Modify: `api/lib/flow-transform.ts`
+- Modify: `api/lib/validators.ts`
+- Modify: `api/routes/flows.ts`
+
+### Step 1: ArrowRow と toArrow に toSide 追加
+
+`api/lib/flow-transform.ts`:
+
+```ts
+export interface ArrowRow {
+  // ... 既存 ...
+  from_side: ArrowSide | null
+  to_side: ArrowSide | null // 新規
+  created_at: string
+  updated_at: string
+}
+
+export function toArrow(row: ArrowRow) {
+  return {
+    // ... 既存 ...
+    fromSide: row.from_side,
+    toSide: row.to_side, // 新規
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+```
+
+### Step 2: Zod schema に toSide 追加
+
+`api/lib/validators.ts` の `arrowSchema`:
+
+```ts
+const arrowSchema = z.object({
+  id: z.string().min(1),
+  fromNodeId: z.string().min(1),
+  toNodeId: z.string().min(1),
+  comment: z.string().nullable().optional(),
+  color: z.string().nullable().optional(),
+  dash: z.string().nullable().optional(),
+  bidirectional: z.boolean().optional(),
+  fromSide: z.enum(['top', 'right', 'bottom', 'left']).nullable().optional(),
+  toSide: z.enum(['top', 'right', 'bottom', 'left']).nullable().optional(), // 新規
+})
+```
+
+### Step 3: INSERT 文 2 箇所に to_side を追加
+
+`api/routes/flows.ts:291` および :447 の INSERT 文を以下のように変更:
+
+```sql
+INSERT INTO arrows (id, flow_id, from_node_id, to_node_id, comment, color, dash, bidirectional, from_side, to_side) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+```
+
+それぞれの bind に `arrow.toSide ?? null` を追加（`arrow.fromSide ?? null` の直後）。
+
+### Step 4: 型チェック + テスト pass
+
+Run: `npx tsc -b --pretty && npm test`
+Expected: pass
+
+### Step 5: コミット
+
+```bash
+git add api/lib/flow-transform.ts api/lib/validators.ts api/routes/flows.ts
+git commit -m "feat(#355): API round-trip support for toSide"
+```
+
+---
+
+## Task 5: FlowEditor のドラッグ完了処理を拡張
+
+**Files:**
+
+- Modify: `src/features/editor/FlowEditor.tsx`
+
+### Step 1: 接続元の diamond ガード撤廃 + toSide 派生
+
+`FlowEditor.tsx:1062-1072` 周辺を以下に変更:
+
+```ts
+if (Math.abs(pt.x - c.x) < snapX && Math.abs(pt.y - c.y) < snapY && k !== connectFrom) {
+  const srcTask = tasks[connectFrom]
+  // 接続元 fromSide: shape 不問
+  let fromSide: ArrowSide | undefined
+  if (connectFromPt && srcTask) {
+    const srcLi = liMap[srcTask.lid]
+    const srcRi = riMap[srcTask.rid]
+    if (srcLi !== undefined && srcRi !== undefined) {
+      const sc = ct(srcLi, srcRi)
+      fromSide = deriveFromSide(connectFromPt, sc)
+    }
+  }
+  // 接続先 toSide: ドロップ点とターゲットノード中心から
+  const toSide: ArrowSide | undefined = deriveToSide(pt, c)
+  setArrows((p) => [...p, { id: uid(), from: connectFrom, to: k, comment: '', fromSide, toSide }])
+  break
+}
+```
+
+import に `deriveToSide` を追加。
+
+### Step 2: calcArrowPath 呼び出しに toSide を渡す
+
+`FlowEditor.tsx:1442` 周辺の calcArrowPath:
+
+```ts
+return calcArrowPath(
+  from,
+  to,
+  {
+    hw: TW / 2,
+    hh: TH / 2,
+    rh: RH,
+    fromShape: ft.shape ?? undefined,
+    toShape: tt.shape ?? undefined,
+    fromSide: arrow.fromSide,
+    toSide: arrow.toSide, // 新規
+  },
+  obstacles,
+)
+```
+
+### Step 3: load/save transform に toSide を含める
+
+`FlowEditor.tsx:144` 周辺（load 時）:
+
+```ts
+if (a.fromSide) arr.fromSide = a.fromSide
+if (a.toSide) arr.toSide = a.toSide
+```
+
+`FlowEditor.tsx:215` 周辺（save 時）:
+
+```ts
+fromSide: a.fromSide ?? null,
+toSide: a.toSide ?? null,
+```
+
+### Step 4: 型チェック + テスト pass
+
+Run: `npx tsc -b --pretty && npm test`
+Expected: pass
+
+### Step 5: コミット
+
+```bash
+git add src/features/editor/FlowEditor.tsx
+git commit -m "feat(#355): derive and persist toSide on drag completion"
+```
+
+---
+
+## Task 6: SharedFlowViewer に toSide パススルー
+
+**Files:**
+
+- Modify: `src/features/shared/SharedFlowViewer.tsx`
+
+### Step 1: calcArrowPath 呼び出しに toSide を追加
+
+`src/features/shared/SharedFlowViewer.tsx` の computeArrowPath 内 calcArrowPath:
+
+```ts
+return calcArrowPath(
+  f,
+  t,
+  {
+    hw,
+    hh,
+    rh: RH,
+    fromShape: fromNode.shape as 'diamond' | undefined,
+    toShape: toNode.shape as 'diamond' | undefined,
+    fromSide: arrow.fromSide ?? undefined,
+    toSide: arrow.toSide ?? undefined, // 新規
+  },
+  obstacles,
+)
+```
+
+### Step 2: テスト pass
+
+Run: `npm test`
+Expected: pass
+
+### Step 3: コミット
+
+```bash
+git add src/features/shared/SharedFlowViewer.tsx
+git commit -m "feat(#355): pass toSide through SharedFlowViewer calcArrowPath"
+```
+
+---
+
+## Task 7: RightPanel に「入口側」セクション追加 + diamond ガード撤廃
+
+**Files:**
+
+- Modify: `src/features/editor/components/RightPanel.tsx`
+- Modify: `src/locales/ja/editor.json`
+- Modify: `src/locales/en/editor.json`
+
+### Step 1: i18n キー追加
+
+`src/locales/ja/editor.json` の `rightPanel` セクションに追加:
+
+```json
+"arrowToSide": "入口側"
+```
+
+`src/locales/en/editor.json` 同様:
+
+```json
+"arrowToSide": "Entry side"
+```
+
+### Step 2: RightPanel.tsx の diamond ガード撤廃
+
+`src/features/editor/components/RightPanel.tsx:655` を変更:
+
+Before:
+
+```tsx
+{
+  tasks[selArrowData.from]?.shape === 'diamond' && (
+    <PanelSection label={t('rightPanel.arrowFromSide')}>...</PanelSection>
+  )
+}
+```
+
+After:
+
+```tsx
+<PanelSection label={t('rightPanel.arrowFromSide')}>...</PanelSection>
+```
+
+### Step 3: 「入口側」セクションを直下に追加
+
+「出口側」 PanelSection の直後に以下を追加（fromSide のコピペで toSide 用に書き換え）:
+
+```tsx
+<PanelSection label={t('rightPanel.arrowToSide')}>
+  <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+    {[
+      { id: 'auto', value: undefined, label: t('rightPanel.arrowSideAuto') },
+      { id: 'top', value: 'top' as const, label: t('rightPanel.arrowSideTop') },
+      { id: 'right', value: 'right' as const, label: t('rightPanel.arrowSideRight') },
+      { id: 'bottom', value: 'bottom' as const, label: t('rightPanel.arrowSideBottom') },
+      { id: 'left', value: 'left' as const, label: t('rightPanel.arrowSideLeft') },
+    ].map((opt) => {
+      const isActive =
+        opt.value === undefined ? !selArrowData.toSide : selArrowData.toSide === opt.value
+      return (
+        <div
+          key={opt.id}
+          onClick={() =>
+            setArrows((p) => p.map((a) => (a.id === selArrow ? { ...a, toSide: opt.value } : a)))
+          }
+          style={
+            {
+              /* 同じスタイル */
+            }
+          }
+        >
+          {opt.label}
+        </div>
+      )
+    })}
+  </div>
+</PanelSection>
+```
+
+### Step 4: 型チェック + テスト pass
+
+Run: `npx tsc -b --pretty && npm test`
+Expected: pass
+
+### Step 5: コミット
+
+```bash
+git add src/features/editor/components/RightPanel.tsx src/locales/ja/editor.json src/locales/en/editor.json
+git commit -m "feat(#355): RightPanel show fromSide/toSide for any shape + add 入口側 selector"
+```
+
+---
+
+## Task 8: 全体検証
+
+**Files:** なし
+
+### Step 1: フルテスト・ビルド
+
+Run:
+
+```bash
+npm test
+npm run build
+npx tsc -b --pretty
+npx prettier --check .
+```
+
+Expected: 全 pass
+
+### Step 2: dev サーバで動作確認
+
+`npm run dev` を起動。以下を確認:
+
+- 矢印を選択 → プロパティパネルに「出口側」「入口側」両方表示
+- 四角形ノード間矢印で「出口側」を「右」に変更 → 即時反映
+- ひし形ノード → 四角形ノードの矢印で「入口側=左」 → 左辺中央から入る
+- 既存矢印（toSide/fromSide null）は変化なし
+- 共有 URL を別タブで開き、エディタと完全一致
+
+スクリーンショットを `.screenshots/355-*.png` に保存。
+
+### Step 3: LCP 確認
+
+DevTools Performance で LCP ≤ 1 秒。
+
+---
+
+## Task 9: PR & レビュー & Merge
+
+CLAUDE.md workflow Step 7-11 に従う。
+
+- `git pull origin main --rebase && npm test`
+- push & `gh pr create`（title: `feat(#355): add toSide and rectangle side support`）
+- `gh pr checks --watch`
+- `@claude` レビュー依頼
+- 判定 [C:承認OK] まで修正ループ
+- merge → main 更新 → デプロイ確認
+- worktree remove + branch -d
+
+### PR description template
+
+```markdown
+## Summary
+
+- `toSide` を矢印データに追加（ドラッグ完了時のドロップ位置から自動派生）
+- 四角形ノードでも `fromSide` / `toSide` を honor（従来は diamond 限定）
+- プロパティパネルの「出口側」 diamond ガード撤廃 → 矢印選択中は常に表示
+- 「入口側」セレクタを新規追加（diamond/四角形どちらでも表示）
+- DB マイグレーション 0014: `arrows.to_side` カラム追加
+- API ラウンドトリップ（Zod / INSERT / toArrow / ArrowRow）
+- `shared/types.ts` の `ArrowSide` を継続活用（#357 で集約済み）
+
+## 後方互換
+
+- 既存矢印（fromSide/toSide=NULL）は従来の auto ロジックのまま
+- ひし形 fromSide のみ指定の既存矢印も挙動不変
+
+## Closes #355
+```

--- a/docs/superpowers/specs/2026-05-22-toside-rect-design.md
+++ b/docs/superpowers/specs/2026-05-22-toside-rect-design.md
@@ -1,0 +1,275 @@
+# toSide + 四角形ノード side 指定
+
+- 関連 issue: #355
+- 関連 PR: #352 (#349 — fromSide for diamond)
+- 関連 issue: #69（共有ビューと描画乖離 — 防止のため SharedFlowViewer も同時更新）
+
+## 背景
+
+#349 でひし形ノードの接続元 (`fromSide`) 指定を実装した。残るスコープは以下の 2 点:
+
+1. **`toSide`**: 接続先（target 側）の頂点/辺を指定
+2. **四角形ノード**: 現在 `fromSide` の honor は `shape === 'diamond'` 限定 → 四角形ノードでも上下左右の出口/入口指定を可能にする
+
+両者は `exitPt` / `entryPt` の四角形分岐、UI セレクタ、DB マイグレーション、API シリアライズが密結合のため 1 PR にまとめる。
+
+## 目標
+
+- ドラッグ完了時に接続先のスナップ位置から `toSide` を導出して保存
+- `entryPt` が `toSide` を受け取り、指定時はその頂点/辺を返す
+- `exitPt` / `entryPt` の四角形分岐でも `fromSide` / `toSide` を honor
+- プロパティパネル「出口側」セレクタを diamond/四角形どちらでも表示
+- プロパティパネルに「入口側」セレクタを追加（diamond/四角形どちらでも）
+- 既存矢印（`fromSide` / `toSide` 未指定）は従来の自動ロジック（後方互換）
+
+## 非目標
+
+- 始点エンドポイントをドラッグで掴み直す UX（別 issue）
+- auto-connect 経路からの fromSide/toSide 推論（実害なし・実装効果なしと判断、見送り）
+
+## 設計
+
+### 型（shared 共有）
+
+`src/lib/types.ts` の `InternalArrow` に `toSide?: ArrowSide` を追加（`ArrowSide` は既に #357 で `shared/types.ts` に集約済み）。
+
+```ts
+export interface InternalArrow {
+  // ... 既存 ...
+  fromSide?: ArrowSide
+  toSide?: ArrowSide // 新規
+}
+```
+
+### routing (`src/lib/arrow-routing.ts`)
+
+#### `exitPt` の四角形分岐に fromSide 対応
+
+```ts
+export const exitPt = (
+  c, o, hw, hh, rh,
+  shape?: 'diamond',
+  fromSide?: ArrowSide,
+): Point => {
+  if (shape === 'diamond') {
+    // 既存 diamond 分岐（fromSide honor 含む）
+    ...
+  }
+  // 新規: 四角形でも fromSide があれば優先
+  if (fromSide === 'top')    return { x: c.x, y: c.y - hh }
+  if (fromSide === 'right')  return { x: c.x + hw, y: c.y }
+  if (fromSide === 'bottom') return { x: c.x, y: c.y + hh }
+  if (fromSide === 'left')   return { x: c.x - hw, y: c.y }
+  // 既存 auto 分岐
+  ...
+}
+```
+
+#### `entryPt` を拡張して toSide を受ける
+
+```ts
+export const entryPt = (
+  c, o, hw, hh, rh,
+  shape?: 'diamond',
+  toSide?: ArrowSide,
+): Point => {
+  if (shape === 'diamond') {
+    if (toSide === 'top')    return { x: c.x, y: c.y - DS }
+    if (toSide === 'right')  return { x: c.x + DS, y: c.y }
+    if (toSide === 'bottom') return { x: c.x, y: c.y + DS }
+    if (toSide === 'left')   return { x: c.x - DS, y: c.y }
+    // 既存 diamond auto 分岐
+    ...
+  }
+  // 四角形でも toSide があれば優先
+  if (toSide === 'top')    return { x: c.x, y: c.y - hh }
+  if (toSide === 'right')  return { x: c.x + hw, y: c.y }
+  if (toSide === 'bottom') return { x: c.x, y: c.y + hh }
+  if (toSide === 'left')   return { x: c.x - hw, y: c.y }
+  // 既存 auto 分岐
+  ...
+}
+```
+
+#### `deriveToSide` の追加
+
+数学的には `deriveFromSide(origin, center)` と同一（`dx = point.x - center.x` の符号と `dy` の比較で side を決定）。コードの readable さのため別関数として export し、内部実装は再利用:
+
+```ts
+/** ドロップ点 (point) とターゲットノード中心 (center) の位置関係から
+ *  どの側に接続するかを判定する。deriveFromSide と同一ロジック。 */
+export const deriveToSide = deriveFromSide
+```
+
+### `calcArrowPath` (`src/lib/flow-engine.ts`)
+
+`ArrowConfig` に `toSide?: ArrowSide` を追加し、`entryPt` に渡す:
+
+```ts
+interface ArrowConfig {
+  hw: number
+  hh: number
+  rh: number
+  fromShape?: 'diamond'
+  toShape?: 'diamond'
+  fromSide?: ArrowSide
+  toSide?: ArrowSide // 新規
+}
+
+// calcArrowPath 内部
+const e = entryPt(t, f, config.hw, config.hh, config.rh, config.toShape, config.toSide)
+```
+
+### DB マイグレーション
+
+`migrations/0014_arrow_to_side.sql`:
+
+```sql
+-- Issue #355: 矢印に入口側 (toSide) を持たせる
+-- diamond/四角形どちらでも意味を持つ。NULL は自動（既存ロジック）。
+ALTER TABLE arrows ADD COLUMN to_side TEXT;
+```
+
+### API
+
+#### `api/lib/flow-transform.ts`
+
+```ts
+export interface ArrowRow {
+  // ... 既存 ...
+  from_side: ArrowSide | null
+  to_side: ArrowSide | null // 新規
+  // ...
+}
+
+export function toArrow(row: ArrowRow) {
+  return {
+    // ... 既存 ...
+    fromSide: row.from_side,
+    toSide: row.to_side, // 新規
+    // ...
+  }
+}
+```
+
+#### `api/lib/validators.ts`
+
+```ts
+const arrowSchema = z.object({
+  // ... 既存 ...
+  fromSide: z.enum(['top', 'right', 'bottom', 'left']).nullable().optional(),
+  toSide: z.enum(['top', 'right', 'bottom', 'left']).nullable().optional(), // 新規
+})
+```
+
+#### `api/routes/flows.ts`
+
+INSERT 文 2 箇所に `to_side` カラムと `arrow.toSide ?? null` を追加。
+
+### Frontend
+
+#### `src/features/editor/FlowEditor.tsx`
+
+ドラッグ完了時（line 1062 周辺）:
+
+```ts
+// 接続元: 既存の diamond ガードを撤廃し、shape に関わらず fromSide を派生
+let fromSide: ArrowSide | undefined
+if (connectFromPt) {
+  const srcLi = liMap[srcTask.lid]
+  const srcRi = riMap[srcTask.rid]
+  if (srcLi !== undefined && srcRi !== undefined) {
+    const sc = ct(srcLi, srcRi)
+    fromSide = deriveFromSide(connectFromPt, sc)
+  }
+}
+
+// 接続先: 新規 toSide を派生（ドロップ点とターゲットノード中心から）
+const toSide: ArrowSide | undefined = deriveToSide(pt, c)
+
+setArrows((p) => [...p, { id: uid(), from: connectFrom, to: k, comment: '', fromSide, toSide }])
+```
+
+矢印描画（line 1442 の calcArrowPath 呼び出し）:
+
+```ts
+return calcArrowPath(
+  from,
+  to,
+  {
+    hw: TW / 2,
+    hh: TH / 2,
+    rh: RH,
+    fromShape: ft.shape ?? undefined,
+    toShape: tt.shape ?? undefined,
+    fromSide: arrow.fromSide,
+    toSide: arrow.toSide, // 新規
+  },
+  obstacles,
+)
+```
+
+load/save transform (line 144, 215 周辺): `toSide` も同様にパススルー。
+
+#### `src/features/shared/SharedFlowViewer.tsx`
+
+calcArrowPath 呼び出しに `toSide: arrow.toSide ?? undefined` を追加。
+
+#### `src/features/editor/components/RightPanel.tsx`
+
+- 「出口側」セクションの diamond ガード `tasks[selArrowData.from]?.shape === 'diamond'` を撤廃 → 矢印選択中は常に表示
+- その直下に「入口側」セクションを追加（同じ 5 択 UI、`selArrowData.toSide` を読み書き）
+
+#### i18n
+
+`src/locales/{ja,en}/editor.json` に `rightPanel.arrowToSide` を追加。
+
+```json
+// ja
+"arrowToSide": "入口側"
+// en
+"arrowToSide": "Entry side"
+```
+
+## 検証
+
+### TDD で追加するテスト
+
+- `arrow-routing.test.ts`:
+  - `exitPt`: 四角形 + fromSide=top/right/bottom/left → 上下左右の辺中央
+  - `entryPt`: 四角形 + toSide=各方向 → 対応する辺中央
+  - `entryPt`: diamond + toSide=各方向 → 対応する頂点
+  - `deriveToSide`: deriveFromSide と同一結果（基本パリティ）
+- `flow-engine.test.ts`:
+  - `calcArrowPath`: ArrowConfig.toSide を渡すと entryPt に届く（diamond/rect の両ケース）
+  - 既存矢印（toSide 未指定）の挙動が変化しないこと
+
+### 既存テストの維持
+
+- 全 1645 テスト pass
+- API ラウンドトリップで toSide が保存・取得される
+
+### 実画面確認
+
+- 矢印選択 → 「入口側」セレクタ表示、5 択（自動/上/右/下/左）クリックで即時描画反映
+- 四角形ノード同士の矢印で出口/入口側が指定通りに動く
+- ひし形 → 四角形矢印で `toSide=left` 指定 → 左辺中央から入る
+- 既存矢印（toSide=null）は変化なし
+- 共有ビューで完全一致（#69 防止）
+
+## 影響範囲
+
+- 新規: `migrations/0014_arrow_to_side.sql`, ja/en に `arrowToSide` キー追加
+- 修正:
+  - `src/lib/types.ts`, `src/features/editor/types.ts`
+  - `src/lib/arrow-routing.ts`, `src/lib/arrow-routing.test.ts`
+  - `src/lib/flow-engine.ts`, `src/lib/flow-engine.test.ts`
+  - `src/features/editor/FlowEditor.tsx`
+  - `src/features/shared/SharedFlowViewer.tsx`
+  - `src/features/editor/components/RightPanel.tsx`
+  - `api/lib/flow-transform.ts`, `api/lib/validators.ts`, `api/routes/flows.ts`
+  - 各種テスト
+
+## 工数見積
+
+3-4 時間（型・routing 実装 1h、API/DB 30min、UI 1h、テスト 1h、検証 30min）

--- a/migrations/0014_arrow_to_side.sql
+++ b/migrations/0014_arrow_to_side.sql
@@ -1,0 +1,3 @@
+-- Issue #355: 矢印に入口側 (toSide) を持たせる
+-- diamond/四角形どちらでも意味を持つ。NULL は自動（既存ロジック）。
+ALTER TABLE arrows ADD COLUMN to_side TEXT;

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -1224,6 +1224,7 @@ export default function FlowEditor({
     }
     const k = ky(lid, rid)
     if (connectFrom) {
+      // クリック接続経路: ドロップ座標が無いため fromSide/toSide は派生せず auto routing に委ねる
       if (k !== connectFrom && tasks[k])
         setArrows((p) => [...p, { id: uid(), from: connectFrom, to: k, comment: '' }])
       setConnectFrom(null)
@@ -1288,6 +1289,7 @@ export default function FlowEditor({
   const taskClick = (k: string, e: React.MouseEvent): void => {
     e.stopPropagation()
     if (connectFrom) {
+      // クリック接続経路: ドロップ座標が無いため fromSide/toSide は派生せず auto routing に委ねる
       if (k !== connectFrom)
         setArrows((p) => [...p, { id: uid(), from: connectFrom, to: k, comment: '' }])
       setConnectFrom(null)

--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -40,6 +40,7 @@ import {
   DS,
   buildObstacles,
   deriveFromSide,
+  deriveToSide,
   type Bbox,
   type ObstacleNode,
 } from '../../lib/arrow-routing'
@@ -142,6 +143,7 @@ export function flowToInternalState(flow: Flow): {
       if (a.dash) arr.dash = a.dash
       if (a.bidirectional) arr.bidirectional = true
       if (a.fromSide) arr.fromSide = a.fromSide
+      if (a.toSide) arr.toSide = a.toSide
       return arr
     })
     .filter((a): a is InternalArrow => a !== null)
@@ -213,6 +215,7 @@ export function internalStateToPayload(
         dash: a.dash || null,
         bidirectional: a.bidirectional ?? false,
         fromSide: a.fromSide ?? null,
+        toSide: a.toSide ?? null,
       }
     })
     .filter((a): a is NonNullable<typeof a> => a !== null)
@@ -1060,8 +1063,9 @@ export default function FlowEditor({
         const snapY = isDia ? DS + 12 : TH / 2 + 12
         if (Math.abs(pt.x - c.x) < snapX && Math.abs(pt.y - c.y) < snapY && k !== connectFrom) {
           const srcTask = tasks[connectFrom]
+          // 接続元 fromSide: shape を問わず derive（#355: 四角形ノードも対応）
           let fromSide: ArrowSide | undefined
-          if (srcTask?.shape === 'diamond' && connectFromPt) {
+          if (connectFromPt && srcTask) {
             const srcLi = liMap[srcTask.lid]
             const srcRi = riMap[srcTask.rid]
             if (srcLi !== undefined && srcRi !== undefined) {
@@ -1069,7 +1073,12 @@ export default function FlowEditor({
               fromSide = deriveFromSide(connectFromPt, sc)
             }
           }
-          setArrows((p) => [...p, { id: uid(), from: connectFrom, to: k, comment: '', fromSide }])
+          // 接続先 toSide: ドロップ点とターゲットノード中心から derive
+          const toSide: ArrowSide = deriveToSide(pt, c)
+          setArrows((p) => [
+            ...p,
+            { id: uid(), from: connectFrom, to: k, comment: '', fromSide, toSide },
+          ])
           break
         }
       }
@@ -1449,6 +1458,7 @@ export default function FlowEditor({
         fromShape: ft.shape ?? undefined,
         toShape: tt.shape ?? undefined,
         fromSide: arrow.fromSide,
+        toSide: arrow.toSide,
       },
       obstacles,
     )

--- a/src/features/editor/components/RightPanel.tsx
+++ b/src/features/editor/components/RightPanel.tsx
@@ -11,6 +11,7 @@ import type {
   RowData,
   InternalLane,
   InternalArrow,
+  ArrowSide,
   EditorSettings,
 } from '../types'
 import {
@@ -21,6 +22,50 @@ import {
   LINE_COLORS,
   STROKE_STYLES,
 } from '../theme-constants'
+
+interface ArrowSideSelectorProps {
+  label: string
+  value: ArrowSide | null | undefined
+  onChange: (v: ArrowSide | undefined) => void
+  T: Theme
+  isDark: boolean
+  options: ReadonlyArray<{ id: string; value: ArrowSide | undefined; label: string }>
+}
+
+function ArrowSideSelector({ label, value, onChange, T, isDark, options }: ArrowSideSelectorProps) {
+  return (
+    <PanelSection label={label}>
+      <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+        {options.map((opt) => {
+          const isActive = opt.value === undefined ? !value : value === opt.value
+          return (
+            <div
+              key={opt.id}
+              onClick={() => onChange(opt.value)}
+              style={{
+                flex: 1,
+                minWidth: 36,
+                height: 30,
+                borderRadius: 6,
+                cursor: 'pointer',
+                background: isActive ? (isDark ? '#333' : '#F0EBFF') : 'transparent',
+                border: `1px solid ${isActive ? T.accent : T.inputBorder}`,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 12,
+                color: isActive ? T.accent : T.panelText,
+                transition: 'all 0.1s',
+              }}
+            >
+              {opt.label}
+            </div>
+          )
+        })}
+      </div>
+    </PanelSection>
+  )
+}
 
 interface RightPanelProps {
   // Selection
@@ -105,6 +150,18 @@ export const RightPanel = ({
   const { t } = useTranslation('editor')
   const T: Theme = THEMES[themeId]
   const isDark = themeId === 'midnight'
+
+  const arrowSideOptions: ReadonlyArray<{
+    id: string
+    value: ArrowSide | undefined
+    label: string
+  }> = [
+    { id: 'auto', value: undefined, label: t('rightPanel.arrowSideAuto') },
+    { id: 'top', value: 'top', label: t('rightPanel.arrowSideTop') },
+    { id: 'right', value: 'right', label: t('rightPanel.arrowSideRight') },
+    { id: 'bottom', value: 'bottom', label: t('rightPanel.arrowSideBottom') },
+    { id: 'left', value: 'left', label: t('rightPanel.arrowSideLeft') },
+  ]
 
   const selTaskData = selTask ? tasks[selTask] : null
   const selArrowData = selArrow ? arrows.find((a) => a.id === selArrow) : null
@@ -652,90 +709,27 @@ export const RightPanel = ({
             })}
           </div>
         </PanelSection>
-        <PanelSection label={t('rightPanel.arrowFromSide')}>
-          <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
-            {[
-              { id: 'auto', value: undefined, label: t('rightPanel.arrowSideAuto') },
-              { id: 'top', value: 'top' as const, label: t('rightPanel.arrowSideTop') },
-              { id: 'right', value: 'right' as const, label: t('rightPanel.arrowSideRight') },
-              { id: 'bottom', value: 'bottom' as const, label: t('rightPanel.arrowSideBottom') },
-              { id: 'left', value: 'left' as const, label: t('rightPanel.arrowSideLeft') },
-            ].map((opt) => {
-              const isActive =
-                opt.value === undefined
-                  ? !selArrowData.fromSide
-                  : selArrowData.fromSide === opt.value
-              return (
-                <div
-                  key={opt.id}
-                  onClick={() =>
-                    setArrows((p) =>
-                      p.map((a) => (a.id === selArrow ? { ...a, fromSide: opt.value } : a)),
-                    )
-                  }
-                  style={{
-                    flex: 1,
-                    minWidth: 36,
-                    height: 30,
-                    borderRadius: 6,
-                    cursor: 'pointer',
-                    background: isActive ? (isDark ? '#333' : '#F0EBFF') : 'transparent',
-                    border: `1px solid ${isActive ? T.accent : T.inputBorder}`,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    fontSize: 12,
-                    color: isActive ? T.accent : T.panelText,
-                    transition: 'all 0.1s',
-                  }}
-                >
-                  {opt.label}
-                </div>
-              )
-            })}
-          </div>
-        </PanelSection>
-        <PanelSection label={t('rightPanel.arrowToSide')}>
-          <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
-            {[
-              { id: 'auto', value: undefined, label: t('rightPanel.arrowSideAuto') },
-              { id: 'top', value: 'top' as const, label: t('rightPanel.arrowSideTop') },
-              { id: 'right', value: 'right' as const, label: t('rightPanel.arrowSideRight') },
-              { id: 'bottom', value: 'bottom' as const, label: t('rightPanel.arrowSideBottom') },
-              { id: 'left', value: 'left' as const, label: t('rightPanel.arrowSideLeft') },
-            ].map((opt) => {
-              const isActive =
-                opt.value === undefined ? !selArrowData.toSide : selArrowData.toSide === opt.value
-              return (
-                <div
-                  key={opt.id}
-                  onClick={() =>
-                    setArrows((p) =>
-                      p.map((a) => (a.id === selArrow ? { ...a, toSide: opt.value } : a)),
-                    )
-                  }
-                  style={{
-                    flex: 1,
-                    minWidth: 36,
-                    height: 30,
-                    borderRadius: 6,
-                    cursor: 'pointer',
-                    background: isActive ? (isDark ? '#333' : '#F0EBFF') : 'transparent',
-                    border: `1px solid ${isActive ? T.accent : T.inputBorder}`,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    fontSize: 12,
-                    color: isActive ? T.accent : T.panelText,
-                    transition: 'all 0.1s',
-                  }}
-                >
-                  {opt.label}
-                </div>
-              )
-            })}
-          </div>
-        </PanelSection>
+        <ArrowSideSelector
+          label={t('rightPanel.arrowFromSide')}
+          value={selArrowData.fromSide}
+          onChange={(v) =>
+            setArrows((p) => p.map((a) => (a.id === selArrow ? { ...a, fromSide: v } : a)))
+          }
+          T={T}
+          isDark={isDark}
+          options={arrowSideOptions}
+        />
+        <ArrowSideSelector
+          label={t('rightPanel.arrowToSide')}
+          value={selArrowData.toSide}
+          onChange={(v) =>
+            setArrows((p) => p.map((a) => (a.id === selArrow ? { ...a, toSide: v } : a)))
+          }
+          T={T}
+          isDark={isDark}
+          options={arrowSideOptions}
+        />
+
         <PanelSection label={t('rightPanel.operations')}>
           <div className={styles.panelActions}>
             <PanelBtn

--- a/src/features/editor/components/RightPanel.tsx
+++ b/src/features/editor/components/RightPanel.tsx
@@ -652,51 +652,90 @@ export const RightPanel = ({
             })}
           </div>
         </PanelSection>
-        {tasks[selArrowData.from]?.shape === 'diamond' && (
-          <PanelSection label={t('rightPanel.arrowFromSide')}>
-            <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
-              {[
-                { id: 'auto', value: undefined, label: t('rightPanel.arrowSideAuto') },
-                { id: 'top', value: 'top' as const, label: t('rightPanel.arrowSideTop') },
-                { id: 'right', value: 'right' as const, label: t('rightPanel.arrowSideRight') },
-                { id: 'bottom', value: 'bottom' as const, label: t('rightPanel.arrowSideBottom') },
-                { id: 'left', value: 'left' as const, label: t('rightPanel.arrowSideLeft') },
-              ].map((opt) => {
-                const isActive =
-                  opt.value === undefined
-                    ? !selArrowData.fromSide
-                    : selArrowData.fromSide === opt.value
-                return (
-                  <div
-                    key={opt.id}
-                    onClick={() =>
-                      setArrows((p) =>
-                        p.map((a) => (a.id === selArrow ? { ...a, fromSide: opt.value } : a)),
-                      )
-                    }
-                    style={{
-                      flex: 1,
-                      minWidth: 36,
-                      height: 30,
-                      borderRadius: 6,
-                      cursor: 'pointer',
-                      background: isActive ? (isDark ? '#333' : '#F0EBFF') : 'transparent',
-                      border: `1px solid ${isActive ? T.accent : T.inputBorder}`,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      fontSize: 12,
-                      color: isActive ? T.accent : T.panelText,
-                      transition: 'all 0.1s',
-                    }}
-                  >
-                    {opt.label}
-                  </div>
-                )
-              })}
-            </div>
-          </PanelSection>
-        )}
+        <PanelSection label={t('rightPanel.arrowFromSide')}>
+          <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+            {[
+              { id: 'auto', value: undefined, label: t('rightPanel.arrowSideAuto') },
+              { id: 'top', value: 'top' as const, label: t('rightPanel.arrowSideTop') },
+              { id: 'right', value: 'right' as const, label: t('rightPanel.arrowSideRight') },
+              { id: 'bottom', value: 'bottom' as const, label: t('rightPanel.arrowSideBottom') },
+              { id: 'left', value: 'left' as const, label: t('rightPanel.arrowSideLeft') },
+            ].map((opt) => {
+              const isActive =
+                opt.value === undefined
+                  ? !selArrowData.fromSide
+                  : selArrowData.fromSide === opt.value
+              return (
+                <div
+                  key={opt.id}
+                  onClick={() =>
+                    setArrows((p) =>
+                      p.map((a) => (a.id === selArrow ? { ...a, fromSide: opt.value } : a)),
+                    )
+                  }
+                  style={{
+                    flex: 1,
+                    minWidth: 36,
+                    height: 30,
+                    borderRadius: 6,
+                    cursor: 'pointer',
+                    background: isActive ? (isDark ? '#333' : '#F0EBFF') : 'transparent',
+                    border: `1px solid ${isActive ? T.accent : T.inputBorder}`,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: 12,
+                    color: isActive ? T.accent : T.panelText,
+                    transition: 'all 0.1s',
+                  }}
+                >
+                  {opt.label}
+                </div>
+              )
+            })}
+          </div>
+        </PanelSection>
+        <PanelSection label={t('rightPanel.arrowToSide')}>
+          <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+            {[
+              { id: 'auto', value: undefined, label: t('rightPanel.arrowSideAuto') },
+              { id: 'top', value: 'top' as const, label: t('rightPanel.arrowSideTop') },
+              { id: 'right', value: 'right' as const, label: t('rightPanel.arrowSideRight') },
+              { id: 'bottom', value: 'bottom' as const, label: t('rightPanel.arrowSideBottom') },
+              { id: 'left', value: 'left' as const, label: t('rightPanel.arrowSideLeft') },
+            ].map((opt) => {
+              const isActive =
+                opt.value === undefined ? !selArrowData.toSide : selArrowData.toSide === opt.value
+              return (
+                <div
+                  key={opt.id}
+                  onClick={() =>
+                    setArrows((p) =>
+                      p.map((a) => (a.id === selArrow ? { ...a, toSide: opt.value } : a)),
+                    )
+                  }
+                  style={{
+                    flex: 1,
+                    minWidth: 36,
+                    height: 30,
+                    borderRadius: 6,
+                    cursor: 'pointer',
+                    background: isActive ? (isDark ? '#333' : '#F0EBFF') : 'transparent',
+                    border: `1px solid ${isActive ? T.accent : T.inputBorder}`,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: 12,
+                    color: isActive ? T.accent : T.panelText,
+                    transition: 'all 0.1s',
+                  }}
+                >
+                  {opt.label}
+                </div>
+              )
+            })}
+          </div>
+        </PanelSection>
         <PanelSection label={t('rightPanel.operations')}>
           <div className={styles.panelActions}>
             <PanelBtn

--- a/src/features/editor/types.ts
+++ b/src/features/editor/types.ts
@@ -99,8 +99,10 @@ export interface Arrow {
   color?: string | null
   dash?: string | null
   bidirectional?: boolean
-  /** 接続元 diamond ノードの出口頂点。null/undefined なら自動。 */
+  /** 接続元ノードの出口側（頂点/辺）。null/undefined なら自動。 */
   fromSide?: ArrowSide | null
+  /** 接続先ノードの入口側（頂点/辺）。null/undefined なら自動。 */
+  toSide?: ArrowSide | null
 }
 
 export interface Flow {

--- a/src/features/shared/SharedFlowViewer.tsx
+++ b/src/features/shared/SharedFlowViewer.tsx
@@ -151,6 +151,7 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
         fromShape: fromNode.shape as 'diamond' | undefined,
         toShape: toNode.shape as 'diamond' | undefined,
         fromSide: arrow.fromSide ?? undefined,
+        toSide: arrow.toSide ?? undefined,
       },
       obstacles,
     )

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -6,7 +6,9 @@ import {
   collectDiagonalObstacles,
   detectDiagonalDetour,
   deriveFromSide,
+  deriveToSide,
   exitPt,
+  entryPt,
   DS,
   type Bbox,
   type ObstacleNode,
@@ -956,11 +958,109 @@ describe('exitPt with explicit fromSide (diamond)', () => {
     expect(exitPt(c, o, hw, hh, rh, 'diamond')).toEqual({ x: 200 + DS, y: 200 })
   })
 
-  it('shape が diamond でないとき fromSide は無視される', () => {
-    // 通常ノードは fromSide を受けてもサイド出口の自動ロジックに従う
+  it('shape が diamond でない四角形ノードでも fromSide=top を honor する', () => {
+    // #355: 四角形ノードでも fromSide があれば優先（上辺中央）
     const result = exitPt(c, o, hw, hh, rh, undefined, 'top' as ArrowSide)
-    // dx>0, dy>0 → サイド出口（上方向）→ 下方向出口（dy>rh*0.3）
-    expect(result).toEqual({ x: 200, y: 200 + hh })
+    expect(result).toEqual({ x: 200, y: 200 - hh })
+  })
+})
+
+describe('exitPt 四角形ノードの fromSide honor (#355)', () => {
+  const c = { x: 100, y: 100 }
+  const o = { x: 200, y: 100 } // dx>0 で自動ロジックなら 'right'
+  const hw = 50
+  const hh = 25
+  const rh = 84
+
+  it('四角形 + fromSide=top → 上辺中央', () => {
+    expect(exitPt(c, o, hw, hh, rh, undefined, 'top')).toEqual({ x: 100, y: 75 })
+  })
+
+  it('四角形 + fromSide=right → 右辺中央', () => {
+    expect(exitPt(c, o, hw, hh, rh, undefined, 'right')).toEqual({ x: 150, y: 100 })
+  })
+
+  it('四角形 + fromSide=bottom → 下辺中央', () => {
+    expect(exitPt(c, o, hw, hh, rh, undefined, 'bottom')).toEqual({ x: 100, y: 125 })
+  })
+
+  it('四角形 + fromSide=left → 左辺中央', () => {
+    expect(exitPt(c, o, hw, hh, rh, undefined, 'left')).toEqual({ x: 50, y: 100 })
+  })
+
+  it('四角形 + fromSide=undefined → 既存の auto ロジック（後方互換）', () => {
+    // dx>0, dy=0 → 水平方向 → 右辺
+    expect(exitPt(c, o, hw, hh, rh, undefined, undefined)).toEqual({ x: 150, y: 100 })
+  })
+})
+
+describe('entryPt with explicit toSide (#355)', () => {
+  const c = { x: 100, y: 100 }
+  const o = { x: 200, y: 100 }
+  const hw = 50
+  const hh = 25
+  const rh = 84
+
+  it('四角形 + toSide=top → 上辺中央', () => {
+    expect(entryPt(c, o, hw, hh, rh, undefined, 'top')).toEqual({ x: 100, y: 75 })
+  })
+
+  it('四角形 + toSide=right → 右辺中央', () => {
+    expect(entryPt(c, o, hw, hh, rh, undefined, 'right')).toEqual({ x: 150, y: 100 })
+  })
+
+  it('四角形 + toSide=bottom → 下辺中央', () => {
+    expect(entryPt(c, o, hw, hh, rh, undefined, 'bottom')).toEqual({ x: 100, y: 125 })
+  })
+
+  it('四角形 + toSide=left → 左辺中央', () => {
+    expect(entryPt(c, o, hw, hh, rh, undefined, 'left')).toEqual({ x: 50, y: 100 })
+  })
+
+  it('diamond + toSide=top → 上頂点 (DS)', () => {
+    expect(entryPt(c, o, hw, hh, rh, 'diamond', 'top')).toEqual({ x: 100, y: 100 - DS })
+  })
+
+  it('diamond + toSide=right → 右頂点 (DS)', () => {
+    expect(entryPt(c, o, hw, hh, rh, 'diamond', 'right')).toEqual({ x: 100 + DS, y: 100 })
+  })
+
+  it('diamond + toSide=bottom → 下頂点 (DS)', () => {
+    expect(entryPt(c, o, hw, hh, rh, 'diamond', 'bottom')).toEqual({ x: 100, y: 100 + DS })
+  })
+
+  it('diamond + toSide=left → 左頂点 (DS)', () => {
+    expect(entryPt(c, o, hw, hh, rh, 'diamond', 'left')).toEqual({ x: 100 - DS, y: 100 })
+  })
+
+  it('toSide=undefined → 既存 auto ロジック（後方互換）', () => {
+    // o.x > c.x, dy=0 → 水平方向 → 右辺
+    expect(entryPt(c, o, hw, hh, rh, undefined, undefined)).toEqual({ x: 150, y: 100 })
+  })
+})
+
+describe('deriveToSide (#355)', () => {
+  const c = { x: 100, y: 100 }
+
+  it('deriveFromSide と同一ロジック', () => {
+    const point = { x: 110, y: 90 }
+    expect(deriveToSide(point, c)).toBe(deriveFromSide(point, c))
+  })
+
+  it('右にドロップ → "right"', () => {
+    expect(deriveToSide({ x: 140, y: 100 }, c)).toBe('right')
+  })
+
+  it('上にドロップ → "top"', () => {
+    expect(deriveToSide({ x: 100, y: 60 }, c)).toBe('top')
+  })
+
+  it('下にドロップ → "bottom"', () => {
+    expect(deriveToSide({ x: 100, y: 140 }, c)).toBe('bottom')
+  })
+
+  it('左にドロップ → "left"', () => {
+    expect(deriveToSide({ x: 60, y: 100 }, c)).toBe('left')
   })
 })
 

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -304,6 +304,12 @@ export const exitPt = (
     return { x: c.x - DS, y: c.y }
   }
 
+  // 四角形でも fromSide があれば優先（#355）
+  if (fromSide === 'top') return { x: c.x, y: c.y - hh }
+  if (fromSide === 'right') return { x: c.x + hw, y: c.y }
+  if (fromSide === 'bottom') return { x: c.x, y: c.y + hh }
+  if (fromSide === 'left') return { x: c.x - hw, y: c.y }
+
   // 同位置
   if (Math.abs(dx) < 1 && Math.abs(dy) < 1) return { x: c.x, y: c.y + hh }
   // 下方向: 下部から出る
@@ -328,16 +334,27 @@ export const entryPt = (
   hh: number,
   rh: number,
   shape?: 'diamond',
+  toSide?: ArrowSide,
 ): Point => {
   const dx = o.x - c.x,
     dy = o.y - c.y
 
   if (shape === 'diamond') {
+    if (toSide === 'top') return { x: c.x, y: c.y - DS }
+    if (toSide === 'right') return { x: c.x + DS, y: c.y }
+    if (toSide === 'bottom') return { x: c.x, y: c.y + DS }
+    if (toSide === 'left') return { x: c.x - DS, y: c.y }
     if (dy < -rh * 0.3) return { x: c.x, y: c.y - DS }
     if (dy > rh * 0.3) return { x: c.x, y: c.y + DS }
     if (dx > 0) return { x: c.x + DS, y: c.y }
     return { x: c.x - DS, y: c.y }
   }
+
+  // 四角形でも toSide があれば優先（#355）
+  if (toSide === 'top') return { x: c.x, y: c.y - hh }
+  if (toSide === 'right') return { x: c.x + hw, y: c.y }
+  if (toSide === 'bottom') return { x: c.x, y: c.y + hh }
+  if (toSide === 'left') return { x: c.x - hw, y: c.y }
 
   // 同位置
   if (Math.abs(dx) < 1 && Math.abs(dy) < 1) return { x: c.x, y: c.y - hh }
@@ -350,6 +367,10 @@ export const entryPt = (
   // フォールバック
   return { x: c.x, y: c.y - hh }
 }
+
+/** ドロップ点とターゲットノード中心から接続先 side を判定する。
+ *  deriveFromSide と同一ロジック（dx/dy の符号と絶対値比較）。 */
+export const deriveToSide = deriveFromSide
 
 /**
  * 始点 s から終点 e への矢印パス(SVG path d属性)を生成する。

--- a/src/lib/flow-engine.test.ts
+++ b/src/lib/flow-engine.test.ts
@@ -272,6 +272,43 @@ describe('calcArrowPath', () => {
     // dx>0 → right 頂点 {234, 200}
     expect(r.d.startsWith('M234,200')).toBe(true)
   })
+
+  it('toSide=top で四角形ターゲットの上辺に入る (#355)', () => {
+    // from=(100, 50), to=(200, 200), hw=50, hh=25
+    // entryPt(to, from, toSide='top') → 上辺中央 (200, 175)
+    const r = calcArrowPath(
+      { x: 100, y: 50 },
+      { x: 200, y: 200 },
+      { hw: 50, hh: 25, rh: 84, toSide: 'top' as const },
+    )
+    expect(r.d).toContain('200,175')
+  })
+
+  it('diamond の toSide=left を尊重する (#355)', () => {
+    // to=(200, 100), DS=34, toSide='left' → 左頂点 (166, 100)
+    const r = calcArrowPath(
+      { x: 100, y: 50 },
+      { x: 200, y: 100 },
+      {
+        hw: 76,
+        hh: 28,
+        rh: 84,
+        toShape: 'diamond' as const,
+        toSide: 'left' as const,
+      },
+    )
+    expect(r.d).toContain('166,100')
+  })
+
+  it('toSide 未指定なら従来の auto ロジック (#355 後方互換)', () => {
+    // 既存テスト「cross-lane horizontal」と同じ条件で結果が変わらないこと
+    const r = calcArrowPath(
+      { x: 100, y: 200 },
+      { x: 400, y: 200 },
+      { hw: 76, hh: 28, rh: 84 },
+    )
+    expect(r.d).toBe('M176,200 L324,200')
+  })
 })
 
 /* ========================================================= */

--- a/src/lib/flow-engine.test.ts
+++ b/src/lib/flow-engine.test.ts
@@ -302,11 +302,7 @@ describe('calcArrowPath', () => {
 
   it('toSide 未指定なら従来の auto ロジック (#355 後方互換)', () => {
     // 既存テスト「cross-lane horizontal」と同じ条件で結果が変わらないこと
-    const r = calcArrowPath(
-      { x: 100, y: 200 },
-      { x: 400, y: 200 },
-      { hw: 76, hh: 28, rh: 84 },
-    )
+    const r = calcArrowPath({ x: 100, y: 200 }, { x: 400, y: 200 }, { hw: 76, hh: 28, rh: 84 })
     expect(r.d).toBe('M176,200 L324,200')
   })
 })

--- a/src/lib/flow-engine.ts
+++ b/src/lib/flow-engine.ts
@@ -19,6 +19,7 @@ interface ArrowConfig {
   fromShape?: 'diamond'
   toShape?: 'diamond'
   fromSide?: ArrowSide
+  toSide?: ArrowSide
 }
 
 /* --------------------------------------------------------- */
@@ -41,7 +42,7 @@ export function calcArrowPath(
   const f: Point = { x: from.x, y: from.y }
   const t: Point = { x: to.x, y: to.y }
   const s = exitPt(f, t, config.hw, config.hh, config.rh, config.fromShape, config.fromSide)
-  const e = entryPt(t, f, config.hw, config.hh, config.rh, config.toShape)
+  const e = entryPt(t, f, config.hw, config.hh, config.rh, config.toShape, config.toSide)
   return buildArrowPath(s, e, f, t, obstacles)
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,8 +10,10 @@ export interface InternalArrow {
   color?: string
   dash?: string
   bidirectional?: boolean
-  /** 接続元ノードのどの頂点/辺から線を出すか。diamond ノードのみ意味を持つ。 */
+  /** 接続元ノードのどの頂点/辺から線を出すか。未指定なら自動。 */
   fromSide?: ArrowSide
+  /** 接続先ノードのどの頂点/辺に線を入れるか。未指定なら自動。 */
+  toSide?: ArrowSide
 }
 
 /** 矢印パス計算結果（DOM/React非依存） */

--- a/src/locales/en/editor.json
+++ b/src/locales/en/editor.json
@@ -53,6 +53,7 @@
     "arrowColor": "Line color",
     "arrowStyle": "Line style",
     "arrowFromSide": "Exit side",
+    "arrowToSide": "Entry side",
     "arrowSideAuto": "Auto",
     "arrowSideTop": "Top",
     "arrowSideRight": "Right",

--- a/src/locales/ja/editor.json
+++ b/src/locales/ja/editor.json
@@ -53,6 +53,7 @@
     "arrowColor": "線の色",
     "arrowStyle": "線の種類",
     "arrowFromSide": "出口側",
+    "arrowToSide": "入口側",
     "arrowSideAuto": "自動",
     "arrowSideTop": "上",
     "arrowSideRight": "右",

--- a/tests/helpers/mock-d1.ts
+++ b/tests/helpers/mock-d1.ts
@@ -19,6 +19,7 @@ export function createTestDb(): ReturnType<typeof Database> {
     '0011_arrow_bidirectional.sql',
     '0012_lane_groups.sql',
     '0013_arrow_from_side.sql',
+    '0014_arrow_to_side.sql',
   ]
   for (const file of migrationFiles) {
     const sql = readFileSync(resolve(__dirname, '../../migrations/', file), 'utf-8')


### PR DESCRIPTION
## Summary

- 矢印に `toSide?: ArrowSide` を追加し、ドラッグ完了時のドロップ位置から自動派生
- 四角形ノードでも `fromSide` / `toSide` を honor（従来は diamond 限定）
- プロパティパネルの「出口側」 diamond ガード撤廃 → 矢印選択中は常に表示
- 「入口側」セレクタを新規追加（diamond/四角形どちらでも 5 択）
- DB マイグレーション 0014: `arrows.to_side TEXT` カラム追加
- API ラウンドトリップ（Zod / INSERT 文 ×2 / toArrow / ArrowRow）
- `shared/types.ts` の `ArrowSide` を継続活用（#357 で集約済み）

## 設計判断

- `deriveToSide = deriveFromSide`（dx/dy の符号と絶対値比較ロジックは同一なので alias とした）
- `entryPt` に新規パラメータ `toSide?: ArrowSide` を追加（diamond/rect どちらでも早期 return）
- `exitPt` の rectangle 分岐にも `fromSide` 早期 return を追加

## 後方互換

- 既存矢印（fromSide/toSide が NULL）は従来の auto ロジックのまま
- 既存ひし形 fromSide 指定の矢印も挙動不変
- DB マイグレーション 0014 は `ALTER TABLE ... ADD COLUMN ... TEXT`（既存行は NULL 設定で安全）

## Test plan

- [x] TDD で 17 件の新規 unit test 追加（exitPt rect+fromSide / entryPt toSide / deriveToSide / calcArrowPath toSide）
- [x] 全 1667 テスト pass（前回 1645 + 新規 22）
- [x] `npm run build` 成功
- [x] `npx tsc -b` 型チェック pass
- [x] `npx prettier --check .` OK
- [x] `npx eslint .` エラーなし（既存 4 warnings のみ）
- [ ] dev サーバで実画面確認（ローカル wrangler API auth 既知の 500 問題で未実施。Cloudflare Pages preview で確認推奨）

## 関連 issue

- #349 (#352): ひし形 fromSide 実装 — 本 PR の前段
- #357 (#361): ArrowSide 型集約 — `shared/types.ts` を活用
- #356 (#362): SharedFlowViewer 統一 — 共有ビュー側の同時更新リスクを低減
- #69: 共有ビュー描画乖離バグ — 本 PR でも SharedFlowViewer に toSide パススルー済み

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)