### PR TITLE
fix: 薄いエッジセグメントを迂回対象から除外しジャンパー弧を機能させる

### DIFF
--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -35,8 +35,11 @@ const yOverlap = (a: Bbox, b: Bbox): boolean => Math.abs(a.y - b.y) < (a.h + b.h
 
 // エッジセグメント由来の薄い線分 Bbox かどうか判定する。
 // `segmentsToBboxes` は水平セグメントを `h=1`、垂直セグメントを `w=1` で生成するため
-// `h < 3 || w < 3` で識別できる。塞がり判定（up/down/left/right blocked）でこの種の
-// 線分を除外する用途で使う。経路上の障害物判定（inRow/inCol）には引き続き使う。
+// `h < 3 || w < 3` で識別できる。
+// 用途: 段階4 (ジャンパー) 導入以降、エッジ同士の交差は弧で表現するため、
+// detectDetour / detectVerticalDetour / detectDiagonalDetour の経路上障害物判定
+// (inRow / inCol / sourceColHits / targetColHits / middleRowHits) と
+// 塞がり判定 (up/down/left/right blocked) の両方からこの種の線分を除外する。
 const isThinSegment = (b: Bbox): boolean => b.h < 3 || b.w < 3
 
 const TRACK_GAP = 8
@@ -130,8 +133,8 @@ function detectDetour(s: Point, e: Point, obstacles: Bbox[]): { detourY: number 
   // のノードが入っていること（collectObstacles ヘルパーがこれを保証する）。Y 距離の
   // 厳密チェックを省略しているのはこの前提のため。
   // 注: routeAllArrows がエッジセグメント由来の薄い Bbox を obstacles に追加する場合がある。
-  // それら（h<3 または w<3）は別行を遠くで通っていても xOverlap で誤って塞がり判定を
-  // 引き起こすため、塞がり判定からは除外する（経路上の障害物判定 inRow には残す）。
+  // それら（h<3 または w<3）は inRow フィルタ側で既に除外済み (段階4 ジャンパー対応) だが、
+  // 塞がり判定でも xOverlap 誤判定を防ぐため明示的に除外する。
   const downBlocked = inRow.some((obs) =>
     obstacles.some((b) => !isThinSegment(b) && b.y > obs.y + 1 && xOverlap(obs, b)),
   )
@@ -182,8 +185,8 @@ function detectVerticalDetour(s: Point, e: Point, obstacles: Bbox[]): { detourX:
   // 左右塞がり判定（Y 重なりするノードが直左/直右に存在するか）
   // 前提: obstacles 配列には呼び出し側で「同一列＋直左列＋直右列のみ」をフィルタ済み
   // 注: routeAllArrows がエッジセグメント由来の薄い Bbox を obstacles に追加する場合がある。
-  // それら（h<3 または w<3）は別列を遠くで通っていても yOverlap で誤って塞がり判定を
-  // 引き起こすため、塞がり判定からは除外する（経路上の障害物判定 inCol には残す）。
+  // それら（h<3 または w<3）は inCol フィルタ側で既に除外済み (段階4 ジャンパー対応) だが、
+  // 塞がり判定でも yOverlap 誤判定を防ぐため明示的に除外する。
   const rightBlocked = inCol.some((obs) =>
     obstacles.some((b) => !isThinSegment(b) && b.x > obs.x + 1 && yOverlap(obs, b)),
   )

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -112,10 +112,16 @@ function detectDetour(s: Point, e: Point, obstacles: Bbox[]): { detourY: number 
   // 水平移動がなければ迂回対象なし
   if (xLow >= xHigh - 1) return null
 
-  // 経路上の障害ノード = 同一行（rowY と Y が重なる）かつ X が始終点の間
+  // 経路上の障害ノード = 同一行（rowY と Y が重なる）かつ X が始終点の間。
+  // 薄いセグメント（他エッジの直交線）は迂回対象から除外する。
+  // 理由: エッジ同士の H × V 交差は段階4 のジャンパー弧で表現すべきであり、
+  // ここで迂回すると不自然な U字パスが生成され、jumper も描画されない。
   const inRow = obstacles.filter(
     (b) =>
-      Math.abs(b.y - rowY) < b.h / 2 + 2 && b.x - b.w / 2 < xHigh - 1 && b.x + b.w / 2 > xLow + 1,
+      !isThinSegment(b) &&
+      Math.abs(b.y - rowY) < b.h / 2 + 2 &&
+      b.x - b.w / 2 < xHigh - 1 &&
+      b.x + b.w / 2 > xLow + 1,
   )
   if (inRow.length === 0) return null
 
@@ -162,10 +168,14 @@ function detectVerticalDetour(s: Point, e: Point, obstacles: Bbox[]): { detourX:
   // 垂直移動がなければ迂回対象なし
   if (yLow >= yHigh - 1) return null
 
-  // 経路上の障害ノード = 同一列（colX と X が重なる）かつ Y が始終点の間
+  // 経路上の障害ノード = 同一列（colX と X が重なる）かつ Y が始終点の間。
+  // 薄いセグメント（他エッジの直交線）は迂回対象から除外（段階4 ジャンパー弧で表現）。
   const inCol = obstacles.filter(
     (b) =>
-      Math.abs(b.x - colX) < b.w / 2 + 2 && b.y - b.h / 2 < yHigh - 1 && b.y + b.h / 2 > yLow + 1,
+      !isThinSegment(b) &&
+      Math.abs(b.x - colX) < b.w / 2 + 2 &&
+      b.y - b.h / 2 < yHigh - 1 &&
+      b.y + b.h / 2 > yLow + 1,
   )
   if (inCol.length === 0) return null
 
@@ -314,8 +324,9 @@ export function detectDiagonalDetour(
 
   const my = (s.y + e.y) / 2
 
-  // source 列衝突: source 縦セグメント (s.y → my) と重なる障害
+  // source 列衝突: source 縦セグメント (s.y → my) と重なる障害ノード（薄いセグメントは除外）
   const sourceColHits = obstacles.filter((b) => {
+    if (isThinSegment(b)) return false
     const yLow = Math.min(s.y, my)
     const yHigh = Math.max(s.y, my)
     return (
@@ -323,8 +334,9 @@ export function detectDiagonalDetour(
     )
   })
 
-  // target 列衝突: target 縦セグメント (my → e.y) と重なる障害
+  // target 列衝突: target 縦セグメント (my → e.y) と重なる障害ノード（薄いセグメントは除外）
   const targetColHits = obstacles.filter((b) => {
+    if (isThinSegment(b)) return false
     const yLow = Math.min(my, e.y)
     const yHigh = Math.max(my, e.y)
     return (
@@ -334,10 +346,12 @@ export function detectDiagonalDetour(
 
   // 中央水平セグメント衝突: Y ≈ my で X が source-target 間 (早期計算で全 kind 分岐に提供)
   // source/target 列の hit は対応する column detour で既に回避済みのため除外し、
-  // 純粋に中央水平セグメント上のみに存在する障害だけを評価対象にする。
+  // 純粋に中央水平セグメント上のみに存在する障害ノードだけを評価対象にする。
+  // 薄いセグメント（他エッジ）はジャンパー側で扱うためここでも除外。
   const sourceColSet = new Set(sourceColHits)
   const targetColSet = new Set(targetColHits)
   const middleRowHits = obstacles.filter((b) => {
+    if (isThinSegment(b)) return false
     if (sourceColSet.has(b) || targetColSet.has(b)) return false
     const xLow = Math.min(s.x, e.x)
     const xHigh = Math.max(s.x, e.x)

--- a/src/lib/edge-router.test.ts
+++ b/src/lib/edge-router.test.ts
@@ -40,7 +40,10 @@ describe('routeAllArrows', () => {
     expect(result[1]).not.toBeNull()
   })
 
-  it('second arrow with no shared endpoint sees first arrow segments as obstacles', () => {
+  it('second arrow does NOT detour around first arrow thin segments (jumper-side handles crossings)', () => {
+    // 段階4 (ジャンパー) 導入後、薄いエッジセグメントは迂回判定の障害物に含めない。
+    // a1 と a2 が H × V 交差する位置関係でも、a2 は alone と同一ルートを取り、
+    // 交差点は routeAllArrowsWithJumpers の 2nd pass で弧表現される。
     const arrows = [
       { id: 'a1', from: 'A', to: 'B' },
       { id: 'a2', from: 'C', to: 'D' },
@@ -53,9 +56,8 @@ describe('routeAllArrows', () => {
     const arrowsAlone = [{ id: 'a2', from: 'C', to: 'D' }]
     const alone = routeAllArrows(arrowsAlone, () => makeCtx(50, 100, 250, 100))
 
-    // With a1 present, a2's route must differ from routing alone
-    expect(result[1]?.d).not.toBe(alone[0]?.d)
-    // And still produce a valid result
+    // a1 の薄いセグメントは a2 の迂回判定に影響しないので、ルートは同一
+    expect(result[1]?.d).toBe(alone[0]?.d)
     expect(result[1]).not.toBeNull()
   })
 
@@ -144,7 +146,7 @@ describe('routeAllArrows', () => {
       [
         "M50,100 L750,100",
         "M100,225 L100,250 L700,250 L700,275",
-        "M250,100 L264,100 L264,114.5 L536,114.5 L536,100 L550,100",
+        "M250,100 L550,100",
       ]
     `)
   })


### PR DESCRIPTION
## Summary

PR #372 で段階4 (ジャンパー描画) を導入したが、`detectDetour` 系のフィルタが他エッジの薄いセグメントも迂回対象として扱っていたため、**H × V 交差が成立する位置関係でも先行エッジが大幅な U字迂回を生成し、crossings が発生せずジャンパーが描画されない**問題があった。

例: 23→24 (折り返し電話 グルプラ→ユーザー、同一行) が、行をまたぐ 21→6 縦点線エッジの薄い V セグメントを inRow に含めていたため、`y=1036 → y=1274 (+238px)` の不自然な U字を描画していた。

## Fix

`isThinSegment(b)` を以下 5 箇所のフィルタから除外:
- `detectDetour` の `inRow`
- `detectVerticalDetour` の `inCol`
- `detectDiagonalDetour` の `sourceColHits` / `targetColHits` / `middleRowHits`

エッジ同士の H × V 交差は段階4 のジャンパー弧で表現する設計に統一。

## 検証結果（実画面）

\`/dev/render?fixture=grupura-phone\` で確認:

**修正前** (U字迂回):
\`\`\`
"M530,1036 L516,1036 L516,1274 L198,1274 L198,1036 L184,1036"
\`\`\`

**修正後** (直線+ジャンパー):
\`\`\`
"M754,1036 L605,1036 A5,5 0 0 0 595,1036 L216,1036"
\`\`\`

## Test plan

- [x] 全 1745 ユニットテスト pass
- [x] TypeScript 型チェック OK
- [x] ESLint + Prettier OK
- [x] 本番ビルド OK
- [x] fixture (grupura-phone) で 23→24 が直線+ジャンパー弧 (A5,5) で描画される
- [ ] レビュー後、本番デプロイで「折り返し電話」シナリオの目視確認

## 副作用

- \`routeAllArrows\` の "second arrow with no shared endpoint sees first arrow segments as obstacles" テストは設計変更により無効化。新しい意味 ("does NOT detour around thin segments") に書き換え。
- 累積ルーティング snapshot は a3 が U字迂回→直線に変化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)