### PR TITLE
feat: 矢印ルーティング段階3・段階4（ジャンパー描画 + トラック割当）

### DIFF
--- a/src/features/editor/FlowEditor.tsx
+++ b/src/features/editor/FlowEditor.tsx
@@ -62,7 +62,7 @@ import {
   calcMultiDropTargets,
   cellFromPos as cellFromPosLib,
 } from '../../lib/flow-engine'
-import { routeAllArrows, type ArrowResolveContext } from '../../lib/edge-router'
+import { routeAllArrowsWithJumpers, type ArrowResolveContext } from '../../lib/edge-router'
 import { isGroupParent, isGroupSub, getGroupWidth } from '../../lib/lane-group-utils'
 
 // =============================================
@@ -1468,8 +1468,8 @@ export default function FlowEditor({
     }
   }
 
-  // routeAllArrows でマルチエッジ協調ルーティング（id 順で逐次計算し、先行 segments を後続 obstacles に含める）
-  const allArrowPaths = routeAllArrows(arrows, resolveArrowContext)
+  // routeAllArrowsWithJumpers でマルチエッジ協調ルーティング（id 順で逐次計算し、先行 segments を後続 obstacles に含める）
+  const allArrowPaths = routeAllArrowsWithJumpers(arrows, resolveArrowContext)
 
   // arrows[i] に対応するパスを id ベースで引く Map（O(1) ルックアップ）
   const pathByArrowId = new Map<string, ArrowPathResult | null>()

--- a/src/features/shared/SharedFlowViewer.tsx
+++ b/src/features/shared/SharedFlowViewer.tsx
@@ -121,53 +121,56 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
     original: a,
   }))
 
-  const routedPaths = routeAllArrowsWithJumpers(arrowsForRouting, (mapped): ArrowResolveContext | null => {
-    const arrow = mapped.original
-    const fromNode = nodeById[arrow.fromNodeId]
-    const toNode = nodeById[arrow.toNodeId]
-    if (!fromNode || !toNode) return null
+  const routedPaths = routeAllArrowsWithJumpers(
+    arrowsForRouting,
+    (mapped): ArrowResolveContext | null => {
+      const arrow = mapped.original
+      const fromNode = nodeById[arrow.fromNodeId]
+      const toNode = nodeById[arrow.toNodeId]
+      if (!fromNode || !toNode) return null
 
-    const fli = laneIdToIndex[fromNode.laneId]
-    const tli = laneIdToIndex[toNode.laneId]
-    if (fli === undefined || tli === undefined) return null
+      const fli = laneIdToIndex[fromNode.laneId]
+      const tli = laneIdToIndex[toNode.laneId]
+      if (fli === undefined || tli === undefined) return null
 
-    const f = ct(fli, fromNode.rowIndex)
-    const t = ct(tli, toNode.rowIndex)
-    const hw = TW / 2,
-      hh = TH / 2
+      const f = ct(fli, fromNode.rowIndex)
+      const t = ct(tli, toNode.rowIndex)
+      const hw = TW / 2,
+        hh = TH / 2
 
-    // 同一行/同一レーン/斜め配置に応じて obstacles を組み立てる（迂回判定用）
-    const obstacles: Bbox[] = buildObstacles({
-      nodes: obstacleNodes,
-      fromKey: fromNode.id,
-      toKey: toNode.id,
-      fromCx: f.x,
-      fromCy: f.y,
-      toCx: t.x,
-      toCy: t.y,
-      sameRow: fromNode.rowIndex === toNode.rowIndex,
-      sameLane: fromNode.laneId === toNode.laneId,
-      rowH: RH,
-      colW: LW + G,
-      bboxW: TW,
-      bboxH: TH,
-    })
+      // 同一行/同一レーン/斜め配置に応じて obstacles を組み立てる（迂回判定用）
+      const obstacles: Bbox[] = buildObstacles({
+        nodes: obstacleNodes,
+        fromKey: fromNode.id,
+        toKey: toNode.id,
+        fromCx: f.x,
+        fromCy: f.y,
+        toCx: t.x,
+        toCy: t.y,
+        sameRow: fromNode.rowIndex === toNode.rowIndex,
+        sameLane: fromNode.laneId === toNode.laneId,
+        rowH: RH,
+        colW: LW + G,
+        bboxW: TW,
+        bboxH: TH,
+      })
 
-    return {
-      from: f,
-      to: t,
-      config: {
-        hw,
-        hh,
-        rh: RH,
-        fromShape: fromNode.shape as 'diamond' | undefined,
-        toShape: toNode.shape as 'diamond' | undefined,
-        fromSide: arrow.fromSide ?? undefined,
-        toSide: arrow.toSide ?? undefined,
-      },
-      nodeObstacles: obstacles,
-    }
-  })
+      return {
+        from: f,
+        to: t,
+        config: {
+          hw,
+          hh,
+          rh: RH,
+          fromShape: fromNode.shape as 'diamond' | undefined,
+          toShape: toNode.shape as 'diamond' | undefined,
+          fromSide: arrow.fromSide ?? undefined,
+          toSide: arrow.toSide ?? undefined,
+        },
+        nodeObstacles: obstacles,
+      }
+    },
+  )
 
   const arrowPaths = flow.arrows
     .map((a, i) => ({ arrow: a, path: routedPaths[i] }))

--- a/src/features/shared/SharedFlowViewer.tsx
+++ b/src/features/shared/SharedFlowViewer.tsx
@@ -14,7 +14,7 @@ import {
   type Bbox,
   type ObstacleNode,
 } from '../../lib/arrow-routing'
-import { routeAllArrows } from '../../lib/edge-router'
+import { routeAllArrowsWithJumpers } from '../../lib/edge-router'
 import type { ArrowResolveContext } from '../../lib/edge-router'
 import { formatRelativeTime } from '../../lib/relative-time'
 import { isGroupSub, isGroupParent, getGroupWidth } from '../../lib/lane-group-utils'
@@ -121,7 +121,7 @@ export function SharedFlowViewer({ flow }: SharedFlowViewerProps) {
     original: a,
   }))
 
-  const routedPaths = routeAllArrows(arrowsForRouting, (mapped): ArrowResolveContext | null => {
+  const routedPaths = routeAllArrowsWithJumpers(arrowsForRouting, (mapped): ArrowResolveContext | null => {
     const arrow = mapped.original
     const fromNode = nodeById[arrow.fromNodeId]
     const toNode = nodeById[arrow.toNodeId]

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -1514,3 +1514,71 @@ describe('buildArrowPath segments — diagonal detour (4 kinds)', () => {
     expect(result.segments.map((sg) => sg.orientation)).toEqual(['v', 'h', 'v', 'h', 'v', 'h', 'v'])
   })
 })
+
+describe('buildArrowPath segments 構造（リファクタ安全網）', () => {
+  it('水平直線: segments は単一 H', () => {
+    const s = { x: 100, y: 200 }, e = { x: 300, y: 200 }
+    const fc = { x: 50, y: 200 }, tc = { x: 350, y: 200 }
+    const r = buildArrowPath(s, e, fc, tc)
+    expect(r.segments).toEqual([
+      { orientation: 'h', fixed: 200, range: [100, 300] },
+    ])
+  })
+
+  it('垂直直線: segments は単一 V', () => {
+    const s = { x: 200, y: 100 }, e = { x: 200, y: 300 }
+    const fc = { x: 200, y: 50 }, tc = { x: 200, y: 350 }
+    const r = buildArrowPath(s, e, fc, tc)
+    expect(r.segments).toEqual([
+      { orientation: 'v', fixed: 200, range: [100, 300] },
+    ])
+  })
+
+  it('H 迂回（下迂回）: segments は H-V-H-V-H の 5 セグ', () => {
+    const s = { x: 276, y: 200 }, e = { x: 524, y: 200 }
+    const fc = { x: 200, y: 200 }, tc = { x: 600, y: 200 }
+    const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B])
+    expect(r.segments).toEqual([
+      { orientation: 'h', fixed: 200, range: [276, 290] },
+      { orientation: 'v', fixed: 290, range: [200, 242] },
+      { orientation: 'h', fixed: 242, range: [290, 510] },
+      { orientation: 'v', fixed: 510, range: [200, 242] },
+      { orientation: 'h', fixed: 200, range: [510, 524] },
+    ])
+  })
+
+  it('V 迂回（右迂回）: segments は V-H-V-H-V の 5 セグ', () => {
+    const s = { x: 200, y: 276 }, e = { x: 200, y: 524 }
+    const fc = { x: 200, y: 200 }, tc = { x: 200, y: 600 }
+    const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B])
+    expect(r.segments).toEqual([
+      { orientation: 'v', fixed: 200, range: [276, 290] },
+      { orientation: 'h', fixed: 290, range: [200, 290] },
+      { orientation: 'v', fixed: 290, range: [290, 510] },
+      { orientation: 'h', fixed: 510, range: [200, 290] },
+      { orientation: 'v', fixed: 200, range: [510, 524] },
+    ])
+  })
+
+  it('斜め配置（障害なし）: segments は H-V-H の 3 セグ', () => {
+    const s = { x: 200, y: 100 }, e = { x: 400, y: 300 }
+    const fc = { x: 200, y: 100 }, tc = { x: 400, y: 300 }
+    const r = buildArrowPath(s, e, fc, tc)
+    expect(r.segments).toEqual([
+      { orientation: 'h', fixed: 100, range: [200, 300] },
+      { orientation: 'v', fixed: 300, range: [100, 300] },
+      { orientation: 'h', fixed: 300, range: [300, 400] },
+    ])
+  })
+
+  it('水平直線（障害なし、別案件）: 単一 H', () => {
+    const s = { x: 200, y: 100 }, e = { x: 400, y: 100 }
+    const fc = { x: 200, y: 100 }, tc = { x: 400, y: 100 }
+    const r = buildArrowPath(s, e, fc, tc)
+    expect(r.segments).toEqual([
+      { orientation: 'h', fixed: 100, range: [200, 400] },
+    ])
+  })
+})

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -1535,6 +1535,10 @@ describe('buildArrowPath segments 構造（リファクタ安全網）', () => {
   })
 
   it('H 迂回（下迂回）: segments は H-V-H-V-H の 5 セグ', () => {
+    // 障害 B: x=400, w=152 → 中央x=476, 右端=476。detourY 計算:
+    //   障害 y=200, h=56 → 中央y=228。障害が下塞がり → detourY = 228+DETOUR_MARGIN(14) = 242
+    //   s.x=276, departX = 276+DEPART_GAP(14) = 290
+    //   e.x=524, approachX = 524-APPROACH_GAP(14) = 510
     const s = { x: 276, y: 200 }, e = { x: 524, y: 200 }
     const fc = { x: 200, y: 200 }, tc = { x: 600, y: 200 }
     const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
@@ -1549,6 +1553,9 @@ describe('buildArrowPath segments 構造（リファクタ安全網）', () => {
   })
 
   it('V 迂回（右迂回）: segments は V-H-V-H-V の 5 セグ', () => {
+    // 障害 B: x=200, w=152 → 中央x=276。障害が右塞がり → detourX = 276+DETOUR_MARGIN(14) = 290
+    //   s.y=276, departY = 276+DEPART_GAP(14) = 290
+    //   e.y=524, approachY = 524-APPROACH_GAP(14) = 510
     const s = { x: 200, y: 276 }, e = { x: 200, y: 524 }
     const fc = { x: 200, y: 200 }, tc = { x: 200, y: 600 }
     const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
@@ -1573,12 +1580,4 @@ describe('buildArrowPath segments 構造（リファクタ安全網）', () => {
     ])
   })
 
-  it('水平直線（障害なし、別案件）: 単一 H', () => {
-    const s = { x: 200, y: 100 }, e = { x: 400, y: 100 }
-    const fc = { x: 200, y: 100 }, tc = { x: 400, y: 100 }
-    const r = buildArrowPath(s, e, fc, tc)
-    expect(r.segments).toEqual([
-      { orientation: 'h', fixed: 100, range: [200, 400] },
-    ])
-  })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -1620,6 +1620,46 @@ describe('segmentsToD', () => {
     ]
     expect(segmentsToD(segs)).toBe('M200,100 L200,200 L400,200 L400,300')
   })
+
+  it('jumps あり: 単一ジャンプ点（goingRight）', () => {
+    const segs: EdgeSegment[] = [
+      { orientation: 'h', fixed: 200, range: [100, 300] },
+    ]
+    const jumps = new Map([[0, [200]]])
+    const d = segmentsToD(segs, jumps)
+    expect(d).toBe('M100,200 L195,200 A5,5 0 0 1 205,200 L300,200')
+  })
+
+  it('jumps あり: 単一ジャンプ点（逆方向 goingRight=false）', () => {
+    const segs: EdgeSegment[] = [
+      { orientation: 'h', fixed: 200, range: [300, 100] },
+    ]
+    const jumps = new Map([[0, [200]]])
+    const d = segmentsToD(segs, jumps)
+    // sweep=0（逆方向でも上膨らみ）
+    expect(d).toBe('M300,200 L205,200 A5,5 0 0 0 195,200 L100,200')
+  })
+
+  it('jumps あり: 複数ジャンプ点が進行方向順にソートされる', () => {
+    const segs: EdgeSegment[] = [
+      { orientation: 'h', fixed: 200, range: [100, 400] },
+    ]
+    // 順序を逆に渡しても、進行方向（左→右）で 150 → 300 の順に処理される
+    const jumps = new Map([[0, [300, 150]]])
+    const d = segmentsToD(segs, jumps)
+    expect(d).toBe('M100,200 L145,200 A5,5 0 0 1 155,200 L295,200 A5,5 0 0 1 305,200 L400,200')
+  })
+
+  it('V セグの jumps エントリは無視される', () => {
+    const segs: EdgeSegment[] = [
+      { orientation: 'h', fixed: 200, range: [0, 200] },
+      { orientation: 'v', fixed: 200, range: [200, 400] },
+    ]
+    // V セグの index=1 に jumps を渡しても V には弧が乗らない（規約）
+    const jumps = new Map([[1, [300]]])
+    const d = segmentsToD(segs, jumps)
+    expect(d).toBe('M0,200 L200,200 L200,400')
+  })
 })
 
 describe('detectCrossings', () => {

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -17,7 +17,6 @@ import {
   type EdgeSegment,
   type ObstacleNode,
   type EdgeWithSegments,
-  type Crossing,
 } from './arrow-routing'
 import type { ArrowSide } from './types'
 
@@ -1521,21 +1520,21 @@ describe('buildArrowPath segments — diagonal detour (4 kinds)', () => {
 
 describe('buildArrowPath segments 構造（リファクタ安全網）', () => {
   it('水平直線: segments は単一 H', () => {
-    const s = { x: 100, y: 200 }, e = { x: 300, y: 200 }
-    const fc = { x: 50, y: 200 }, tc = { x: 350, y: 200 }
+    const s = { x: 100, y: 200 },
+      e = { x: 300, y: 200 }
+    const fc = { x: 50, y: 200 },
+      tc = { x: 350, y: 200 }
     const r = buildArrowPath(s, e, fc, tc)
-    expect(r.segments).toEqual([
-      { orientation: 'h', fixed: 200, range: [100, 300] },
-    ])
+    expect(r.segments).toEqual([{ orientation: 'h', fixed: 200, range: [100, 300] }])
   })
 
   it('垂直直線: segments は単一 V', () => {
-    const s = { x: 200, y: 100 }, e = { x: 200, y: 300 }
-    const fc = { x: 200, y: 50 }, tc = { x: 200, y: 350 }
+    const s = { x: 200, y: 100 },
+      e = { x: 200, y: 300 }
+    const fc = { x: 200, y: 50 },
+      tc = { x: 200, y: 350 }
     const r = buildArrowPath(s, e, fc, tc)
-    expect(r.segments).toEqual([
-      { orientation: 'v', fixed: 200, range: [100, 300] },
-    ])
+    expect(r.segments).toEqual([{ orientation: 'v', fixed: 200, range: [100, 300] }])
   })
 
   it('H 迂回（下迂回）: segments は H-V-H-V-H の 5 セグ', () => {
@@ -1543,16 +1542,18 @@ describe('buildArrowPath segments 構造（リファクタ安全網）', () => {
     //   障害 y=200, h=56 → 中央y=228。障害が下塞がり → detourY = 228+DETOUR_MARGIN(14) = 242
     //   s.x=276, departX = 276+DEPART_GAP(14) = 290
     //   e.x=524, approachX = 524-APPROACH_GAP(14) = 510
-    const s = { x: 276, y: 200 }, e = { x: 524, y: 200 }
-    const fc = { x: 200, y: 200 }, tc = { x: 600, y: 200 }
+    const s = { x: 276, y: 200 },
+      e = { x: 524, y: 200 }
+    const fc = { x: 200, y: 200 },
+      tc = { x: 600, y: 200 }
     const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
     const r = buildArrowPath(s, e, fc, tc, [B])
     expect(r.segments).toEqual([
-      { orientation: 'h', fixed: 200, range: [276, 290] },    // s.x → departX
-      { orientation: 'v', fixed: 290, range: [200, 242] },    // s.y → detourY
-      { orientation: 'h', fixed: 242, range: [290, 510] },    // departX → approachX
-      { orientation: 'v', fixed: 510, range: [242, 200] },    // detourY → e.y (下→上)
-      { orientation: 'h', fixed: 200, range: [510, 524] },    // approachX → e.x
+      { orientation: 'h', fixed: 200, range: [276, 290] }, // s.x → departX
+      { orientation: 'v', fixed: 290, range: [200, 242] }, // s.y → detourY
+      { orientation: 'h', fixed: 242, range: [290, 510] }, // departX → approachX
+      { orientation: 'v', fixed: 510, range: [242, 200] }, // detourY → e.y (下→上)
+      { orientation: 'h', fixed: 200, range: [510, 524] }, // approachX → e.x
     ])
   })
 
@@ -1560,22 +1561,26 @@ describe('buildArrowPath segments 構造（リファクタ安全網）', () => {
     // 障害 B: x=200, w=152 → 中央x=276。障害が右塞がり → detourX = 276+DETOUR_MARGIN(14) = 290
     //   s.y=276, departY = 276+DEPART_GAP(14) = 290
     //   e.y=524, approachY = 524-APPROACH_GAP(14) = 510
-    const s = { x: 200, y: 276 }, e = { x: 200, y: 524 }
-    const fc = { x: 200, y: 200 }, tc = { x: 200, y: 600 }
+    const s = { x: 200, y: 276 },
+      e = { x: 200, y: 524 }
+    const fc = { x: 200, y: 200 },
+      tc = { x: 200, y: 600 }
     const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
     const r = buildArrowPath(s, e, fc, tc, [B])
     expect(r.segments).toEqual([
-      { orientation: 'v', fixed: 200, range: [276, 290] },    // s.y → departY
-      { orientation: 'h', fixed: 290, range: [200, 290] },    // s.x → detourX
-      { orientation: 'v', fixed: 290, range: [290, 510] },    // departY → approachY
-      { orientation: 'h', fixed: 510, range: [290, 200] },    // detourX → e.x (右→左)
-      { orientation: 'v', fixed: 200, range: [510, 524] },    // approachY → e.y
+      { orientation: 'v', fixed: 200, range: [276, 290] }, // s.y → departY
+      { orientation: 'h', fixed: 290, range: [200, 290] }, // s.x → detourX
+      { orientation: 'v', fixed: 290, range: [290, 510] }, // departY → approachY
+      { orientation: 'h', fixed: 510, range: [290, 200] }, // detourX → e.x (右→左)
+      { orientation: 'v', fixed: 200, range: [510, 524] }, // approachY → e.y
     ])
   })
 
   it('斜め配置（障害なし）: segments は H-V-H の 3 セグ', () => {
-    const s = { x: 200, y: 100 }, e = { x: 400, y: 300 }
-    const fc = { x: 200, y: 100 }, tc = { x: 400, y: 300 }
+    const s = { x: 200, y: 100 },
+      e = { x: 400, y: 300 }
+    const fc = { x: 200, y: 100 },
+      tc = { x: 400, y: 300 }
     const r = buildArrowPath(s, e, fc, tc)
     expect(r.segments).toEqual([
       { orientation: 'h', fixed: 100, range: [200, 300] },
@@ -1583,7 +1588,6 @@ describe('buildArrowPath segments 構造（リファクタ安全網）', () => {
       { orientation: 'h', fixed: 300, range: [300, 400] },
     ])
   })
-
 })
 
 describe('segmentsToD', () => {
@@ -1592,23 +1596,17 @@ describe('segmentsToD', () => {
   })
 
   it('水平直線 1 セグ（range[0] < range[1]）', () => {
-    const segs: EdgeSegment[] = [
-      { orientation: 'h', fixed: 200, range: [100, 300] },
-    ]
+    const segs: EdgeSegment[] = [{ orientation: 'h', fixed: 200, range: [100, 300] }]
     expect(segmentsToD(segs)).toBe('M100,200 L300,200')
   })
 
   it('水平直線 1 セグ（range[0] > range[1]、逆方向）', () => {
-    const segs: EdgeSegment[] = [
-      { orientation: 'h', fixed: 200, range: [300, 100] },
-    ]
+    const segs: EdgeSegment[] = [{ orientation: 'h', fixed: 200, range: [300, 100] }]
     expect(segmentsToD(segs)).toBe('M300,200 L100,200')
   })
 
   it('垂直直線 1 セグ', () => {
-    const segs: EdgeSegment[] = [
-      { orientation: 'v', fixed: 200, range: [100, 300] },
-    ]
+    const segs: EdgeSegment[] = [{ orientation: 'v', fixed: 200, range: [100, 300] }]
     expect(segmentsToD(segs)).toBe('M200,100 L200,300')
   })
 
@@ -1622,18 +1620,14 @@ describe('segmentsToD', () => {
   })
 
   it('jumps あり: 単一ジャンプ点（goingRight）', () => {
-    const segs: EdgeSegment[] = [
-      { orientation: 'h', fixed: 200, range: [100, 300] },
-    ]
+    const segs: EdgeSegment[] = [{ orientation: 'h', fixed: 200, range: [100, 300] }]
     const jumps = new Map([[0, [200]]])
     const d = segmentsToD(segs, jumps)
     expect(d).toBe('M100,200 L195,200 A5,5 0 0 1 205,200 L300,200')
   })
 
   it('jumps あり: 単一ジャンプ点（逆方向 goingRight=false）', () => {
-    const segs: EdgeSegment[] = [
-      { orientation: 'h', fixed: 200, range: [300, 100] },
-    ]
+    const segs: EdgeSegment[] = [{ orientation: 'h', fixed: 200, range: [300, 100] }]
     const jumps = new Map([[0, [200]]])
     const d = segmentsToD(segs, jumps)
     // sweep=0（逆方向でも上膨らみ）
@@ -1641,9 +1635,7 @@ describe('segmentsToD', () => {
   })
 
   it('jumps あり: 複数ジャンプ点が進行方向順にソートされる', () => {
-    const segs: EdgeSegment[] = [
-      { orientation: 'h', fixed: 200, range: [100, 400] },
-    ]
+    const segs: EdgeSegment[] = [{ orientation: 'h', fixed: 200, range: [100, 400] }]
     // 順序を逆に渡しても、進行方向（左→右）で 150 → 300 の順に処理される
     const jumps = new Map([[0, [300, 150]]])
     const d = segmentsToD(segs, jumps)
@@ -1665,16 +1657,28 @@ describe('segmentsToD', () => {
 describe('detectCrossings', () => {
   it('交差なし: 空配列を返す', () => {
     const edges: EdgeWithSegments[] = [
-      { id: 'a', segments: [{ orientation: 'h' as const, fixed: 100, range: [0, 200] as [number, number] }] },
-      { id: 'b', segments: [{ orientation: 'h' as const, fixed: 200, range: [0, 200] as [number, number] }] },
+      {
+        id: 'a',
+        segments: [{ orientation: 'h' as const, fixed: 100, range: [0, 200] as [number, number] }],
+      },
+      {
+        id: 'b',
+        segments: [{ orientation: 'h' as const, fixed: 200, range: [0, 200] as [number, number] }],
+      },
     ]
     expect(detectCrossings(edges)).toEqual([])
   })
 
   it('H × V 交差: 1 件検出', () => {
     const edges: EdgeWithSegments[] = [
-      { id: 'a', segments: [{ orientation: 'h' as const, fixed: 100, range: [0, 200] as [number, number] }] },
-      { id: 'b', segments: [{ orientation: 'v' as const, fixed: 100, range: [0, 200] as [number, number] }] },
+      {
+        id: 'a',
+        segments: [{ orientation: 'h' as const, fixed: 100, range: [0, 200] as [number, number] }],
+      },
+      {
+        id: 'b',
+        segments: [{ orientation: 'v' as const, fixed: 100, range: [0, 200] as [number, number] }],
+      },
     ]
     const result = detectCrossings(edges)
     expect(result).toHaveLength(1)
@@ -1684,18 +1688,27 @@ describe('detectCrossings', () => {
   it('端点マージン: CROSSING_MARGIN=7 以内の交差は除外', () => {
     // V の fixed=95 は H の終点 100 から 5px (< CROSSING_MARGIN=7) なので除外
     const edges: EdgeWithSegments[] = [
-      { id: 'a', segments: [{ orientation: 'h' as const, fixed: 100, range: [0, 100] as [number, number] }] },
-      { id: 'b', segments: [{ orientation: 'v' as const, fixed: 95, range: [0, 200] as [number, number] }] },
+      {
+        id: 'a',
+        segments: [{ orientation: 'h' as const, fixed: 100, range: [0, 100] as [number, number] }],
+      },
+      {
+        id: 'b',
+        segments: [{ orientation: 'v' as const, fixed: 95, range: [0, 200] as [number, number] }],
+      },
     ]
     expect(detectCrossings(edges)).toEqual([])
   })
 
   it('同一エッジ内の自己交差は無視', () => {
     const edges: EdgeWithSegments[] = [
-      { id: 'a', segments: [
-        { orientation: 'h' as const, fixed: 100, range: [0, 200] as [number, number] },
-        { orientation: 'v' as const, fixed: 100, range: [50, 150] as [number, number] },
-      ]},
+      {
+        id: 'a',
+        segments: [
+          { orientation: 'h' as const, fixed: 100, range: [0, 200] as [number, number] },
+          { orientation: 'v' as const, fixed: 100, range: [50, 150] as [number, number] },
+        ],
+      },
     ]
     expect(detectCrossings(edges)).toEqual([])
   })
@@ -1707,14 +1720,20 @@ describe('detectCrossings', () => {
     //   A の H(y=100) × B の V(x=50): (50, 100) — jumperEdgeId=A
     //   B の H(y=200) × A の V(x=150): (150, 200) — jumperEdgeId=B
     const edges: EdgeWithSegments[] = [
-      { id: 'A', segments: [
-        { orientation: 'h' as const, fixed: 100, range: [0, 200] as [number, number] },
-        { orientation: 'v' as const, fixed: 150, range: [100, 300] as [number, number] },
-      ]},
-      { id: 'B', segments: [
-        { orientation: 'h' as const, fixed: 200, range: [100, 300] as [number, number] },
-        { orientation: 'v' as const, fixed: 50, range: [0, 200] as [number, number] },
-      ]},
+      {
+        id: 'A',
+        segments: [
+          { orientation: 'h' as const, fixed: 100, range: [0, 200] as [number, number] },
+          { orientation: 'v' as const, fixed: 150, range: [100, 300] as [number, number] },
+        ],
+      },
+      {
+        id: 'B',
+        segments: [
+          { orientation: 'h' as const, fixed: 200, range: [100, 300] as [number, number] },
+          { orientation: 'v' as const, fixed: 50, range: [0, 200] as [number, number] },
+        ],
+      },
     ]
     const result = detectCrossings(edges)
     expect(result).toHaveLength(2)
@@ -1724,8 +1743,14 @@ describe('detectCrossings', () => {
 
   it('V セグメントが基準でも H が jumper になる: 規約確認', () => {
     const edges: EdgeWithSegments[] = [
-      { id: 'a', segments: [{ orientation: 'v' as const, fixed: 100, range: [0, 200] as [number, number] }] },
-      { id: 'b', segments: [{ orientation: 'h' as const, fixed: 100, range: [0, 200] as [number, number] }] },
+      {
+        id: 'a',
+        segments: [{ orientation: 'v' as const, fixed: 100, range: [0, 200] as [number, number] }],
+      },
+      {
+        id: 'b',
+        segments: [{ orientation: 'h' as const, fixed: 100, range: [0, 200] as [number, number] }],
+      },
     ]
     const result = detectCrossings(edges)
     expect(result).toHaveLength(1)

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -1652,6 +1652,31 @@ describe('segmentsToD', () => {
     const d = segmentsToD(segs, jumps)
     expect(d).toBe('M0,200 L200,200 L200,400')
   })
+
+  it('密集ジャンプ: 2 * JUMP_RADIUS 未満で並ぶ交差は重複アーク描画を防止', () => {
+    const segs: EdgeSegment[] = [{ orientation: 'h', fixed: 200, range: [0, 400] }]
+    // 進行方向: 100 (afterX=105) → 108 (beforeX=103) は 105 より後退 → スキップ
+    const jumps = new Map([[0, [100, 108]]])
+    const d = segmentsToD(segs, jumps)
+    // 1 番目のアークのみ描画され、2 番目はスキップされる
+    expect(d).toBe('M0,200 L95,200 A5,5 0 0 1 105,200 L400,200')
+  })
+
+  it('密集ジャンプ（逆方向）: goingRight=false でも重複が抑止される', () => {
+    const segs: EdgeSegment[] = [{ orientation: 'h', fixed: 200, range: [400, 0] }]
+    // 進行方向: 300 (afterX=295) → 292 (beforeX=297) は 295 より後退 → スキップ
+    const jumps = new Map([[0, [300, 292]]])
+    const d = segmentsToD(segs, jumps)
+    expect(d).toBe('M400,200 L305,200 A5,5 0 0 0 295,200 L0,200')
+  })
+
+  it('十分離れた密集ジャンプ: 両方描画される', () => {
+    const segs: EdgeSegment[] = [{ orientation: 'h', fixed: 200, range: [0, 400] }]
+    // 100 (afterX=105) → 200 (beforeX=195) は 105 より進行 → 両方描画
+    const jumps = new Map([[0, [100, 200]]])
+    const d = segmentsToD(segs, jumps)
+    expect(d).toBe('M0,200 L95,200 A5,5 0 0 1 105,200 L195,200 A5,5 0 0 1 205,200 L400,200')
+  })
 })
 
 describe('detectCrossings', () => {

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -11,10 +11,13 @@ import {
   entryPt,
   segmentsToBboxes,
   segmentsToD,
+  detectCrossings,
   DS,
   type Bbox,
   type EdgeSegment,
   type ObstacleNode,
+  type EdgeWithSegments,
+  type Crossing,
 } from './arrow-routing'
 import type { ArrowSide } from './types'
 
@@ -1616,5 +1619,76 @@ describe('segmentsToD', () => {
       { orientation: 'v', fixed: 400, range: [200, 300] },
     ]
     expect(segmentsToD(segs)).toBe('M200,100 L200,200 L400,200 L400,300')
+  })
+})
+
+describe('detectCrossings', () => {
+  it('交差なし: 空配列を返す', () => {
+    const edges: EdgeWithSegments[] = [
+      { id: 'a', segments: [{ orientation: 'h' as const, fixed: 100, range: [0, 200] as [number, number] }] },
+      { id: 'b', segments: [{ orientation: 'h' as const, fixed: 200, range: [0, 200] as [number, number] }] },
+    ]
+    expect(detectCrossings(edges)).toEqual([])
+  })
+
+  it('H × V 交差: 1 件検出', () => {
+    const edges: EdgeWithSegments[] = [
+      { id: 'a', segments: [{ orientation: 'h' as const, fixed: 100, range: [0, 200] as [number, number] }] },
+      { id: 'b', segments: [{ orientation: 'v' as const, fixed: 100, range: [0, 200] as [number, number] }] },
+    ]
+    const result = detectCrossings(edges)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({ x: 100, y: 100, jumperEdgeId: 'a', jumperSegmentIndex: 0 })
+  })
+
+  it('端点マージン: CROSSING_MARGIN=7 以内の交差は除外', () => {
+    // V の fixed=95 は H の終点 100 から 5px (< CROSSING_MARGIN=7) なので除外
+    const edges: EdgeWithSegments[] = [
+      { id: 'a', segments: [{ orientation: 'h' as const, fixed: 100, range: [0, 100] as [number, number] }] },
+      { id: 'b', segments: [{ orientation: 'v' as const, fixed: 95, range: [0, 200] as [number, number] }] },
+    ]
+    expect(detectCrossings(edges)).toEqual([])
+  })
+
+  it('同一エッジ内の自己交差は無視', () => {
+    const edges: EdgeWithSegments[] = [
+      { id: 'a', segments: [
+        { orientation: 'h' as const, fixed: 100, range: [0, 200] as [number, number] },
+        { orientation: 'v' as const, fixed: 100, range: [50, 150] as [number, number] },
+      ]},
+    ]
+    expect(detectCrossings(edges)).toEqual([])
+  })
+
+  it('相互ジャンプ: A(H+V) と B(H+V) が絡み合う配置で 2 件検出', () => {
+    // A: H(y=100, x=[0,200]) + V(x=150, y=[100,300])
+    // B: H(y=200, x=[100,300]) + V(x=50, y=[0,200])
+    // 交差点:
+    //   A の H(y=100) × B の V(x=50): (50, 100) — jumperEdgeId=A
+    //   B の H(y=200) × A の V(x=150): (150, 200) — jumperEdgeId=B
+    const edges: EdgeWithSegments[] = [
+      { id: 'A', segments: [
+        { orientation: 'h' as const, fixed: 100, range: [0, 200] as [number, number] },
+        { orientation: 'v' as const, fixed: 150, range: [100, 300] as [number, number] },
+      ]},
+      { id: 'B', segments: [
+        { orientation: 'h' as const, fixed: 200, range: [100, 300] as [number, number] },
+        { orientation: 'v' as const, fixed: 50, range: [0, 200] as [number, number] },
+      ]},
+    ]
+    const result = detectCrossings(edges)
+    expect(result).toHaveLength(2)
+    expect(result).toContainEqual({ x: 50, y: 100, jumperEdgeId: 'A', jumperSegmentIndex: 0 })
+    expect(result).toContainEqual({ x: 150, y: 200, jumperEdgeId: 'B', jumperSegmentIndex: 0 })
+  })
+
+  it('V セグメントが基準でも H が jumper になる: 規約確認', () => {
+    const edges: EdgeWithSegments[] = [
+      { id: 'a', segments: [{ orientation: 'v' as const, fixed: 100, range: [0, 200] as [number, number] }] },
+      { id: 'b', segments: [{ orientation: 'h' as const, fixed: 100, range: [0, 200] as [number, number] }] },
+    ]
+    const result = detectCrossings(edges)
+    expect(result).toHaveLength(1)
+    expect(result[0].jumperEdgeId).toBe('b')
   })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -1545,11 +1545,11 @@ describe('buildArrowPath segments 構造（リファクタ安全網）', () => {
     const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
     const r = buildArrowPath(s, e, fc, tc, [B])
     expect(r.segments).toEqual([
-      { orientation: 'h', fixed: 200, range: [276, 290] },
-      { orientation: 'v', fixed: 290, range: [200, 242] },
-      { orientation: 'h', fixed: 242, range: [290, 510] },
-      { orientation: 'v', fixed: 510, range: [200, 242] },
-      { orientation: 'h', fixed: 200, range: [510, 524] },
+      { orientation: 'h', fixed: 200, range: [276, 290] },    // s.x → departX
+      { orientation: 'v', fixed: 290, range: [200, 242] },    // s.y → detourY
+      { orientation: 'h', fixed: 242, range: [290, 510] },    // departX → approachX
+      { orientation: 'v', fixed: 510, range: [242, 200] },    // detourY → e.y (下→上)
+      { orientation: 'h', fixed: 200, range: [510, 524] },    // approachX → e.x
     ])
   })
 
@@ -1562,11 +1562,11 @@ describe('buildArrowPath segments 構造（リファクタ安全網）', () => {
     const B: Bbox = { x: 200, y: 400, w: 152, h: 56 }
     const r = buildArrowPath(s, e, fc, tc, [B])
     expect(r.segments).toEqual([
-      { orientation: 'v', fixed: 200, range: [276, 290] },
-      { orientation: 'h', fixed: 290, range: [200, 290] },
-      { orientation: 'v', fixed: 290, range: [290, 510] },
-      { orientation: 'h', fixed: 510, range: [200, 290] },
-      { orientation: 'v', fixed: 200, range: [510, 524] },
+      { orientation: 'v', fixed: 200, range: [276, 290] },    // s.y → departY
+      { orientation: 'h', fixed: 290, range: [200, 290] },    // s.x → detourX
+      { orientation: 'v', fixed: 290, range: [290, 510] },    // departY → approachY
+      { orientation: 'h', fixed: 510, range: [290, 200] },    // detourX → e.x (右→左)
+      { orientation: 'v', fixed: 200, range: [510, 524] },    // approachY → e.y
     ])
   })
 

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -10,6 +10,7 @@ import {
   exitPt,
   entryPt,
   segmentsToBboxes,
+  segmentsToD,
   DS,
   type Bbox,
   type EdgeSegment,
@@ -1580,4 +1581,40 @@ describe('buildArrowPath segments 構造（リファクタ安全網）', () => {
     ])
   })
 
+})
+
+describe('segmentsToD', () => {
+  it('空配列 → 空文字列', () => {
+    expect(segmentsToD([])).toBe('')
+  })
+
+  it('水平直線 1 セグ（range[0] < range[1]）', () => {
+    const segs: EdgeSegment[] = [
+      { orientation: 'h', fixed: 200, range: [100, 300] },
+    ]
+    expect(segmentsToD(segs)).toBe('M100,200 L300,200')
+  })
+
+  it('水平直線 1 セグ（range[0] > range[1]、逆方向）', () => {
+    const segs: EdgeSegment[] = [
+      { orientation: 'h', fixed: 200, range: [300, 100] },
+    ]
+    expect(segmentsToD(segs)).toBe('M300,200 L100,200')
+  })
+
+  it('垂直直線 1 セグ', () => {
+    const segs: EdgeSegment[] = [
+      { orientation: 'v', fixed: 200, range: [100, 300] },
+    ]
+    expect(segmentsToD(segs)).toBe('M200,100 L200,300')
+  })
+
+  it('Z字 3セグ', () => {
+    const segs: EdgeSegment[] = [
+      { orientation: 'v', fixed: 200, range: [100, 200] },
+      { orientation: 'h', fixed: 200, range: [200, 400] },
+      { orientation: 'v', fixed: 400, range: [200, 300] },
+    ]
+    expect(segmentsToD(segs)).toBe('M200,100 L200,200 L400,200 L400,300')
+  })
 })

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -1732,3 +1732,45 @@ describe('detectCrossings', () => {
     expect(result[0].jumperEdgeId).toBe('b')
   })
 })
+
+describe('escalateDetourTrack（buildArrowPath 経由で検証）', () => {
+  it('薄いセグメント衝突なし: 元の detourY のまま', () => {
+    const s = { x: 100, y: 200 }
+    const e = { x: 500, y: 200 }
+    const fc = { x: 50, y: 200 }
+    const tc = { x: 550, y: 200 }
+    const B: Bbox = { x: 300, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B])
+    // 障害ノード B 中心 y=200, h=56 → 下端 y=228, +DETOUR_MARGIN(14) → detourY=242
+    expect(r.my).toBe(242)
+  })
+
+  it('薄いセグメント衝突あり: TRACK_GAP=8 だけ direction 方向にシフト', () => {
+    const s = { x: 100, y: 200 }
+    const e = { x: 500, y: 200 }
+    const fc = { x: 50, y: 200 }
+    const tc = { x: 550, y: 200 }
+    const B: Bbox = { x: 300, y: 200, w: 152, h: 56 }
+    // detourY 候補 y=242 に既存の薄い H セグメントを配置（goDown=true、direction=+1）
+    const thinH: Bbox = { x: 300, y: 242, w: 200, h: 1 }
+    const r = buildArrowPath(s, e, fc, tc, [B, thinH])
+    // 衝突するので 242 + 8 = 250 にシフト
+    expect(r.my).toBe(250)
+  })
+
+  it('MAX_TRACK_ESCALATIONS 超過: 最終値を返す（無限ループしない）', () => {
+    const s = { x: 100, y: 200 }
+    const e = { x: 500, y: 200 }
+    const fc = { x: 50, y: 200 }
+    const tc = { x: 550, y: 200 }
+    const B: Bbox = { x: 300, y: 200, w: 152, h: 56 }
+    // 薄い H を 8px 間隔で 10 個並べて escalation を強制
+    const thins: Bbox[] = []
+    for (let i = 0; i < 10; i++) {
+      thins.push({ x: 300, y: 242 + i * 8, w: 200, h: 1 })
+    }
+    // 6 回 escalation して 242 + 6*8 = 290 で打ち切り
+    const r = buildArrowPath(s, e, fc, tc, [B, ...thins])
+    expect(r.my).toBe(290)
+  })
+})

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -580,11 +580,11 @@ export const buildArrowPath = (
       // 6 セグメント: M → 水平(departX まで) → 垂直(detourY まで) → 水平(approachX まで)
       //               → 垂直(e.y まで) → 水平(e.x へ進入)
       const segments: EdgeSegment[] = [
-        { orientation: 'h', fixed: s.y, range: [s.x, departX] },         // s.x → departX
-        { orientation: 'v', fixed: departX, range: [s.y, detourY] },      // s.y → detourY
+        { orientation: 'h', fixed: s.y, range: [s.x, departX] }, // s.x → departX
+        { orientation: 'v', fixed: departX, range: [s.y, detourY] }, // s.y → detourY
         { orientation: 'h', fixed: detourY, range: [departX, approachX] }, // departX → approachX
-        { orientation: 'v', fixed: approachX, range: [detourY, e.y] },    // detourY → e.y
-        { orientation: 'h', fixed: e.y, range: [approachX, e.x] },        // approachX → e.x
+        { orientation: 'v', fixed: approachX, range: [detourY, e.y] }, // detourY → e.y
+        { orientation: 'h', fixed: e.y, range: [approachX, e.x] }, // approachX → e.x
       ]
       return { d: segmentsToD(segments), mx: (s.x + e.x) / 2, my: detourY, segments }
     }
@@ -602,11 +602,11 @@ export const buildArrowPath = (
       // 6 セグメント: M → 垂直(departY まで) → 水平(detourX まで) → 垂直(approachY まで)
       //               → 水平(e.x まで) → 垂直(e.y へ進入)
       const segments: EdgeSegment[] = [
-        { orientation: 'v', fixed: s.x, range: [s.y, departY] },          // s.y → departY
-        { orientation: 'h', fixed: departY, range: [s.x, detourX] },       // s.x → detourX
+        { orientation: 'v', fixed: s.x, range: [s.y, departY] }, // s.y → departY
+        { orientation: 'h', fixed: departY, range: [s.x, detourX] }, // s.x → detourX
         { orientation: 'v', fixed: detourX, range: [departY, approachY] }, // departY → approachY
-        { orientation: 'h', fixed: approachY, range: [detourX, e.x] },     // detourX → e.x
-        { orientation: 'v', fixed: e.x, range: [approachY, e.y] },         // approachY → e.y
+        { orientation: 'h', fixed: approachY, range: [detourX, e.x] }, // detourX → e.x
+        { orientation: 'v', fixed: e.x, range: [approachY, e.y] }, // approachY → e.y
       ]
       return { d: segmentsToD(segments), mx: detourX, my: (s.y + e.y) / 2, segments }
     }
@@ -617,44 +617,44 @@ export const buildArrowPath = (
         case 'target-detour': {
           const { my, detourX, approachY } = dDetour
           const segments: EdgeSegment[] = [
-            { orientation: 'v', fixed: s.x, range: [s.y, my] },           // s.y → my
-            { orientation: 'h', fixed: my, range: [s.x, detourX] },        // s.x → detourX
-            { orientation: 'v', fixed: detourX, range: [my, approachY] },  // my → approachY
+            { orientation: 'v', fixed: s.x, range: [s.y, my] }, // s.y → my
+            { orientation: 'h', fixed: my, range: [s.x, detourX] }, // s.x → detourX
+            { orientation: 'v', fixed: detourX, range: [my, approachY] }, // my → approachY
             { orientation: 'h', fixed: approachY, range: [detourX, e.x] }, // detourX → e.x
-            { orientation: 'v', fixed: e.x, range: [approachY, e.y] },     // approachY → e.y
+            { orientation: 'v', fixed: e.x, range: [approachY, e.y] }, // approachY → e.y
           ]
           return { d: segmentsToD(segments), mx: (s.x + detourX) / 2, my, segments }
         }
         case 'source-detour': {
           const { departY, detourX, my } = dDetour
           const segments: EdgeSegment[] = [
-            { orientation: 'v', fixed: s.x, range: [s.y, departY] },       // s.y → departY
-            { orientation: 'h', fixed: departY, range: [s.x, detourX] },   // s.x → detourX
-            { orientation: 'v', fixed: detourX, range: [departY, my] },     // departY → my
-            { orientation: 'h', fixed: my, range: [detourX, e.x] },         // detourX → e.x
-            { orientation: 'v', fixed: e.x, range: [my, e.y] },             // my → e.y
+            { orientation: 'v', fixed: s.x, range: [s.y, departY] }, // s.y → departY
+            { orientation: 'h', fixed: departY, range: [s.x, detourX] }, // s.x → detourX
+            { orientation: 'v', fixed: detourX, range: [departY, my] }, // departY → my
+            { orientation: 'h', fixed: my, range: [detourX, e.x] }, // detourX → e.x
+            { orientation: 'v', fixed: e.x, range: [my, e.y] }, // my → e.y
           ]
           return { d: segmentsToD(segments), mx: (detourX + e.x) / 2, my, segments }
         }
         case 'both-detour': {
           const { departY, sourceDetourX, my, targetDetourX, approachY } = dDetour
           const segments: EdgeSegment[] = [
-            { orientation: 'v', fixed: s.x, range: [s.y, departY] },                          // s.y → departY
-            { orientation: 'h', fixed: departY, range: [s.x, sourceDetourX] },                // s.x → sourceDetourX
-            { orientation: 'v', fixed: sourceDetourX, range: [departY, my] },                 // departY → my
-            { orientation: 'h', fixed: my, range: [sourceDetourX, targetDetourX] },           // sourceDetourX → targetDetourX
-            { orientation: 'v', fixed: targetDetourX, range: [my, approachY] },               // my → approachY
-            { orientation: 'h', fixed: approachY, range: [targetDetourX, e.x] },              // targetDetourX → e.x
-            { orientation: 'v', fixed: e.x, range: [approachY, e.y] },                        // approachY → e.y
+            { orientation: 'v', fixed: s.x, range: [s.y, departY] }, // s.y → departY
+            { orientation: 'h', fixed: departY, range: [s.x, sourceDetourX] }, // s.x → sourceDetourX
+            { orientation: 'v', fixed: sourceDetourX, range: [departY, my] }, // departY → my
+            { orientation: 'h', fixed: my, range: [sourceDetourX, targetDetourX] }, // sourceDetourX → targetDetourX
+            { orientation: 'v', fixed: targetDetourX, range: [my, approachY] }, // my → approachY
+            { orientation: 'h', fixed: approachY, range: [targetDetourX, e.x] }, // targetDetourX → e.x
+            { orientation: 'v', fixed: e.x, range: [approachY, e.y] }, // approachY → e.y
           ]
           return { d: segmentsToD(segments), mx: (sourceDetourX + targetDetourX) / 2, my, segments }
         }
         case 'shift-my': {
           const { my } = dDetour
           const segments: EdgeSegment[] = [
-            { orientation: 'v', fixed: s.x, range: [s.y, my] },   // s.y → my
-            { orientation: 'h', fixed: my, range: [s.x, e.x] },    // s.x → e.x
-            { orientation: 'v', fixed: e.x, range: [my, e.y] },    // my → e.y
+            { orientation: 'v', fixed: s.x, range: [s.y, my] }, // s.y → my
+            { orientation: 'h', fixed: my, range: [s.x, e.x] }, // s.x → e.x
+            { orientation: 'v', fixed: e.x, range: [my, e.y] }, // my → e.y
           ]
           return { d: segmentsToD(segments), mx: (s.x + e.x) / 2, my, segments }
         }
@@ -678,10 +678,10 @@ export const buildArrowPath = (
     my = (s.y + e.y) / 2
     if (Math.abs(dx) < 2) {
       // 垂直直線
-      segments = [{ orientation: 'v', fixed: s.x, range: [s.y, e.y] }]  // s.y → e.y
+      segments = [{ orientation: 'v', fixed: s.x, range: [s.y, e.y] }] // s.y → e.y
     } else {
       // 水平直線
-      segments = [{ orientation: 'h', fixed: s.y, range: [s.x, e.x] }]  // s.x → e.x
+      segments = [{ orientation: 'h', fixed: s.y, range: [s.x, e.x] }] // s.x → e.x
     }
   } else {
     // 出口が縦方向かどうかを判定（ノード中心との差で判別）
@@ -694,9 +694,9 @@ export const buildArrowPath = (
       mx = (s.x + e.x) / 2
       my = cmy
       segments = [
-        { orientation: 'v', fixed: s.x, range: [s.y, cmy] },   // s.y → cmy
-        { orientation: 'h', fixed: cmy, range: [s.x, e.x] },    // s.x → e.x
-        { orientation: 'v', fixed: e.x, range: [cmy, e.y] },    // cmy → e.y
+        { orientation: 'v', fixed: s.x, range: [s.y, cmy] }, // s.y → cmy
+        { orientation: 'h', fixed: cmy, range: [s.x, e.x] }, // s.x → e.x
+        { orientation: 'v', fixed: e.x, range: [cmy, e.y] }, // cmy → e.y
       ]
     } else if (!sV && !eV) {
       // 両方横出口: Z字パス（縦方向に折り返す）→ ラベルは中央垂直セグメント上
@@ -704,15 +704,15 @@ export const buildArrowPath = (
       mx = cmx
       my = (s.y + e.y) / 2
       segments = [
-        { orientation: 'h', fixed: s.y, range: [s.x, cmx] },   // s.x → cmx
-        { orientation: 'v', fixed: cmx, range: [s.y, e.y] },    // s.y → e.y
-        { orientation: 'h', fixed: e.y, range: [cmx, e.x] },    // cmx → e.x
+        { orientation: 'h', fixed: s.y, range: [s.x, cmx] }, // s.x → cmx
+        { orientation: 'v', fixed: cmx, range: [s.y, e.y] }, // s.y → e.y
+        { orientation: 'h', fixed: e.y, range: [cmx, e.x] }, // cmx → e.x
       ]
     } else if (sV) {
       // 縦出口→横入口: L字パス → ラベルは長辺の中点
       segments = [
-        { orientation: 'v', fixed: s.x, range: [s.y, e.y] },   // s.y → e.y
-        { orientation: 'h', fixed: e.y, range: [s.x, e.x] },    // s.x → e.x
+        { orientation: 'v', fixed: s.x, range: [s.y, e.y] }, // s.y → e.y
+        { orientation: 'h', fixed: e.y, range: [s.x, e.x] }, // s.x → e.x
       ]
       if (Math.abs(e.y - s.y) >= Math.abs(e.x - s.x)) {
         // 縦辺が長い（または等長）: 縦辺の中点
@@ -726,8 +726,8 @@ export const buildArrowPath = (
     } else {
       // 横出口→縦入口: L字パス → ラベルは長辺の中点
       segments = [
-        { orientation: 'h', fixed: s.y, range: [s.x, e.x] },   // s.x → e.x
-        { orientation: 'v', fixed: e.x, range: [s.y, e.y] },    // s.y → e.y
+        { orientation: 'h', fixed: s.y, range: [s.x, e.x] }, // s.x → e.x
+        { orientation: 'v', fixed: e.x, range: [s.y, e.y] }, // s.y → e.y
       ]
       if (Math.abs(e.x - s.x) >= Math.abs(e.y - s.y)) {
         // 横辺が長い（または等長）: 横辺の中点
@@ -1048,8 +1048,8 @@ export interface EdgeWithSegments {
 export interface Crossing {
   x: number
   y: number
-  jumperEdgeId: string         // 跨ぐ側（H セグメントを持つエッジ）
-  jumperSegmentIndex: number   // そのエッジの何番目の segment か
+  jumperEdgeId: string // 跨ぐ側（H セグメントを持つエッジ）
+  jumperSegmentIndex: number // そのエッジの何番目の segment か
 }
 
 /**
@@ -1074,8 +1074,10 @@ export function detectCrossings(edges: EdgeWithSegments[]): Crossing[] {
           const vLow = Math.min(segV.range[0], segV.range[1])
           const vHigh = Math.max(segV.range[0], segV.range[1])
           if (
-            hLow + CROSSING_MARGIN < segV.fixed && segV.fixed < hHigh - CROSSING_MARGIN &&
-            vLow + CROSSING_MARGIN < segH.fixed && segH.fixed < vHigh - CROSSING_MARGIN
+            hLow + CROSSING_MARGIN < segV.fixed &&
+            segV.fixed < hHigh - CROSSING_MARGIN &&
+            vLow + CROSSING_MARGIN < segH.fixed &&
+            segH.fixed < vHigh - CROSSING_MARGIN
           ) {
             out.push({
               x: segV.fixed,

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -72,7 +72,9 @@ function escalateDetourTrack(
     const checkNodeCollision = i > 0
     const occupied = obstacles.some((b) => {
       if (orientation === 'h') {
-        if (isThinSegment(b) && b.h < 3) {
+        // 薄い H セグメント (h < 3) のみが H 方向のトラック衝突を起こしうる。
+        // V 方向の薄いセグメント (w < 3, h は通常) は同方向の Y 座標重なりが少ないので除外。
+        if (b.h < 3) {
           if (Math.abs(b.y - fixed) >= TRACK_COLLISION_TOLERANCE) return false
           return b.x - b.w / 2 < rHigh && b.x + b.w / 2 > rLow
         }
@@ -82,7 +84,7 @@ function escalateDetourTrack(
         }
         return false
       } else {
-        if (isThinSegment(b) && b.w < 3) {
+        if (b.w < 3) {
           if (Math.abs(b.x - fixed) >= TRACK_COLLISION_TOLERANCE) return false
           return b.y - b.h / 2 < rHigh && b.y + b.h / 2 > rLow
         }
@@ -1029,10 +1031,17 @@ export function segmentsToD(
       // sweep: 進行方向に応じた弧の向き。常に「上膨らみ」になる組み合わせ（右進行=1, 左進行=0）
       const sweep = goingRight ? 1 : 0
       const r = JUMP_RADIUS
+      // 前アークの終点 (進行方向座標)。重複/逆進アークを抑止するためのガード。
+      // 2 つの交差点が 2 * JUMP_RADIUS = 10px 未満で並ぶと beforeX が前 afterX より後退し
+      // path が自己交差するため、その場合は当該アークを skip する。
+      let lastAfter = goingRight ? -Infinity : Infinity
       for (const jx of sorted) {
         const beforeX = goingRight ? jx - r : jx + r
         const afterX = goingRight ? jx + r : jx - r
+        // 進行方向に beforeX が lastAfter より進んでいない (≤ 等価含む) ならスキップ
+        if (goingRight ? beforeX <= lastAfter : beforeX >= lastAfter) continue
         d += ` L${beforeX},${seg.fixed} A${r},${r} 0 0 ${sweep} ${afterX},${seg.fixed}`
+        lastAfter = afterX
       }
     }
     d += ` L${endX},${endY}`

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -1039,6 +1039,48 @@ export function buildObstacles(args: BuildObstaclesArgs): Bbox[] {
  * 水平セグメントなら `{w:0, h:1}`、垂直なら `{w:1, h:0}`。
  * 長さを 1 に水増ししない（実態に忠実に degenerate を表現する）方針。
  */
+export const JUMP_RADIUS = 5
+/** ジャンパーアーク半径にマージンを加えた交差検出用の余裕幅。detectCrossings（Task C1）で使用予定。 */
+export const CROSSING_MARGIN = JUMP_RADIUS + 2
+
+/**
+ * EdgeSegment[] と各セグメントのジャンパー位置から SVG path d 属性を生成する。
+ * jumpsPerSegment は segment index → 跨ぎ位置（H セグメントなら x 座標）の配列。
+ * V セグメントには跨ぎが入らない（規約上）。
+ *
+ * 注: jumps なしモード（jumpsPerSegment 省略）は段階4 実装前でも使える。
+ * range は進行方向順 [start, end] を前提とする（start > end も許容）。
+ */
+export function segmentsToD(
+  segments: EdgeSegment[],
+  jumpsPerSegment?: Map<number, number[]>,
+): string {
+  if (segments.length === 0) return ''
+  const first = segments[0]
+  const startX = first.orientation === 'h' ? first.range[0] : first.fixed
+  const startY = first.orientation === 'v' ? first.range[0] : first.fixed
+  let d = `M${startX},${startY}`
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i]
+    const endX = seg.orientation === 'h' ? seg.range[1] : seg.fixed
+    const endY = seg.orientation === 'v' ? seg.range[1] : seg.fixed
+    const jumps = jumpsPerSegment?.get(i)
+    if (seg.orientation === 'h' && jumps && jumps.length > 0) {
+      const goingRight = seg.range[0] < seg.range[1]
+      const sorted = [...jumps].sort((a, b) => (goingRight ? a - b : b - a))
+      const sweep = goingRight ? 1 : 0
+      const r = JUMP_RADIUS
+      for (const jx of sorted) {
+        const beforeX = goingRight ? jx - r : jx + r
+        const afterX = goingRight ? jx + r : jx - r
+        d += ` L${beforeX},${seg.fixed} A${r},${r} 0 0 ${sweep} ${afterX},${seg.fixed}`
+      }
+    }
+    d += ` L${endX},${endY}`
+  }
+  return d
+}
+
 export function segmentsToBboxes(segments: EdgeSegment[]): Bbox[] {
   return segments.map((s) => {
     const r0 = Math.min(s.range[0], s.range[1])

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -39,6 +39,66 @@ const yOverlap = (a: Bbox, b: Bbox): boolean => Math.abs(a.y - b.y) < (a.h + b.h
 // 線分を除外する用途で使う。経路上の障害物判定（inRow/inCol）には引き続き使う。
 const isThinSegment = (b: Bbox): boolean => b.h < 3 || b.w < 3
 
+const TRACK_GAP = 8
+const MAX_TRACK_ESCALATIONS = 6
+const TRACK_COLLISION_TOLERANCE = 4
+
+/**
+ * 算出済みの detour 座標が
+ * (a) 同方向の薄いエッジセグメント、または (b) ノード との衝突がある場合、
+ * direction 方向に TRACK_GAP ずつシフトして空きトラックを探す。
+ *
+ * @param initialFixed 初期 detour 座標（H なら Y、V なら X）
+ * @param crossRange 跨ぐ範囲。H なら [xStart, xEnd]、V なら [yStart, yEnd]
+ * @param orientation detour segment の向き
+ * @param obstacles 全障害物（薄いセグメントとノードの両方を含む）
+ * @param direction +1 or -1: initialFixed から遠ざかる方向
+ * @returns 衝突しない fixed 座標。MAX_TRACK_ESCALATIONS 回試行してもダメなら最終値を返す
+ */
+function escalateDetourTrack(
+  initialFixed: number,
+  crossRange: [number, number],
+  orientation: 'h' | 'v',
+  obstacles: Bbox[],
+  direction: 1 | -1,
+): number {
+  const rLow = Math.min(crossRange[0], crossRange[1])
+  const rHigh = Math.max(crossRange[0], crossRange[1])
+  let fixed = initialFixed
+  for (let i = 0; i < MAX_TRACK_ESCALATIONS; i++) {
+    // 初期位置 (i=0) はノード衝突を許容する (既存ルータがこの位置を妥当と判断済み)。
+    // 薄いセグメント衝突のみを検出して escalate する。
+    // i>=1 ではシフト先がノード内に入らないようノード衝突もチェックする。
+    const checkNodeCollision = i > 0
+    const occupied = obstacles.some((b) => {
+      if (orientation === 'h') {
+        if (isThinSegment(b) && b.h < 3) {
+          if (Math.abs(b.y - fixed) >= TRACK_COLLISION_TOLERANCE) return false
+          return b.x - b.w / 2 < rHigh && b.x + b.w / 2 > rLow
+        }
+        if (checkNodeCollision && !isThinSegment(b)) {
+          if (Math.abs(b.y - fixed) >= b.h / 2) return false
+          return b.x - b.w / 2 < rHigh && b.x + b.w / 2 > rLow
+        }
+        return false
+      } else {
+        if (isThinSegment(b) && b.w < 3) {
+          if (Math.abs(b.x - fixed) >= TRACK_COLLISION_TOLERANCE) return false
+          return b.y - b.h / 2 < rHigh && b.y + b.h / 2 > rLow
+        }
+        if (checkNodeCollision && !isThinSegment(b)) {
+          if (Math.abs(b.x - fixed) >= b.w / 2) return false
+          return b.y - b.h / 2 < rHigh && b.y + b.h / 2 > rLow
+        }
+        return false
+      }
+    })
+    if (!occupied) return fixed
+    fixed += direction * TRACK_GAP
+  }
+  return fixed
+}
+
 function detectDetour(s: Point, e: Point, obstacles: Bbox[]): { detourY: number } | null {
   // 水平直線でなければ迂回しない
   if (Math.abs(e.y - s.y) >= 2) return null
@@ -75,9 +135,11 @@ function detectDetour(s: Point, e: Point, obstacles: Bbox[]): { detourY: number 
   const goDown = !downBlocked || upBlocked
 
   // detourY: 障害ノード群の最下端 + マージン or 最上端 - マージン
-  const detourY = goDown
+  const initialDetourY = goDown
     ? Math.max(...inRow.map((o) => o.y + o.h / 2)) + DETOUR_MARGIN
     : Math.min(...inRow.map((o) => o.y - o.h / 2)) - DETOUR_MARGIN
+  const direction: 1 | -1 = goDown ? 1 : -1
+  const detourY = escalateDetourTrack(initialDetourY, [s.x, e.x], 'h', obstacles, direction)
 
   return { detourY }
 }
@@ -121,9 +183,11 @@ function detectVerticalDetour(s: Point, e: Point, obstacles: Bbox[]): { detourX:
   const goRight = !rightBlocked || leftBlocked
 
   // detourX: 障害ノード群の最右端 + マージン or 最左端 - マージン
-  const detourX = goRight
+  const initialDetourX = goRight
     ? Math.max(...inCol.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
     : Math.min(...inCol.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+  const direction: 1 | -1 = goRight ? 1 : -1
+  const detourX = escalateDetourTrack(initialDetourX, [s.y, e.y], 'v', obstacles, direction)
 
   return { detourX }
 }
@@ -148,7 +212,12 @@ type DiagonalDetourResult =
  * blockers は方向判定対象のブロッカー候補。target/source 列同士の相互ブロッキングを防ぐ
  * ため、both-detour では呼び出し側が反対側列の hits を除外した blockers を渡す。
  */
-function pickDetourX(hits: Bbox[], blockers: Bbox[]): number {
+function pickDetourX(
+  hits: Bbox[],
+  blockers: Bbox[],
+  crossRange: [number, number],
+  obstacles: Bbox[],
+): number {
   // 薄い線分 (エッジセグメント由来 Bbox) は方向判定から除外。
   // detectDetour / detectVerticalDetour と同じ理由 (yOverlap 誤判定を防ぐ)。
   const rightBlocked = hits.some((obs) =>
@@ -158,9 +227,11 @@ function pickDetourX(hits: Bbox[], blockers: Bbox[]): number {
     blockers.some((b) => !isThinSegment(b) && b.x < obs.x - 1 && yOverlap(obs, b)),
   )
   const goRight = !rightBlocked || leftBlocked
-  return goRight
+  const initialDetourX = goRight
     ? Math.max(...hits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
     : Math.min(...hits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+  const direction: 1 | -1 = goRight ? 1 : -1
+  return escalateDetourTrack(initialDetourX, crossRange, 'v', obstacles, direction)
 }
 
 /**
@@ -204,9 +275,11 @@ function computeShiftedMy(
     obstacles.some((b) => !isThinSegment(b) && b.y < obs.y - 1 && inBetween(b) && xOverlap(obs, b)),
   )
   const goDown = !downBlocked || upBlocked
-  const shiftedMy = goDown
+  const initialShiftedMy = goDown
     ? Math.max(...middleRowHits.map((o) => o.y + o.h / 2)) + DETOUR_MARGIN
     : Math.min(...middleRowHits.map((o) => o.y - o.h / 2)) - DETOUR_MARGIN
+  const direction: 1 | -1 = goDown ? 1 : -1
+  const shiftedMy = escalateDetourTrack(initialShiftedMy, [s.x, e.x], 'h', obstacles, direction)
 
   // range-check: source 行 / target 行を侵食しないこと
   // 複数障害の高さが異なる場合に保守的な (最も厳しい) 余白を取るため max を使う。
@@ -214,10 +287,6 @@ function computeShiftedMy(
   const lo = yLow + bboxHMax / 2 + 1
   const hi = yHigh - bboxHMax / 2 - 1
   // 範囲外 → 元の my を返す。
-  // 注意: 呼び出し元が source/target/both-detour を選択しており column detour が
-  // 既に発生する場合、この経路では middleRowHits の障害は回避されない。これは
-  // shift-my の単独経路 (L270+) のような escalation 機構を持たないためで、
-  // 行間が狭い稀なケースで残存しうる既知の制約。
   if (shiftedMy >= lo && shiftedMy <= hi) return shiftedMy
   return my
 }
@@ -279,8 +348,8 @@ export function detectDiagonalDetour(
     const sourceIds = new Set(sourceColHits)
     const srcBlockers = obstacles.filter((b) => !targetIds.has(b))
     const tgtBlockers = obstacles.filter((b) => !sourceIds.has(b))
-    const sourceDetourX = pickDetourX(sourceColHits, srcBlockers)
-    const targetDetourX = pickDetourX(targetColHits, tgtBlockers)
+    const sourceDetourX = pickDetourX(sourceColHits, srcBlockers, [s.y, my], obstacles)
+    const targetDetourX = pickDetourX(targetColHits, tgtBlockers, [my, e.y], obstacles)
     const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
     const departY = clampOffset(s.y, shiftedMy, DEPART_GAP)
     const approachY = clampOffset(e.y, shiftedMy, APPROACH_GAP)
@@ -288,14 +357,14 @@ export function detectDiagonalDetour(
   }
 
   if (targetColHits.length > 0 && sourceColHits.length === 0) {
-    const detourX = pickDetourX(targetColHits, obstacles)
+    const detourX = pickDetourX(targetColHits, obstacles, [my, e.y], obstacles)
     const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
     const approachY = clampOffset(e.y, shiftedMy, APPROACH_GAP)
     return { kind: 'target-detour', my: shiftedMy, detourX, approachY }
   }
 
   if (sourceColHits.length > 0 && targetColHits.length === 0) {
-    const detourX = pickDetourX(sourceColHits, obstacles)
+    const detourX = pickDetourX(sourceColHits, obstacles, [s.y, my], obstacles)
     const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
     const departY = clampOffset(s.y, shiftedMy, DEPART_GAP)
     return { kind: 'source-detour', departY, detourX, my: shiftedMy }
@@ -312,9 +381,11 @@ export function detectDiagonalDetour(
       obstacles.some((b) => !isThinSegment(b) && b.y < obs.y - 1 && xOverlap(obs, b)),
     )
     const goDown = !downBlocked || upBlocked
-    const shiftedMy = goDown
+    const initialShiftedMy = goDown
       ? Math.max(...middleRowHits.map((o) => o.y + o.h / 2)) + DETOUR_MARGIN
       : Math.min(...middleRowHits.map((o) => o.y - o.h / 2)) - DETOUR_MARGIN
+    const direction: 1 | -1 = goDown ? 1 : -1
+    const shiftedMy = escalateDetourTrack(initialShiftedMy, [s.x, e.x], 'h', obstacles, direction)
 
     // ガード: shiftedMy が source 行 / target 行を侵食しないこと
     // 複数障害の高さが異なる場合に保守的な (最も厳しい) 余白を取るため max を使う。
@@ -332,7 +403,7 @@ export function detectDiagonalDetour(
     // detourX は障害の左右どちらかに DETOUR_MARGIN 取られているため、s.x と e.x の
     // どちらが detourX と同じ側にあるかで衝突しない kind が決まる。
     // 左→右 (s.x < e.x) でも右→左 (s.x > e.x) でも幾何学的に正しく判定できる (#359)。
-    const detourX = pickDetourX(middleRowHits, obstacles)
+    const detourX = pickDetourX(middleRowHits, obstacles, [s.y, e.y], obstacles)
     const obsRight = Math.max(...middleRowHits.map((o) => o.x + o.w / 2))
     const obsLeft = Math.min(...middleRowHits.map((o) => o.x - o.w / 2))
     // source-detour 中央水平 = [min(detourX, e.x), max(detourX, e.x)]

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -1067,7 +1067,9 @@ export function segmentsToD(
     const jumps = jumpsPerSegment?.get(i)
     if (seg.orientation === 'h' && jumps && jumps.length > 0) {
       const goingRight = seg.range[0] < seg.range[1]
+      // 進行方向順に跨ぎ点を並べる（始点→終点へ）
       const sorted = [...jumps].sort((a, b) => (goingRight ? a - b : b - a))
+      // sweep: 進行方向に応じた弧の向き。常に「上膨らみ」になる組み合わせ（右進行=1, 左進行=0）
       const sweep = goingRight ? 1 : 0
       const r = JUMP_RADIUS
       for (const jx of sorted) {

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -969,6 +969,57 @@ export function segmentsToD(
   return d
 }
 
+export interface EdgeWithSegments {
+  id: string
+  segments: EdgeSegment[]
+}
+
+export interface Crossing {
+  x: number
+  y: number
+  jumperEdgeId: string         // 跨ぐ側（H セグメントを持つエッジ）
+  jumperSegmentIndex: number   // そのエッジの何番目の segment か
+}
+
+/**
+ * 全エッジ間の H × V 交差を列挙する。
+ * 規約: 水平セグメントが垂直セグメントを跨ぐ（H が jumper）。
+ * 同一エッジ内の交差は無視（自己ループ防止）。
+ *
+ * ループ順序 (i, j, si 昇順) と push 順序が決定論性の根拠。
+ */
+export function detectCrossings(edges: EdgeWithSegments[]): Crossing[] {
+  const out: Crossing[] = []
+  for (let i = 0; i < edges.length; i++) {
+    for (let j = 0; j < edges.length; j++) {
+      if (i === j) continue
+      for (let si = 0; si < edges[i].segments.length; si++) {
+        const segH = edges[i].segments[si]
+        if (segH.orientation !== 'h') continue
+        for (const segV of edges[j].segments) {
+          if (segV.orientation !== 'v') continue
+          const hLow = Math.min(segH.range[0], segH.range[1])
+          const hHigh = Math.max(segH.range[0], segH.range[1])
+          const vLow = Math.min(segV.range[0], segV.range[1])
+          const vHigh = Math.max(segV.range[0], segV.range[1])
+          if (
+            hLow + CROSSING_MARGIN < segV.fixed && segV.fixed < hHigh - CROSSING_MARGIN &&
+            vLow + CROSSING_MARGIN < segH.fixed && segH.fixed < vHigh - CROSSING_MARGIN
+          ) {
+            out.push({
+              x: segV.fixed,
+              y: segH.fixed,
+              jumperEdgeId: edges[i].id,
+              jumperSegmentIndex: si,
+            })
+          }
+        }
+      }
+    }
+  }
+  return out
+}
+
 export function segmentsToBboxes(segments: EdgeSegment[]): Bbox[] {
   return segments.map((s) => {
     const r0 = Math.min(s.range[0], s.range[1])

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -15,6 +15,7 @@ export interface Bbox {
 export interface EdgeSegment {
   orientation: 'h' | 'v'
   fixed: number
+  /** [start, end]: 進行方向に沿った座標。start > end も許容される */
   range: [number, number]
 }
 
@@ -507,35 +508,14 @@ export const buildArrowPath = (
       const approachX = e.x - sign * Math.min(APPROACH_GAP, halfDx)
       // 6 セグメント: M → 水平(departX まで) → 垂直(detourY まで) → 水平(approachX まで)
       //               → 垂直(e.y まで) → 水平(e.x へ進入)
-      const d = `M${s.x},${s.y} L${departX},${s.y} L${departX},${detourY} L${approachX},${detourY} L${approachX},${e.y} L${e.x},${e.y}`
       const segments: EdgeSegment[] = [
-        {
-          orientation: 'h',
-          fixed: s.y,
-          range: [Math.min(s.x, departX), Math.max(s.x, departX)],
-        },
-        {
-          orientation: 'v',
-          fixed: departX,
-          range: [Math.min(s.y, detourY), Math.max(s.y, detourY)],
-        },
-        {
-          orientation: 'h',
-          fixed: detourY,
-          range: [Math.min(departX, approachX), Math.max(departX, approachX)],
-        },
-        {
-          orientation: 'v',
-          fixed: approachX,
-          range: [Math.min(detourY, e.y), Math.max(detourY, e.y)],
-        },
-        {
-          orientation: 'h',
-          fixed: e.y,
-          range: [Math.min(approachX, e.x), Math.max(approachX, e.x)],
-        },
+        { orientation: 'h', fixed: s.y, range: [s.x, departX] },         // s.x → departX
+        { orientation: 'v', fixed: departX, range: [s.y, detourY] },      // s.y → detourY
+        { orientation: 'h', fixed: detourY, range: [departX, approachX] }, // departX → approachX
+        { orientation: 'v', fixed: approachX, range: [detourY, e.y] },    // detourY → e.y
+        { orientation: 'h', fixed: e.y, range: [approachX, e.x] },        // approachX → e.x
       ]
-      return { d, mx: (s.x + e.x) / 2, my: detourY, segments }
+      return { d: segmentsToD(segments), mx: (s.x + e.x) / 2, my: detourY, segments }
     }
 
     const vDetour = detectVerticalDetour(s, e, obstacles)
@@ -550,35 +530,14 @@ export const buildArrowPath = (
       const approachY = e.y - sign * Math.min(APPROACH_GAP, halfDy)
       // 6 セグメント: M → 垂直(departY まで) → 水平(detourX まで) → 垂直(approachY まで)
       //               → 水平(e.x まで) → 垂直(e.y へ進入)
-      const d = `M${s.x},${s.y} L${s.x},${departY} L${detourX},${departY} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
       const segments: EdgeSegment[] = [
-        {
-          orientation: 'v',
-          fixed: s.x,
-          range: [Math.min(s.y, departY), Math.max(s.y, departY)],
-        },
-        {
-          orientation: 'h',
-          fixed: departY,
-          range: [Math.min(s.x, detourX), Math.max(s.x, detourX)],
-        },
-        {
-          orientation: 'v',
-          fixed: detourX,
-          range: [Math.min(departY, approachY), Math.max(departY, approachY)],
-        },
-        {
-          orientation: 'h',
-          fixed: approachY,
-          range: [Math.min(detourX, e.x), Math.max(detourX, e.x)],
-        },
-        {
-          orientation: 'v',
-          fixed: e.x,
-          range: [Math.min(approachY, e.y), Math.max(approachY, e.y)],
-        },
+        { orientation: 'v', fixed: s.x, range: [s.y, departY] },          // s.y → departY
+        { orientation: 'h', fixed: departY, range: [s.x, detourX] },       // s.x → detourX
+        { orientation: 'v', fixed: detourX, range: [departY, approachY] }, // departY → approachY
+        { orientation: 'h', fixed: approachY, range: [detourX, e.x] },     // detourX → e.x
+        { orientation: 'v', fixed: e.x, range: [approachY, e.y] },         // approachY → e.y
       ]
-      return { d, mx: detourX, my: (s.y + e.y) / 2, segments }
+      return { d: segmentsToD(segments), mx: detourX, my: (s.y + e.y) / 2, segments }
     }
 
     const dDetour = detectDiagonalDetour(s, e, obstacles)
@@ -586,114 +545,47 @@ export const buildArrowPath = (
       switch (dDetour.kind) {
         case 'target-detour': {
           const { my, detourX, approachY } = dDetour
-          const d = `M${s.x},${s.y} L${s.x},${my} L${detourX},${my} L${detourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
           const segments: EdgeSegment[] = [
-            { orientation: 'v', fixed: s.x, range: [Math.min(s.y, my), Math.max(s.y, my)] },
-            {
-              orientation: 'h',
-              fixed: my,
-              range: [Math.min(s.x, detourX), Math.max(s.x, detourX)],
-            },
-            {
-              orientation: 'v',
-              fixed: detourX,
-              range: [Math.min(my, approachY), Math.max(my, approachY)],
-            },
-            {
-              orientation: 'h',
-              fixed: approachY,
-              range: [Math.min(detourX, e.x), Math.max(detourX, e.x)],
-            },
-            {
-              orientation: 'v',
-              fixed: e.x,
-              range: [Math.min(approachY, e.y), Math.max(approachY, e.y)],
-            },
+            { orientation: 'v', fixed: s.x, range: [s.y, my] },           // s.y → my
+            { orientation: 'h', fixed: my, range: [s.x, detourX] },        // s.x → detourX
+            { orientation: 'v', fixed: detourX, range: [my, approachY] },  // my → approachY
+            { orientation: 'h', fixed: approachY, range: [detourX, e.x] }, // detourX → e.x
+            { orientation: 'v', fixed: e.x, range: [approachY, e.y] },     // approachY → e.y
           ]
-          return { d, mx: (s.x + detourX) / 2, my, segments }
+          return { d: segmentsToD(segments), mx: (s.x + detourX) / 2, my, segments }
         }
         case 'source-detour': {
           const { departY, detourX, my } = dDetour
-          const d = `M${s.x},${s.y} L${s.x},${departY} L${detourX},${departY} L${detourX},${my} L${e.x},${my} L${e.x},${e.y}`
           const segments: EdgeSegment[] = [
-            {
-              orientation: 'v',
-              fixed: s.x,
-              range: [Math.min(s.y, departY), Math.max(s.y, departY)],
-            },
-            {
-              orientation: 'h',
-              fixed: departY,
-              range: [Math.min(s.x, detourX), Math.max(s.x, detourX)],
-            },
-            {
-              orientation: 'v',
-              fixed: detourX,
-              range: [Math.min(departY, my), Math.max(departY, my)],
-            },
-            {
-              orientation: 'h',
-              fixed: my,
-              range: [Math.min(detourX, e.x), Math.max(detourX, e.x)],
-            },
-            { orientation: 'v', fixed: e.x, range: [Math.min(my, e.y), Math.max(my, e.y)] },
+            { orientation: 'v', fixed: s.x, range: [s.y, departY] },       // s.y → departY
+            { orientation: 'h', fixed: departY, range: [s.x, detourX] },   // s.x → detourX
+            { orientation: 'v', fixed: detourX, range: [departY, my] },     // departY → my
+            { orientation: 'h', fixed: my, range: [detourX, e.x] },         // detourX → e.x
+            { orientation: 'v', fixed: e.x, range: [my, e.y] },             // my → e.y
           ]
-          return { d, mx: (detourX + e.x) / 2, my, segments }
+          return { d: segmentsToD(segments), mx: (detourX + e.x) / 2, my, segments }
         }
         case 'both-detour': {
           const { departY, sourceDetourX, my, targetDetourX, approachY } = dDetour
-          const d = `M${s.x},${s.y} L${s.x},${departY} L${sourceDetourX},${departY} L${sourceDetourX},${my} L${targetDetourX},${my} L${targetDetourX},${approachY} L${e.x},${approachY} L${e.x},${e.y}`
           const segments: EdgeSegment[] = [
-            {
-              orientation: 'v',
-              fixed: s.x,
-              range: [Math.min(s.y, departY), Math.max(s.y, departY)],
-            },
-            {
-              orientation: 'h',
-              fixed: departY,
-              range: [Math.min(s.x, sourceDetourX), Math.max(s.x, sourceDetourX)],
-            },
-            {
-              orientation: 'v',
-              fixed: sourceDetourX,
-              range: [Math.min(departY, my), Math.max(departY, my)],
-            },
-            {
-              orientation: 'h',
-              fixed: my,
-              range: [
-                Math.min(sourceDetourX, targetDetourX),
-                Math.max(sourceDetourX, targetDetourX),
-              ],
-            },
-            {
-              orientation: 'v',
-              fixed: targetDetourX,
-              range: [Math.min(my, approachY), Math.max(my, approachY)],
-            },
-            {
-              orientation: 'h',
-              fixed: approachY,
-              range: [Math.min(targetDetourX, e.x), Math.max(targetDetourX, e.x)],
-            },
-            {
-              orientation: 'v',
-              fixed: e.x,
-              range: [Math.min(approachY, e.y), Math.max(approachY, e.y)],
-            },
+            { orientation: 'v', fixed: s.x, range: [s.y, departY] },                          // s.y → departY
+            { orientation: 'h', fixed: departY, range: [s.x, sourceDetourX] },                // s.x → sourceDetourX
+            { orientation: 'v', fixed: sourceDetourX, range: [departY, my] },                 // departY → my
+            { orientation: 'h', fixed: my, range: [sourceDetourX, targetDetourX] },           // sourceDetourX → targetDetourX
+            { orientation: 'v', fixed: targetDetourX, range: [my, approachY] },               // my → approachY
+            { orientation: 'h', fixed: approachY, range: [targetDetourX, e.x] },              // targetDetourX → e.x
+            { orientation: 'v', fixed: e.x, range: [approachY, e.y] },                        // approachY → e.y
           ]
-          return { d, mx: (sourceDetourX + targetDetourX) / 2, my, segments }
+          return { d: segmentsToD(segments), mx: (sourceDetourX + targetDetourX) / 2, my, segments }
         }
         case 'shift-my': {
           const { my } = dDetour
-          const d = `M${s.x},${s.y} L${s.x},${my} L${e.x},${my} L${e.x},${e.y}`
           const segments: EdgeSegment[] = [
-            { orientation: 'v', fixed: s.x, range: [Math.min(s.y, my), Math.max(s.y, my)] },
-            { orientation: 'h', fixed: my, range: [Math.min(s.x, e.x), Math.max(s.x, e.x)] },
-            { orientation: 'v', fixed: e.x, range: [Math.min(my, e.y), Math.max(my, e.y)] },
+            { orientation: 'v', fixed: s.x, range: [s.y, my] },   // s.y → my
+            { orientation: 'h', fixed: my, range: [s.x, e.x] },    // s.x → e.x
+            { orientation: 'v', fixed: e.x, range: [my, e.y] },    // my → e.y
           ]
-          return { d, mx: (s.x + e.x) / 2, my, segments }
+          return { d: segmentsToD(segments), mx: (s.x + e.x) / 2, my, segments }
         }
         default: {
           const _exhaustive: never = dDetour
@@ -705,22 +597,20 @@ export const buildArrowPath = (
     }
   }
 
-  let d: string
   let mx: number
   let my: number
   let segments: EdgeSegment[] = []
 
   // 直線パス: ほぼ垂直またはほぼ水平
   if (Math.abs(dx) < 2 || Math.abs(dy) < 2) {
-    d = `M${s.x},${s.y} L${e.x},${e.y}`
     mx = (s.x + e.x) / 2
     my = (s.y + e.y) / 2
     if (Math.abs(dx) < 2) {
       // 垂直直線
-      segments = [{ orientation: 'v', fixed: s.x, range: [Math.min(s.y, e.y), Math.max(s.y, e.y)] }]
+      segments = [{ orientation: 'v', fixed: s.x, range: [s.y, e.y] }]  // s.y → e.y
     } else {
       // 水平直線
-      segments = [{ orientation: 'h', fixed: s.y, range: [Math.min(s.x, e.x), Math.max(s.x, e.x)] }]
+      segments = [{ orientation: 'h', fixed: s.y, range: [s.x, e.x] }]  // s.x → e.x
     }
   } else {
     // 出口が縦方向かどうかを判定（ノード中心との差で判別）
@@ -730,31 +620,28 @@ export const buildArrowPath = (
     if (sV && eV) {
       // 両方縦出口: Z字パス（横方向に折り返す）→ ラベルは中央水平セグメント上
       const cmy = (s.y + e.y) / 2
-      d = `M${s.x},${s.y} L${s.x},${cmy} L${e.x},${cmy} L${e.x},${e.y}`
       mx = (s.x + e.x) / 2
       my = cmy
       segments = [
-        { orientation: 'v', fixed: s.x, range: [Math.min(s.y, cmy), Math.max(s.y, cmy)] },
-        { orientation: 'h', fixed: cmy, range: [Math.min(s.x, e.x), Math.max(s.x, e.x)] },
-        { orientation: 'v', fixed: e.x, range: [Math.min(cmy, e.y), Math.max(cmy, e.y)] },
+        { orientation: 'v', fixed: s.x, range: [s.y, cmy] },   // s.y → cmy
+        { orientation: 'h', fixed: cmy, range: [s.x, e.x] },    // s.x → e.x
+        { orientation: 'v', fixed: e.x, range: [cmy, e.y] },    // cmy → e.y
       ]
     } else if (!sV && !eV) {
       // 両方横出口: Z字パス（縦方向に折り返す）→ ラベルは中央垂直セグメント上
       const cmx = (s.x + e.x) / 2
-      d = `M${s.x},${s.y} L${cmx},${s.y} L${cmx},${e.y} L${e.x},${e.y}`
       mx = cmx
       my = (s.y + e.y) / 2
       segments = [
-        { orientation: 'h', fixed: s.y, range: [Math.min(s.x, cmx), Math.max(s.x, cmx)] },
-        { orientation: 'v', fixed: cmx, range: [Math.min(s.y, e.y), Math.max(s.y, e.y)] },
-        { orientation: 'h', fixed: e.y, range: [Math.min(cmx, e.x), Math.max(cmx, e.x)] },
+        { orientation: 'h', fixed: s.y, range: [s.x, cmx] },   // s.x → cmx
+        { orientation: 'v', fixed: cmx, range: [s.y, e.y] },    // s.y → e.y
+        { orientation: 'h', fixed: e.y, range: [cmx, e.x] },    // cmx → e.x
       ]
     } else if (sV) {
       // 縦出口→横入口: L字パス → ラベルは長辺の中点
-      d = `M${s.x},${s.y} L${s.x},${e.y} L${e.x},${e.y}`
       segments = [
-        { orientation: 'v', fixed: s.x, range: [Math.min(s.y, e.y), Math.max(s.y, e.y)] },
-        { orientation: 'h', fixed: e.y, range: [Math.min(s.x, e.x), Math.max(s.x, e.x)] },
+        { orientation: 'v', fixed: s.x, range: [s.y, e.y] },   // s.y → e.y
+        { orientation: 'h', fixed: e.y, range: [s.x, e.x] },    // s.x → e.x
       ]
       if (Math.abs(e.y - s.y) >= Math.abs(e.x - s.x)) {
         // 縦辺が長い（または等長）: 縦辺の中点
@@ -767,10 +654,9 @@ export const buildArrowPath = (
       }
     } else {
       // 横出口→縦入口: L字パス → ラベルは長辺の中点
-      d = `M${s.x},${s.y} L${e.x},${s.y} L${e.x},${e.y}`
       segments = [
-        { orientation: 'h', fixed: s.y, range: [Math.min(s.x, e.x), Math.max(s.x, e.x)] },
-        { orientation: 'v', fixed: e.x, range: [Math.min(s.y, e.y), Math.max(s.y, e.y)] },
+        { orientation: 'h', fixed: s.y, range: [s.x, e.x] },   // s.x → e.x
+        { orientation: 'v', fixed: e.x, range: [s.y, e.y] },    // s.y → e.y
       ]
       if (Math.abs(e.x - s.x) >= Math.abs(e.y - s.y)) {
         // 横辺が長い（または等長）: 横辺の中点
@@ -784,7 +670,7 @@ export const buildArrowPath = (
     }
   }
 
-  return { d, mx, my, segments }
+  return { d: segmentsToD(segments), mx, my, segments }
 }
 
 export interface ObstacleNode {

--- a/src/lib/edge-router.test.ts
+++ b/src/lib/edge-router.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { routeAllArrows } from './edge-router'
+import { routeAllArrows, routeAllArrowsWithJumpers } from './edge-router'
 import type { ArrowResolveContext } from './edge-router'
 import type { Bbox } from './arrow-routing'
 
@@ -147,5 +147,71 @@ describe('routeAllArrows', () => {
         "M250,100 L264,100 L264,114.5 L536,114.5 L536,100 L550,100",
       ]
     `)
+  })
+})
+
+describe('routeAllArrowsWithJumpers', () => {
+  it('交差なし: routeAllArrows と完全同一の出力', () => {
+    const arrows = [
+      { id: 'a1', from: 'A', to: 'B' },
+      { id: 'a2', from: 'C', to: 'D' },
+    ]
+    const ctxMap: Record<string, ArrowResolveContext> = {
+      a1: makeCtx(0, 100, 200, 100),
+      a2: makeCtx(0, 300, 200, 300),  // 平行で交差しない
+    }
+    const baseline = routeAllArrows(arrows, (a) => ctxMap[a.id] ?? null)
+    const result = routeAllArrowsWithJumpers(arrows, (a) => ctxMap[a.id] ?? null)
+    expect(result.map((r) => r?.d)).toEqual(baseline.map((r) => r?.d))
+  })
+
+  it('X字交差: 片方の H セグメントに弧が挿入される', () => {
+    // 共有 from='A' を使い、routeAllArrows の障害物バイパスを発動させ
+    // 純粋な H×V 交差を作る
+    const arrows = [
+      { id: 'a1', from: 'A', to: 'B' },
+      { id: 'a2', from: 'A', to: 'C' },
+    ]
+    const ctxMap: Record<string, ArrowResolveContext> = {
+      a1: makeCtx(0, 200, 600, 200),    // 水平
+      a2: makeCtx(300, 0, 300, 400),    // 垂直
+    }
+    const result = routeAllArrowsWithJumpers(arrows, (a) => ctxMap[a.id] ?? null)
+    // どちらか片方の d に "A5,5" が含まれる（弧マーカー）
+    const hasArc = result.some((r) => r?.d.includes('A5,5'))
+    expect(hasArc).toBe(true)
+    // segments 自体は不変
+    const baseline = routeAllArrows(arrows, (a) => ctxMap[a.id] ?? null)
+    expect(result[0]?.segments).toEqual(baseline[0]?.segments)
+    expect(result[1]?.segments).toEqual(baseline[1]?.segments)
+  })
+
+  it('null context は null のまま伝播する', () => {
+    const arrows = [
+      { id: 'a1', from: 'A', to: 'B' },
+      { id: 'a2', from: 'C', to: 'D' },
+    ]
+    const result = routeAllArrowsWithJumpers(arrows, (a) =>
+      a.id === 'a1' ? makeCtx(0, 100, 200, 100) : null,
+    )
+    expect(result[0]).not.toBeNull()
+    expect(result[1]).toBeNull()
+  })
+
+  it('決定論性: 同じ入力を 10 回流して全結果の d が一致', () => {
+    const arrows = [
+      { id: 'a1', from: 'A', to: 'B' },
+      { id: 'a2', from: 'A', to: 'C' },
+    ]
+    const ctxMap: Record<string, ArrowResolveContext> = {
+      a1: makeCtx(0, 200, 600, 200),
+      a2: makeCtx(300, 0, 300, 400),
+    }
+    const runs = Array.from({ length: 10 }, () =>
+      routeAllArrowsWithJumpers(arrows, (a) => ctxMap[a.id] ?? null).map((r) => r?.d),
+    )
+    for (let i = 1; i < runs.length; i++) {
+      expect(runs[i]).toEqual(runs[0])
+    }
   })
 })

--- a/src/lib/edge-router.test.ts
+++ b/src/lib/edge-router.test.ts
@@ -127,4 +127,25 @@ describe('routeAllArrows', () => {
     expect(findById(r1, arrows1, 'a1')).toBe(findById(r2, arrows2, 'a1'))
     expect(findById(r1, arrows1, 'z1')).toBe(findById(r2, arrows2, 'z1'))
   })
+
+  it('snapshot: 3エッジ累積ルーティングの d 出力が安定する', () => {
+    const arrows = [
+      { id: 'a1', from: 'A', to: 'B' },
+      { id: 'a2', from: 'C', to: 'D' },
+      { id: 'a3', from: 'E', to: 'F' },
+    ]
+    const ctxMap: Record<string, ArrowResolveContext> = {
+      a1: makeCtx(0, 100, 800, 100),
+      a2: makeCtx(100, 200, 700, 300),
+      a3: makeCtx(200, 100, 600, 100),
+    }
+    const result = routeAllArrows(arrows, (a) => ctxMap[a.id] ?? null)
+    expect(result.map((r) => r?.d)).toMatchInlineSnapshot(`
+      [
+        "M50,100 L750,100",
+        "M100,225 L100,250 L700,250 L700,275",
+        "M250,100 L264,100 L264,114.5 L536,114.5 L536,100 L550,100",
+      ]
+    `)
+  })
 })

--- a/src/lib/edge-router.test.ts
+++ b/src/lib/edge-router.test.ts
@@ -158,7 +158,7 @@ describe('routeAllArrowsWithJumpers', () => {
     ]
     const ctxMap: Record<string, ArrowResolveContext> = {
       a1: makeCtx(0, 100, 200, 100),
-      a2: makeCtx(0, 300, 200, 300),  // 平行で交差しない
+      a2: makeCtx(0, 300, 200, 300), // 平行で交差しない
     }
     const baseline = routeAllArrows(arrows, (a) => ctxMap[a.id] ?? null)
     const result = routeAllArrowsWithJumpers(arrows, (a) => ctxMap[a.id] ?? null)
@@ -173,8 +173,8 @@ describe('routeAllArrowsWithJumpers', () => {
       { id: 'a2', from: 'A', to: 'C' },
     ]
     const ctxMap: Record<string, ArrowResolveContext> = {
-      a1: makeCtx(0, 200, 600, 200),    // 水平
-      a2: makeCtx(300, 0, 300, 400),    // 垂直
+      a1: makeCtx(0, 200, 600, 200), // 水平
+      a2: makeCtx(300, 0, 300, 400), // 垂直
     }
     const result = routeAllArrowsWithJumpers(arrows, (a) => ctxMap[a.id] ?? null)
     // どちらか片方の d に "A5,5" が含まれる（弧マーカー）

--- a/src/lib/edge-router.ts
+++ b/src/lib/edge-router.ts
@@ -1,7 +1,7 @@
 import { calcArrowPath } from './flow-engine'
 import type { ArrowConfig } from './flow-engine'
-import { segmentsToBboxes } from './arrow-routing'
-import type { Point, Bbox, EdgeSegment } from './arrow-routing'
+import { segmentsToBboxes, detectCrossings, segmentsToD } from './arrow-routing'
+import type { Point, Bbox, EdgeSegment, EdgeWithSegments } from './arrow-routing'
 import type { ArrowPathResult } from './types'
 
 export interface ArrowResolveContext {
@@ -74,4 +74,58 @@ export function routeAllArrows<T extends ArrowLike>(
   }
 
   return results
+}
+
+/**
+ * routeAllArrows の出力に対し、エッジ間の H×V 交差を検出して水平セグメントに
+ * ジャンパー弧を挿入した d を再生成する。既存 routeAllArrows の挙動は変更しない。
+ *
+ * 規約: H が V を跨ぐ（H 側に弧が乗る）。
+ *
+ * @param arrows ルーティング対象のエッジ配列
+ * @param resolveContext 各 arrow から計算コンテキストを解決するコールバック
+ * @returns arrows[i] に対応する ArrowPathResult | null の配列
+ *   交差なしのエッジは routeAllArrows と同一の結果。
+ *   交差ありの H セグメントを含むエッジは d のみが再生成される（segments は不変）。
+ */
+export function routeAllArrowsWithJumpers<T extends ArrowLike>(
+  arrows: T[],
+  resolveContext: (arrow: T) => ArrowResolveContext | null,
+): Array<ArrowPathResult | null> {
+  // 1パス目: 既存 routeAllArrows で全 segments 確定
+  const paths = routeAllArrows(arrows, resolveContext)
+
+  // 2パス目: 交差検出
+  const edgesForCrossing: EdgeWithSegments[] = []
+  for (let i = 0; i < arrows.length; i++) {
+    const p = paths[i]
+    if (p) edgesForCrossing.push({ id: arrows[i].id, segments: p.segments })
+  }
+  const crossings = detectCrossings(edgesForCrossing)
+
+  if (crossings.length === 0) return paths
+
+  // jumperEdgeId → segmentIndex → x[] のマップを構築
+  const jumpsByEdge = new Map<string, Map<number, number[]>>()
+  for (const c of crossings) {
+    let segMap = jumpsByEdge.get(c.jumperEdgeId)
+    if (!segMap) {
+      segMap = new Map()
+      jumpsByEdge.set(c.jumperEdgeId, segMap)
+    }
+    let arr = segMap.get(c.jumperSegmentIndex)
+    if (!arr) {
+      arr = []
+      segMap.set(c.jumperSegmentIndex, arr)
+    }
+    arr.push(c.x)
+  }
+
+  // 3パス目: d 再生成（ジャンパー対象のエッジのみ）
+  return paths.map((p, i) => {
+    if (!p) return null
+    const jumps = jumpsByEdge.get(arrows[i].id)
+    if (!jumps) return p
+    return { ...p, d: segmentsToD(p.segments, jumps) }
+  })
 }


### PR DESCRIPTION
## Summary

ロジック修正により、スクリーンショット「折り返し電話」ケースの可読性問題を解消します:

- **段階4 (ジャンパー描画)**: 位相的に避けられない H × V 交差を半円弧で表現
- **段階3 (トラック割当)**: 複数エッジが同じ領域を迂回する際のトラック衝突を `escalateDetourTrack` で回避
- 既存 `routeAllArrows` を保持し、ラッパー `routeAllArrowsWithJumpers` を追加（後方互換）
- `EdgeSegment.range` を進行方向順 `[start, end]` に統一（ジャンパー sweep 方向決定のため）

設計ドキュメント: `docs/参考デザイン/20260523_ロジック修正/arrow-routing-stage-3-4-revised.md`
実装プラン: `docs/superpowers/plans/2026-05-23-arrow-routing-stage-3-4-plan.md`

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/lib/arrow-routing.ts` | `segmentsToD`, `detectCrossings`, `escalateDetourTrack`, 型 `EdgeWithSegments`/`Crossing`, 定数 `JUMP_RADIUS`/`CROSSING_MARGIN` を追加。range 順序保持化。 |
| `src/lib/edge-router.ts` | `routeAllArrowsWithJumpers` を追加（既存 `routeAllArrows` は無変更） |
| `src/features/editor/FlowEditor.tsx` | `routeAllArrows` → `routeAllArrowsWithJumpers` |
| `src/features/shared/SharedFlowViewer.tsx` | 同上 |
| `src/lib/arrow-routing.test.ts` | segments 構造スナップショット (5) + `segmentsToD` (9) + `detectCrossings` (6) + `escalateDetourTrack` (3) のテスト追加 |
| `src/lib/edge-router.test.ts` | `routeAllArrows` snapshot 安全網 (1) + `routeAllArrowsWithJumpers` テスト (4) を追加 |

## Test plan

- [x] 全 1742 ユニットテスト pass
- [x] TypeScript 型チェック OK
- [x] ESLint + Prettier OK
- [x] 本番ビルド OK
- [x] ブラウザ実行で `routeAllArrowsWithJumpers` が `A5,5` 弧マーカーを生成することを直接確認
- [ ] 実画面で X 字交差「折り返し電話」シナリオに弧が描画される（ユーザー確認）
- [ ] 上方向 escalation 領域で弧と隣接線が干渉していない（ユーザー確認）

## 補足

- `routeAllArrows` の挙動は完全に温存（既存 7 ケース + 新規 snapshot 1 ケース pass）
- 共有 endpoint エッジ間も交差検出対象（`routeAllArrows` の障害物除外で交差が生じやすいため）
- `escalateDetourTrack` は初期位置のノード衝突を許容（既存ルータの判断を尊重）、シフト後 (i≥1) のみノード衝突をチェック
- 設計レビューで指摘された干渉懸念（`TRACK_GAP=8` < `2×JUMP_RADIUS=10`）は Phase D 目視で確認、問題があれば `TRACK_GAP=12` への変更を後続対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)