### PR TITLE
fix(#374): pickDetourX に middle-row 障害認識を追加

### DIFF
--- a/docs/superpowers/plans/2026-05-23-arrow-routing-pickDetourX-middle-hits-plan.md
+++ b/docs/superpowers/plans/2026-05-23-arrow-routing-pickDetourX-middle-hits-plan.md
@@ -15,6 +15,7 @@
 ## File Structure
 
 **Modify:**
+
 - `src/lib/arrow-routing.ts` — `pickDetourX` シグネチャ拡張 + L386 / L370 の呼び出し更新 + L379 / L371 / L425 に follow-up コメント
 - `src/lib/arrow-routing.test.ts` — 既存 `describe('detectDiagonalDetour')` と `describe('buildArrowPath - 斜め迂回（異行×異レーン）')` ブロックに新規テストを追加
 
@@ -77,6 +78,7 @@ Expected: 既存と同じパッケージ構成でインストール完了。
 ## Task 1: TDD Red — 失敗するテストを追加
 
 **Files:**
+
 - Test: `src/lib/arrow-routing.test.ts`
 
 **設計意図:** 5 テストを 1 commit で投入 → 全部 fail することを確認 → 後続タスクで実装で順次 green にする。
@@ -86,83 +88,83 @@ Expected: 既存と同じパッケージ構成でインストール完了。
 `src/lib/arrow-routing.test.ts` の `describe('detectDiagonalDetour')` ブロック内 (L1000 付近の `should shift my when both-detour selected AND middle-row obstacle exists` テストの直後) に以下を追加:
 
 ```typescript
-  // --- issue #374: pickDetourX に middle-row 障害認識を追加 ---
+// --- issue #374: pickDetourX に middle-row 障害認識を追加 ---
 
-  it('should pick detourX past middle-row hit when source-detour selected and middle-row hit is on target side', () => {
-    // issue #374 再現: source-col blocker (片側)、中央 H が他ノードを貫通するケース。
-    // s=(100, 100), e=(300, 300), my=200。target は右にある (e.x > s.x)。
-    // sourceColHits: (100, 200) → 旧来は左迂回 (左に blocker なし、右に middleRow があるため右 blocked と判定)
-    // middleRowHits: (200, 200) → これも detourX の extent に含めるべき
-    // 期待: 新ロジックで detourX = max(140, 240) + 14 = 254 (sourceCol + middleRow の union 最遠端 + DETOUR_MARGIN)
-    const obstacles: Bbox[] = [
-      { x: 100, y: 200, w: 80, h: 40 }, // sourceColHit (source col=100, row y=200)
-      { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit (row y=200, source/target col 以外)
-    ]
-    const r = detectDiagonalDetour({ x: 100, y: 100 }, { x: 300, y: 300 }, obstacles)
-    expect(r?.kind).toBe('source-detour')
-    if (r?.kind === 'source-detour') {
-      // detourX = max(sourceColHit.right=140, middleRowHit.right=240) + 14 = 254
-      expect(r.detourX).toBe(254)
-      // my は middle-row 障害があるが、shift-my で escape できない場合は元の 200 のまま。
-      // ここでは my の精密値より「detourX が正しく union 計算されている」点を検証。
-      // h=40, yLow=100, yHigh=300, bboxHMax=40, lo=121, hi=279 → shift-my OK
-      // shift-my で goDown=true → 200 + 20 + 14 = 234 (range 内)
-      expect(r.my).toBe(234)
-    }
-  })
+it('should pick detourX past middle-row hit when source-detour selected and middle-row hit is on target side', () => {
+  // issue #374 再現: source-col blocker (片側)、中央 H が他ノードを貫通するケース。
+  // s=(100, 100), e=(300, 300), my=200。target は右にある (e.x > s.x)。
+  // sourceColHits: (100, 200) → 旧来は左迂回 (左に blocker なし、右に middleRow があるため右 blocked と判定)
+  // middleRowHits: (200, 200) → これも detourX の extent に含めるべき
+  // 期待: 新ロジックで detourX = max(140, 240) + 14 = 254 (sourceCol + middleRow の union 最遠端 + DETOUR_MARGIN)
+  const obstacles: Bbox[] = [
+    { x: 100, y: 200, w: 80, h: 40 }, // sourceColHit (source col=100, row y=200)
+    { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit (row y=200, source/target col 以外)
+  ]
+  const r = detectDiagonalDetour({ x: 100, y: 100 }, { x: 300, y: 300 }, obstacles)
+  expect(r?.kind).toBe('source-detour')
+  if (r?.kind === 'source-detour') {
+    // detourX = max(sourceColHit.right=140, middleRowHit.right=240) + 14 = 254
+    expect(r.detourX).toBe(254)
+    // my は middle-row 障害があるが、shift-my で escape できない場合は元の 200 のまま。
+    // ここでは my の精密値より「detourX が正しく union 計算されている」点を検証。
+    // h=40, yLow=100, yHigh=300, bboxHMax=40, lo=121, hi=279 → shift-my OK
+    // shift-my で goDown=true → 200 + 20 + 14 = 234 (range 内)
+    expect(r.my).toBe(234)
+  }
+})
 
-  it('should pick detourX past middle-row hit even when source-col blocker is closer than middle-row hit', () => {
-    // sourceColHits.right < middleRowHits.right となるケース。
-    // 旧ロジックは sourceColHits だけ見て detourX=140 (sourceCol 右迂回) を選ぶが、
-    // それでは中央 H (140 → 300) が middleRowHit (160-240) を貫通する。
-    // 新ロジックは union extent の最遠端を取って detourX=254 を選ぶ (リグレッション防止)。
-    const obstacles: Bbox[] = [
-      { x: 100, y: 200, w: 80, h: 40 }, // sourceColHit, right=140
-      { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit, right=240
-    ]
-    const r = detectDiagonalDetour({ x: 100, y: 100 }, { x: 300, y: 300 }, obstacles)
-    expect(r?.kind).toBe('source-detour')
-    if (r?.kind === 'source-detour') {
-      expect(r.detourX).toBe(254)
-    }
-  })
+it('should pick detourX past middle-row hit even when source-col blocker is closer than middle-row hit', () => {
+  // sourceColHits.right < middleRowHits.right となるケース。
+  // 旧ロジックは sourceColHits だけ見て detourX=140 (sourceCol 右迂回) を選ぶが、
+  // それでは中央 H (140 → 300) が middleRowHit (160-240) を貫通する。
+  // 新ロジックは union extent の最遠端を取って detourX=254 を選ぶ (リグレッション防止)。
+  const obstacles: Bbox[] = [
+    { x: 100, y: 200, w: 80, h: 40 }, // sourceColHit, right=140
+    { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit, right=240
+  ]
+  const r = detectDiagonalDetour({ x: 100, y: 100 }, { x: 300, y: 300 }, obstacles)
+  expect(r?.kind).toBe('source-detour')
+  if (r?.kind === 'source-detour') {
+    expect(r.detourX).toBe(254)
+  }
+})
 
-  it('should mirror correctly for right-to-left diagonal source-detour with middle-row hit on left', () => {
-    // source.x > target.x: target は左にある (targetDirection=-1)。
-    // s=(300, 100), e=(100, 300), my=200。
-    // sourceColHits: (300, 200) → source col=300
-    // middleRowHits: (200, 200) → middle col
-    // 期待: detourX = min(sourceCol.left=260, middleRow.left=160) - 14 = 146 (左迂回 + middleRow を回避)
-    const obstacles: Bbox[] = [
-      { x: 300, y: 200, w: 80, h: 40 }, // sourceColHit, left=260
-      { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit, left=160
-    ]
-    const r = detectDiagonalDetour({ x: 300, y: 100 }, { x: 100, y: 300 }, obstacles)
-    expect(r?.kind).toBe('source-detour')
-    if (r?.kind === 'source-detour') {
-      // detourX = min(260, 160) - 14 = 146
-      expect(r.detourX).toBe(146)
-    }
-  })
+it('should mirror correctly for right-to-left diagonal source-detour with middle-row hit on left', () => {
+  // source.x > target.x: target は左にある (targetDirection=-1)。
+  // s=(300, 100), e=(100, 300), my=200。
+  // sourceColHits: (300, 200) → source col=300
+  // middleRowHits: (200, 200) → middle col
+  // 期待: detourX = min(sourceCol.left=260, middleRow.left=160) - 14 = 146 (左迂回 + middleRow を回避)
+  const obstacles: Bbox[] = [
+    { x: 300, y: 200, w: 80, h: 40 }, // sourceColHit, left=260
+    { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit, left=160
+  ]
+  const r = detectDiagonalDetour({ x: 300, y: 100 }, { x: 100, y: 300 }, obstacles)
+  expect(r?.kind).toBe('source-detour')
+  if (r?.kind === 'source-detour') {
+    // detourX = min(260, 160) - 14 = 146
+    expect(r.detourX).toBe(146)
+  }
+})
 
-  it('should pick sourceDetourX past middle-row hit in both-detour when middle-row hit exists on target side', () => {
-    // both-detour: source col と target col 両方に障害あり、加えて middle 行にも障害あり。
-    // s=(100, 100), e=(300, 300), my=200。
-    // sourceColHit: (100, 200), targetColHit: (300, 200), middleRowHit: (200, 200)
-    // 期待: sourceDetourX = max(sourceCol.right=140, middleRow.right=240) + 14 = 254
-    //       targetDetourX = 既存ロジック (本 PR 対象外) = 300 + 40 + 14 = 354
-    const obstacles: Bbox[] = [
-      { x: 100, y: 200, w: 80, h: 40 }, // sourceColHit
-      { x: 300, y: 200, w: 80, h: 40 }, // targetColHit
-      { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit
-    ]
-    const r = detectDiagonalDetour({ x: 100, y: 100 }, { x: 300, y: 300 }, obstacles)
-    expect(r?.kind).toBe('both-detour')
-    if (r?.kind === 'both-detour') {
-      expect(r.sourceDetourX).toBe(254) // 新ロジック適用
-      expect(r.targetDetourX).toBe(354) // 旧ロジック維持 (issue #375 で対応)
-    }
-  })
+it('should pick sourceDetourX past middle-row hit in both-detour when middle-row hit exists on target side', () => {
+  // both-detour: source col と target col 両方に障害あり、加えて middle 行にも障害あり。
+  // s=(100, 100), e=(300, 300), my=200。
+  // sourceColHit: (100, 200), targetColHit: (300, 200), middleRowHit: (200, 200)
+  // 期待: sourceDetourX = max(sourceCol.right=140, middleRow.right=240) + 14 = 254
+  //       targetDetourX = 既存ロジック (本 PR 対象外) = 300 + 40 + 14 = 354
+  const obstacles: Bbox[] = [
+    { x: 100, y: 200, w: 80, h: 40 }, // sourceColHit
+    { x: 300, y: 200, w: 80, h: 40 }, // targetColHit
+    { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit
+  ]
+  const r = detectDiagonalDetour({ x: 100, y: 100 }, { x: 300, y: 300 }, obstacles)
+  expect(r?.kind).toBe('both-detour')
+  if (r?.kind === 'both-detour') {
+    expect(r.sourceDetourX).toBe(254) // 新ロジック適用
+    expect(r.targetDetourX).toBe(354) // 旧ロジック維持 (issue #375 で対応)
+  }
+})
 ```
 
 - [ ] **Step 1.2: `describe('buildArrowPath - 斜め迂回（異行×異レーン）')` ブロックの末尾に統合テスト追加**
@@ -170,25 +172,25 @@ Expected: 既存と同じパッケージ構成でインストール完了。
 `src/lib/arrow-routing.test.ts` の `describe('buildArrowPath - 斜め迂回（異行×異レーン）')` ブロック内 (L662 の `'should handle diagonal detour when source/target points come from diamond shape'` テストの直後) に以下を追加:
 
 ```typescript
-  it('should not cross row obstacles when source has single-side blocker and target is on opposite side (issue #374)', () => {
-    // issue #374 再現: source-col blocker と middle-row blocker が同じ行にあり、
-    // 旧ロジックは左迂回して中央 H が両 blocker を貫通していた。
-    // 新ロジックは sourceCol + middleRow の union 最遠端まで detourX を張り出して
-    // 中央 H が他ノードを跨がない source-detour パスを生成する。
-    const sBug = { x: 100, y: 100 }
-    const eBug = { x: 300, y: 300 }
-    const fcBug = { x: 100, y: 50 }
-    const tcBug = { x: 300, y: 350 }
-    const obstacles: Bbox[] = [
-      { x: 100, y: 200, w: 80, h: 40 }, // sourceColHit (row y=200, source col=100)
-      { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit (row y=200, middle col)
-    ]
-    const r = buildArrowPath(sBug, eBug, fcBug, tcBug, obstacles)
-    // 中央水平 H は y=234 (shift-my) で detourX=254 → e.x=300 を辿るので
-    // middleRowHit (x=160-240, y=200, h=40 → y=180-220) には触れない。
-    // departY = clampOffset(100, 234, 14) = 114
-    expect(r.d).toBe('M100,100 L100,114 L254,114 L254,234 L300,234 L300,300')
-  })
+it('should not cross row obstacles when source has single-side blocker and target is on opposite side (issue #374)', () => {
+  // issue #374 再現: source-col blocker と middle-row blocker が同じ行にあり、
+  // 旧ロジックは左迂回して中央 H が両 blocker を貫通していた。
+  // 新ロジックは sourceCol + middleRow の union 最遠端まで detourX を張り出して
+  // 中央 H が他ノードを跨がない source-detour パスを生成する。
+  const sBug = { x: 100, y: 100 }
+  const eBug = { x: 300, y: 300 }
+  const fcBug = { x: 100, y: 50 }
+  const tcBug = { x: 300, y: 350 }
+  const obstacles: Bbox[] = [
+    { x: 100, y: 200, w: 80, h: 40 }, // sourceColHit (row y=200, source col=100)
+    { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit (row y=200, middle col)
+  ]
+  const r = buildArrowPath(sBug, eBug, fcBug, tcBug, obstacles)
+  // 中央水平 H は y=234 (shift-my) で detourX=254 → e.x=300 を辿るので
+  // middleRowHit (x=160-240, y=200, h=40 → y=180-220) には触れない。
+  // departY = clampOffset(100, 234, 14) = 114
+  expect(r.d).toBe('M100,100 L100,114 L254,114 L254,234 L300,234 L300,300')
+})
 ```
 
 - [ ] **Step 1.3: テストが全部 fail することを確認**
@@ -245,6 +247,7 @@ Expected: チェックリスト全項目クリア。不足あれば修正。
 ## Task 3: 実装 — `pickDetourX` に opts API を追加
 
 **Files:**
+
 - Modify: `src/lib/arrow-routing.ts` L230-L250
 
 - [ ] **Step 3.1: pickDetourX のシグネチャと本体を書き換え**
@@ -344,6 +347,7 @@ EOF
 ## Task 4: source-detour 呼び出しを opts ベースに更新
 
 **Files:**
+
 - Modify: `src/lib/arrow-routing.ts` L385-L390 (source-detour 分岐)
 
 - [ ] **Step 4.1: source-detour 分岐の pickDetourX 呼び出しを opts 付きに**
@@ -351,15 +355,15 @@ EOF
 `src/lib/arrow-routing.ts` L385-L390 の `if (sourceColHits.length > 0 && targetColHits.length === 0)` ブロックを以下に変更:
 
 ```typescript
-  if (sourceColHits.length > 0 && targetColHits.length === 0) {
-    const detourX = pickDetourX(sourceColHits, obstacles, [s.y, my], obstacles, {
-      targetDirection: e.x > s.x ? 1 : -1,
-      middleHitsToClear: middleRowHits,
-    })
-    const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
-    const departY = clampOffset(s.y, shiftedMy, DEPART_GAP)
-    return { kind: 'source-detour', departY, detourX, my: shiftedMy }
-  }
+if (sourceColHits.length > 0 && targetColHits.length === 0) {
+  const detourX = pickDetourX(sourceColHits, obstacles, [s.y, my], obstacles, {
+    targetDirection: e.x > s.x ? 1 : -1,
+    middleHitsToClear: middleRowHits,
+  })
+  const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
+  const departY = clampOffset(s.y, shiftedMy, DEPART_GAP)
+  return { kind: 'source-detour', departY, detourX, my: shiftedMy }
+}
 ```
 
 - [ ] **Step 4.2: テスト実行 — source-detour 関連が green になる**
@@ -369,6 +373,7 @@ npm test -- src/lib/arrow-routing.test.ts 2>&1 | tail -40
 ```
 
 Expected:
+
 - Step 1.1 の 1, 2, 3 番目のテスト (source-detour 3 ケース) PASS
 - Step 1.1 の 4 番目 (both-detour) は引き続き FAIL
 - Step 1.2 の統合テスト PASS
@@ -395,6 +400,7 @@ EOF
 ## Task 5: both-detour.sourceDetourX を opts ベースに更新 + follow-up コメント追加
 
 **Files:**
+
 - Modify: `src/lib/arrow-routing.ts` L364-L376 (both-detour 分岐) + L378-L383 (target-detour 分岐) + L425 付近 (middle-only 分岐)
 
 - [ ] **Step 5.1: both-detour 分岐を更新**
@@ -402,24 +408,24 @@ EOF
 `src/lib/arrow-routing.ts` L364-L376 の `if (sourceColHits.length > 0 && targetColHits.length > 0)` ブロックを以下に変更:
 
 ```typescript
-  if (sourceColHits.length > 0 && targetColHits.length > 0) {
-    // 相互ブロッキング回避: 反対側列の hits は方向判定から除外。対応する迂回パスで既に回避済み。
-    const targetIds = new Set(targetColHits)
-    const sourceIds = new Set(sourceColHits)
-    const srcBlockers = obstacles.filter((b) => !targetIds.has(b))
-    const tgtBlockers = obstacles.filter((b) => !sourceIds.has(b))
-    // sourceDetourX: 新ロジック (issue #374) で middleRowHits も extent に含める。
-    const sourceDetourX = pickDetourX(sourceColHits, srcBlockers, [s.y, my], obstacles, {
-      targetDirection: e.x > s.x ? 1 : -1,
-      middleHitsToClear: middleRowHits,
-    })
-    // targetDetourX: 旧ロジック維持。target-detour 系の対称対応は issue #375 で別途。
-    const targetDetourX = pickDetourX(targetColHits, tgtBlockers, [my, e.y], obstacles)
-    const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
-    const departY = clampOffset(s.y, shiftedMy, DEPART_GAP)
-    const approachY = clampOffset(e.y, shiftedMy, APPROACH_GAP)
-    return { kind: 'both-detour', departY, sourceDetourX, my: shiftedMy, targetDetourX, approachY }
-  }
+if (sourceColHits.length > 0 && targetColHits.length > 0) {
+  // 相互ブロッキング回避: 反対側列の hits は方向判定から除外。対応する迂回パスで既に回避済み。
+  const targetIds = new Set(targetColHits)
+  const sourceIds = new Set(sourceColHits)
+  const srcBlockers = obstacles.filter((b) => !targetIds.has(b))
+  const tgtBlockers = obstacles.filter((b) => !sourceIds.has(b))
+  // sourceDetourX: 新ロジック (issue #374) で middleRowHits も extent に含める。
+  const sourceDetourX = pickDetourX(sourceColHits, srcBlockers, [s.y, my], obstacles, {
+    targetDirection: e.x > s.x ? 1 : -1,
+    middleHitsToClear: middleRowHits,
+  })
+  // targetDetourX: 旧ロジック維持。target-detour 系の対称対応は issue #375 で別途。
+  const targetDetourX = pickDetourX(targetColHits, tgtBlockers, [my, e.y], obstacles)
+  const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
+  const departY = clampOffset(s.y, shiftedMy, DEPART_GAP)
+  const approachY = clampOffset(e.y, shiftedMy, APPROACH_GAP)
+  return { kind: 'both-detour', departY, sourceDetourX, my: shiftedMy, targetDetourX, approachY }
+}
 ```
 
 - [ ] **Step 5.2: target-detour / middle-only 分岐に follow-up コメント追加**
@@ -508,11 +514,13 @@ Expected: Vite dev サーバーが localhost (通常 5173) で起動。
 Playwright MCP または chrome-devtools で `http://localhost:5173/dev/render?fixture=grupura-phone` を開く。
 
 確認ポイント:
+
 - 「ステータス変更 (店舗 row 15) → 請求 グルプラ(2) (グルプラ(2) row 17)」の矢印が **右迂回** している
 - 中央水平セグメントが row 16 の「確認連絡 店舗」「確認連絡 グルプラ」のいずれにも触れていない
 - 他の矢印に視覚的リグレッションがない (他の fixture も軽く目視確認)
 
 スクリーンショットを `.screenshots/` に保存:
+
 ```bash
 # Playwright MCP の screenshot 機能を使用
 ```
@@ -662,6 +670,7 @@ gh pr view --json comments
 `claude[bot]` の最新コメントを確認。jq パースエラー時は `--jq` を使わず生の JSON を読む。
 
 判定方法:
+
 - 再レビュー後の判定は、**再レビュー依頼コメントの `created_at` より後** の `claude[bot]` コメントだけを対象。古いレビュー判定文字列で誤って終了しないこと。
 - 自分自身のコメントで判定しない。
 

--- a/docs/superpowers/plans/2026-05-23-arrow-routing-pickDetourX-middle-hits-plan.md
+++ b/docs/superpowers/plans/2026-05-23-arrow-routing-pickDetourX-middle-hits-plan.md
@@ -1,0 +1,742 @@
+# pickDetourX に middle-row 障害認識を追加 Implementation Plan (issue #374)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `pickDetourX` に `opts { targetDirection, middleHitsToClear }` を追加し、source-detour / both-detour.sourceDetourX で中央水平セグメントが他ノードを貫通するバグを解消する。
+
+**Architecture:** 既存呼び出しは `opts` 省略で完全な後方互換。`opts` 指定時のみ「sourceColHits ∪ middleRowHits」の union を「迂回すべき extent」として一括で最遠端 + DETOUR_MARGIN を取る新ロジックを使う。`detectDiagonalDetour` 内の 2 箇所 (source-detour, both-detour.sourceDetourX) で `opts` を渡し、target-detour / both-detour.tgtDetourX は本 PR スコープ外 (#375)。
+
+**Tech Stack:** TypeScript, Vitest, Vite, React (本 PR は純粋関数のみ変更)
+
+**Spec:** `docs/superpowers/specs/2026-05-23-arrow-routing-pickDetourX-middle-hits-design.md`
+
+---
+
+## File Structure
+
+**Modify:**
+- `src/lib/arrow-routing.ts` — `pickDetourX` シグネチャ拡張 + L386 / L370 の呼び出し更新 + L379 / L371 / L425 に follow-up コメント
+- `src/lib/arrow-routing.test.ts` — 既存 `describe('detectDiagonalDetour')` と `describe('buildArrowPath - 斜め迂回（異行×異レーン）')` ブロックに新規テストを追加
+
+**No new files.**
+
+---
+
+## Task 0: Setup — worktree + ラベル
+
+**Files:** （ファイル変更なし。環境準備のみ）
+
+- [ ] **Step 0.1: main を最新化**
+
+```bash
+git checkout main
+git fetch origin
+git merge --ff-only origin/main
+```
+
+Expected: `Already up to date.` または fast-forward 成功。失敗した場合は人間に報告して中断。
+
+- [ ] **Step 0.2: 「作業開始」ラベルを issue に付与**
+
+```bash
+gh issue edit 374 --add-label "作業開始"
+```
+
+Expected: ラベル付与成功。
+
+- [ ] **Step 0.3: worktree 作成**
+
+```bash
+git worktree add .worktrees/fix-arrow-routing-pickDetourX-middle-hits -b fix/arrow-routing-pickDetourX-middle-hits
+cd .worktrees/fix-arrow-routing-pickDetourX-middle-hits
+
+MAIN=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
+for f in "$MAIN"/.env*; do [ -f "$f" ] && ln -sf "$f" .; done
+```
+
+Expected: worktree 作成成功、.env 系シンボリックリンク作成。
+
+- [ ] **Step 0.4: テストルール確認**
+
+```bash
+cat ~/.claude/rules/testing.md
+```
+
+Expected: testing.md の内容を確認。以降のテスト作成で参照する。
+
+- [ ] **Step 0.5: 依存インストール (worktree 内)**
+
+```bash
+npm install
+```
+
+Expected: 既存と同じパッケージ構成でインストール完了。
+
+---
+
+## Task 1: TDD Red — 失敗するテストを追加
+
+**Files:**
+- Test: `src/lib/arrow-routing.test.ts`
+
+**設計意図:** 5 テストを 1 commit で投入 → 全部 fail することを確認 → 後続タスクで実装で順次 green にする。
+
+- [ ] **Step 1.1: `describe('detectDiagonalDetour')` ブロックの末尾に 4 ユニットテスト追加**
+
+`src/lib/arrow-routing.test.ts` の `describe('detectDiagonalDetour')` ブロック内 (L1000 付近の `should shift my when both-detour selected AND middle-row obstacle exists` テストの直後) に以下を追加:
+
+```typescript
+  // --- issue #374: pickDetourX に middle-row 障害認識を追加 ---
+
+  it('should pick detourX past middle-row hit when source-detour selected and middle-row hit is on target side', () => {
+    // issue #374 再現: source-col blocker (片側)、中央 H が他ノードを貫通するケース。
+    // s=(100, 100), e=(300, 300), my=200。target は右にある (e.x > s.x)。
+    // sourceColHits: (100, 200) → 旧来は左迂回 (左に blocker なし、右に middleRow があるため右 blocked と判定)
+    // middleRowHits: (200, 200) → これも detourX の extent に含めるべき
+    // 期待: 新ロジックで detourX = max(140, 240) + 14 = 254 (sourceCol + middleRow の union 最遠端 + DETOUR_MARGIN)
+    const obstacles: Bbox[] = [
+      { x: 100, y: 200, w: 80, h: 40 }, // sourceColHit (source col=100, row y=200)
+      { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit (row y=200, source/target col 以外)
+    ]
+    const r = detectDiagonalDetour({ x: 100, y: 100 }, { x: 300, y: 300 }, obstacles)
+    expect(r?.kind).toBe('source-detour')
+    if (r?.kind === 'source-detour') {
+      // detourX = max(sourceColHit.right=140, middleRowHit.right=240) + 14 = 254
+      expect(r.detourX).toBe(254)
+      // my は middle-row 障害があるが、shift-my で escape できない場合は元の 200 のまま。
+      // ここでは my の精密値より「detourX が正しく union 計算されている」点を検証。
+      // h=40, yLow=100, yHigh=300, bboxHMax=40, lo=121, hi=279 → shift-my OK
+      // shift-my で goDown=true → 200 + 20 + 14 = 234 (range 内)
+      expect(r.my).toBe(234)
+    }
+  })
+
+  it('should pick detourX past middle-row hit even when source-col blocker is closer than middle-row hit', () => {
+    // sourceColHits.right < middleRowHits.right となるケース。
+    // 旧ロジックは sourceColHits だけ見て detourX=140 (sourceCol 右迂回) を選ぶが、
+    // それでは中央 H (140 → 300) が middleRowHit (160-240) を貫通する。
+    // 新ロジックは union extent の最遠端を取って detourX=254 を選ぶ (リグレッション防止)。
+    const obstacles: Bbox[] = [
+      { x: 100, y: 200, w: 80, h: 40 }, // sourceColHit, right=140
+      { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit, right=240
+    ]
+    const r = detectDiagonalDetour({ x: 100, y: 100 }, { x: 300, y: 300 }, obstacles)
+    expect(r?.kind).toBe('source-detour')
+    if (r?.kind === 'source-detour') {
+      expect(r.detourX).toBe(254)
+    }
+  })
+
+  it('should mirror correctly for right-to-left diagonal source-detour with middle-row hit on left', () => {
+    // source.x > target.x: target は左にある (targetDirection=-1)。
+    // s=(300, 100), e=(100, 300), my=200。
+    // sourceColHits: (300, 200) → source col=300
+    // middleRowHits: (200, 200) → middle col
+    // 期待: detourX = min(sourceCol.left=260, middleRow.left=160) - 14 = 146 (左迂回 + middleRow を回避)
+    const obstacles: Bbox[] = [
+      { x: 300, y: 200, w: 80, h: 40 }, // sourceColHit, left=260
+      { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit, left=160
+    ]
+    const r = detectDiagonalDetour({ x: 300, y: 100 }, { x: 100, y: 300 }, obstacles)
+    expect(r?.kind).toBe('source-detour')
+    if (r?.kind === 'source-detour') {
+      // detourX = min(260, 160) - 14 = 146
+      expect(r.detourX).toBe(146)
+    }
+  })
+
+  it('should pick sourceDetourX past middle-row hit in both-detour when middle-row hit exists on target side', () => {
+    // both-detour: source col と target col 両方に障害あり、加えて middle 行にも障害あり。
+    // s=(100, 100), e=(300, 300), my=200。
+    // sourceColHit: (100, 200), targetColHit: (300, 200), middleRowHit: (200, 200)
+    // 期待: sourceDetourX = max(sourceCol.right=140, middleRow.right=240) + 14 = 254
+    //       targetDetourX = 既存ロジック (本 PR 対象外) = 300 + 40 + 14 = 354
+    const obstacles: Bbox[] = [
+      { x: 100, y: 200, w: 80, h: 40 }, // sourceColHit
+      { x: 300, y: 200, w: 80, h: 40 }, // targetColHit
+      { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit
+    ]
+    const r = detectDiagonalDetour({ x: 100, y: 100 }, { x: 300, y: 300 }, obstacles)
+    expect(r?.kind).toBe('both-detour')
+    if (r?.kind === 'both-detour') {
+      expect(r.sourceDetourX).toBe(254) // 新ロジック適用
+      expect(r.targetDetourX).toBe(354) // 旧ロジック維持 (issue #375 で対応)
+    }
+  })
+```
+
+- [ ] **Step 1.2: `describe('buildArrowPath - 斜め迂回（異行×異レーン）')` ブロックの末尾に統合テスト追加**
+
+`src/lib/arrow-routing.test.ts` の `describe('buildArrowPath - 斜め迂回（異行×異レーン）')` ブロック内 (L662 の `'should handle diagonal detour when source/target points come from diamond shape'` テストの直後) に以下を追加:
+
+```typescript
+  it('should not cross row obstacles when source has single-side blocker and target is on opposite side (issue #374)', () => {
+    // issue #374 再現: source-col blocker と middle-row blocker が同じ行にあり、
+    // 旧ロジックは左迂回して中央 H が両 blocker を貫通していた。
+    // 新ロジックは sourceCol + middleRow の union 最遠端まで detourX を張り出して
+    // 中央 H が他ノードを跨がない source-detour パスを生成する。
+    const sBug = { x: 100, y: 100 }
+    const eBug = { x: 300, y: 300 }
+    const fcBug = { x: 100, y: 50 }
+    const tcBug = { x: 300, y: 350 }
+    const obstacles: Bbox[] = [
+      { x: 100, y: 200, w: 80, h: 40 }, // sourceColHit (row y=200, source col=100)
+      { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit (row y=200, middle col)
+    ]
+    const r = buildArrowPath(sBug, eBug, fcBug, tcBug, obstacles)
+    // 中央水平 H は y=234 (shift-my) で detourX=254 → e.x=300 を辿るので
+    // middleRowHit (x=160-240, y=200, h=40 → y=180-220) には触れない。
+    // departY = clampOffset(100, 234, 14) = 114
+    expect(r.d).toBe('M100,100 L100,114 L254,114 L254,234 L300,234 L300,300')
+  })
+```
+
+- [ ] **Step 1.3: テストが全部 fail することを確認**
+
+```bash
+npm test -- src/lib/arrow-routing.test.ts 2>&1 | tail -40
+```
+
+Expected: 上記 5 テストが FAIL (期待値と実際値の差分が表示される)。既存テストは PASS。
+理由: pickDetourX 旧ロジックは binary blocker 判定で動作し、middle-row 障害を考慮せず detourX を計算するため。
+
+- [ ] **Step 1.4: TDD red commit**
+
+```bash
+git add src/lib/arrow-routing.test.ts
+git commit -m "$(cat <<'EOF'
+test(#374): pickDetourX に middle-row 障害認識を追加するテスト (red)
+
+source-detour / both-detour.sourceDetourX で sourceColHits と middleRowHits の
+union として detourX を決定すべきケースをカバーする 5 テストを追加。
+本 commit 時点では全 5 テスト FAIL する (実装は後続 commit)。
+
+- 4 unit (detectDiagonalDetour): source-detour 単一/逆方向/both-detour
+- 1 integration (buildArrowPath): grupura-phone-like 再現パス
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: テスト品質チェック
+
+**Files:** （ファイル変更なし）
+
+- [ ] **Step 2.1: testing.md チェックリストと照合**
+
+`~/.claude/rules/testing.md` の以下を満たしているか確認:
+
+- [x] 振る舞いテスト (期待 SVG path / detourX 値) で実装詳細に依存しない
+- [x] 各テスト独立 (グローバル state なし)
+- [x] 決定論的 (ネットワーク / 時刻なし)
+- [x] エッジケース: 左/右両方向 (LTR + RTL), single-side blocker, union 最遠端が sourceCol/middleRow 双方
+- [x] 命名規則: `should [behavior] when [condition]`
+- [x] モック不要 (純粋関数)
+
+特に「union の最遠端を見ているか」を verify する Step 1.1 の 2 番目のテストは、リグレッション検出に必須なので削除しないこと。
+
+Expected: チェックリスト全項目クリア。不足あれば修正。
+
+---
+
+## Task 3: 実装 — `pickDetourX` に opts API を追加
+
+**Files:**
+- Modify: `src/lib/arrow-routing.ts` L230-L250
+
+- [ ] **Step 3.1: pickDetourX のシグネチャと本体を書き換え**
+
+`src/lib/arrow-routing.ts` の L223-L250 を以下に置き換え (関数全体 replace):
+
+```typescript
+/**
+ * 右優先で迂回 X を決定する。hits 中のいずれかが Y 重なりするブロッカーを直右に持てば右塞がり、
+ * 直左に持てば左塞がり。両塞がりなら右優先 (#333 と整合)。
+ *
+ * blockers は方向判定対象のブロッカー候補。target/source 列同士の相互ブロッキングを防ぐ
+ * ため、both-detour では呼び出し側が反対側列の hits を除外した blockers を渡す。
+ *
+ * opts (issue #374):
+ *   指定時は binary blocker 判定をスキップし、targetDirection 方向に hits ∪ middleHitsToClear の
+ *   union 最遠端 + DETOUR_MARGIN を取る新ロジックを使う。これにより source-detour で中央水平
+ *   セグメントが middle-row 障害を貫通するバグを解消する。両フィールド必須。
+ */
+function pickDetourX(
+  hits: Bbox[],
+  blockers: Bbox[],
+  crossRange: [number, number],
+  obstacles: Bbox[],
+  opts?: {
+    targetDirection: 1 | -1
+    middleHitsToClear: Bbox[]
+  },
+): number {
+  if (opts) {
+    // 新ロジック (issue #374): hits ∪ middleHitsToClear の最遠端を取る。
+    // sourceColHits だけ見ていた旧ロジックでは middleRowHits を貫通する detourX を選んでしまう。
+    const extent = [...hits, ...opts.middleHitsToClear]
+    const initialDetourX =
+      opts.targetDirection === 1
+        ? Math.max(...extent.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+        : Math.min(...extent.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+    return escalateDetourTrack(initialDetourX, crossRange, 'v', obstacles, opts.targetDirection)
+  }
+
+  // 既存ロジック (opts 未指定時): binary blocker 判定による方向決定。
+  // 薄い線分 (エッジセグメント由来 Bbox) は方向判定から除外。
+  // detectDetour / detectVerticalDetour と同じ理由 (yOverlap 誤判定を防ぐ)。
+  const rightBlocked = hits.some((obs) =>
+    blockers.some((b) => !isThinSegment(b) && b.x > obs.x + 1 && yOverlap(obs, b)),
+  )
+  const leftBlocked = hits.some((obs) =>
+    blockers.some((b) => !isThinSegment(b) && b.x < obs.x - 1 && yOverlap(obs, b)),
+  )
+  const goRight = !rightBlocked || leftBlocked
+  const initialDetourX = goRight
+    ? Math.max(...hits.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+    : Math.min(...hits.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+  const direction: 1 | -1 = goRight ? 1 : -1
+  return escalateDetourTrack(initialDetourX, crossRange, 'v', obstacles, direction)
+}
+```
+
+- [ ] **Step 3.2: lint + typecheck**
+
+```bash
+npm run lint -- src/lib/arrow-routing.ts
+npx tsc --noEmit
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 3.3: 既存テスト無変化を確認 (新規テストは引き続き FAIL)**
+
+```bash
+npm test -- src/lib/arrow-routing.test.ts 2>&1 | tail -40
+```
+
+Expected: 既存テスト (issue #374 追加分以外) 全部 PASS。新規 5 テストは引き続き FAIL (呼び出し側で opts を渡していないため)。
+
+- [ ] **Step 3.4: 中間 commit**
+
+```bash
+git add src/lib/arrow-routing.ts
+git commit -m "$(cat <<'EOF'
+feat(#374): pickDetourX に opts API を追加 (後方互換)
+
+opts { targetDirection, middleHitsToClear } を指定すると binary blocker 判定を
+スキップし、hits ∪ middleHitsToClear の union 最遠端 + DETOUR_MARGIN を取る新
+ロジックで detourX を決定する。opts 未指定時は既存ロジックそのままで完全な
+後方互換 (既存テスト無変化を確認済み)。
+
+呼び出し側の更新は後続 commit にて。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: source-detour 呼び出しを opts ベースに更新
+
+**Files:**
+- Modify: `src/lib/arrow-routing.ts` L385-L390 (source-detour 分岐)
+
+- [ ] **Step 4.1: source-detour 分岐の pickDetourX 呼び出しを opts 付きに**
+
+`src/lib/arrow-routing.ts` L385-L390 の `if (sourceColHits.length > 0 && targetColHits.length === 0)` ブロックを以下に変更:
+
+```typescript
+  if (sourceColHits.length > 0 && targetColHits.length === 0) {
+    const detourX = pickDetourX(sourceColHits, obstacles, [s.y, my], obstacles, {
+      targetDirection: e.x > s.x ? 1 : -1,
+      middleHitsToClear: middleRowHits,
+    })
+    const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
+    const departY = clampOffset(s.y, shiftedMy, DEPART_GAP)
+    return { kind: 'source-detour', departY, detourX, my: shiftedMy }
+  }
+```
+
+- [ ] **Step 4.2: テスト実行 — source-detour 関連が green になる**
+
+```bash
+npm test -- src/lib/arrow-routing.test.ts 2>&1 | tail -40
+```
+
+Expected:
+- Step 1.1 の 1, 2, 3 番目のテスト (source-detour 3 ケース) PASS
+- Step 1.1 の 4 番目 (both-detour) は引き続き FAIL
+- Step 1.2 の統合テスト PASS
+- 既存テスト全部 PASS
+
+- [ ] **Step 4.3: 中間 commit**
+
+```bash
+git add src/lib/arrow-routing.ts
+git commit -m "$(cat <<'EOF'
+fix(#374): source-detour で sourceColHits ∪ middleRowHits を union 評価
+
+detectDiagonalDetour の source-detour 分岐で pickDetourX に opts を渡し、
+detourX を中央水平 H の通過範囲も含めて決定する。これにより密集レイアウトで
+中央 H が他ノードを貫通する症状を解消。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: both-detour.sourceDetourX を opts ベースに更新 + follow-up コメント追加
+
+**Files:**
+- Modify: `src/lib/arrow-routing.ts` L364-L376 (both-detour 分岐) + L378-L383 (target-detour 分岐) + L425 付近 (middle-only 分岐)
+
+- [ ] **Step 5.1: both-detour 分岐を更新**
+
+`src/lib/arrow-routing.ts` L364-L376 の `if (sourceColHits.length > 0 && targetColHits.length > 0)` ブロックを以下に変更:
+
+```typescript
+  if (sourceColHits.length > 0 && targetColHits.length > 0) {
+    // 相互ブロッキング回避: 反対側列の hits は方向判定から除外。対応する迂回パスで既に回避済み。
+    const targetIds = new Set(targetColHits)
+    const sourceIds = new Set(sourceColHits)
+    const srcBlockers = obstacles.filter((b) => !targetIds.has(b))
+    const tgtBlockers = obstacles.filter((b) => !sourceIds.has(b))
+    // sourceDetourX: 新ロジック (issue #374) で middleRowHits も extent に含める。
+    const sourceDetourX = pickDetourX(sourceColHits, srcBlockers, [s.y, my], obstacles, {
+      targetDirection: e.x > s.x ? 1 : -1,
+      middleHitsToClear: middleRowHits,
+    })
+    // targetDetourX: 旧ロジック維持。target-detour 系の対称対応は issue #375 で別途。
+    const targetDetourX = pickDetourX(targetColHits, tgtBlockers, [my, e.y], obstacles)
+    const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
+    const departY = clampOffset(s.y, shiftedMy, DEPART_GAP)
+    const approachY = clampOffset(e.y, shiftedMy, APPROACH_GAP)
+    return { kind: 'both-detour', departY, sourceDetourX, my: shiftedMy, targetDetourX, approachY }
+  }
+```
+
+- [ ] **Step 5.2: target-detour / middle-only 分岐に follow-up コメント追加**
+
+`src/lib/arrow-routing.ts` L378 の `if (targetColHits.length > 0 && sourceColHits.length === 0)` の直前に以下のコメントを追加:
+
+```typescript
+  // 注: target-detour の detourX 計算は対称的に opts { targetDirection, middleHitsToClear } を
+  // 渡せる API を持つが、本 PR (issue #374) では source-detour のみに適用してリグレッションリスクを
+  // 抑える。target-detour / both-detour.tgtDetourX の対称対応は issue #375 でフォローアップ予定。
+  if (targetColHits.length > 0 && sourceColHits.length === 0) {
+```
+
+L425 付近の `const detourX = pickDetourX(middleRowHits, obstacles, [s.y, e.y], obstacles)` (middle-only 分岐の kind escalation 用) は本 PR スコープ外。既存ロジック維持。
+
+- [ ] **Step 5.3: テスト全部 green を確認**
+
+```bash
+npm test -- src/lib/arrow-routing.test.ts 2>&1 | tail -40
+```
+
+Expected: 新規 5 テスト + 既存テスト全部 PASS。
+
+- [ ] **Step 5.4: 中間 commit**
+
+```bash
+git add src/lib/arrow-routing.ts
+git commit -m "$(cat <<'EOF'
+fix(#374): both-detour.sourceDetourX も union 評価に更新 + #375 コメント
+
+both-detour の sourceDetourX 計算にも opts を伝搬。tgtDetourX は本 PR 対象外
+として既存ロジック維持、対称対応は issue #375 で。target-detour / middle-only
+分岐に follow-up を示すコメントを追加。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: フルテスト + lint + typecheck
+
+**Files:** （変更なし）
+
+- [ ] **Step 6.1: フルテスト実行**
+
+```bash
+npm test
+```
+
+Expected: 全 suite PASS。FAIL が 1 件でもあれば修正 (今回の修正対象外でも)。
+
+- [ ] **Step 6.2: lint**
+
+```bash
+npm run lint
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 6.3: typecheck**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: エラーなし。
+
+---
+
+## Task 7: ブラウザ目視検証 — grupura-phone 再現
+
+**Files:** （アプリ起動のみ）
+
+- [ ] **Step 7.1: dev サーバー起動**
+
+```bash
+npm run dev &
+```
+
+Expected: Vite dev サーバーが localhost (通常 5173) で起動。
+
+- [ ] **Step 7.2: `/dev/render?fixture=grupura-phone` を開いてスクリーンショット**
+
+Playwright MCP または chrome-devtools で `http://localhost:5173/dev/render?fixture=grupura-phone` を開く。
+
+確認ポイント:
+- 「ステータス変更 (店舗 row 15) → 請求 グルプラ(2) (グルプラ(2) row 17)」の矢印が **右迂回** している
+- 中央水平セグメントが row 16 の「確認連絡 店舗」「確認連絡 グルプラ」のいずれにも触れていない
+- 他の矢印に視覚的リグレッションがない (他の fixture も軽く目視確認)
+
+スクリーンショットを `.screenshots/` に保存:
+```bash
+# Playwright MCP の screenshot 機能を使用
+```
+
+Expected: 修正後の SVG path が中央 H で 916.5 → 1055.5 (LTR) になり、row 16 を跨がない。
+
+- [ ] **Step 7.3: 表示速度チェック**
+
+`/dev/render?fixture=grupura-phone` の LCP が **1 秒以内** であることを確認 (DevTools Performance または Lighthouse)。
+
+Expected: LCP ≤ 1000ms。超過した場合は原因調査 → Task 3-5 に戻る。
+
+- [ ] **Step 7.4: dev サーバー停止**
+
+```bash
+# 起動した dev サーバーを停止
+```
+
+---
+
+## Task 8: 最新 main 同期
+
+**Files:** （変更なし）
+
+- [ ] **Step 8.1: main を最新化して rebase**
+
+```bash
+git fetch origin main
+git rebase origin/main
+```
+
+Expected: conflict なし。conflict があれば解決。
+
+- [ ] **Step 8.2: 全テスト再実行**
+
+```bash
+npm test
+```
+
+Expected: 全部 PASS。
+
+---
+
+## Task 9: PR 作成 + CI 監視
+
+**Files:** （変更なし）
+
+- [ ] **Step 9.1: push**
+
+```bash
+git push -u origin fix/arrow-routing-pickDetourX-middle-hits
+```
+
+Expected: リモートにブランチ作成成功。
+
+- [ ] **Step 9.2: PR 作成**
+
+```bash
+gh pr create --title "fix(#374): pickDetourX に middle-row 障害認識を追加" --body "$(cat <<'EOF'
+## Summary
+
+issue #374 の修正。密集レイアウトで斜め配置の矢印が source 列 blocker により target と反対方向へ迂回し、中央水平セグメントが他ノードを貫通する問題を解消する。
+
+設計案 A' (`pickDetourX` に `opts { targetDirection, middleHitsToClear }` を追加する後方互換 API) で対応:
+
+- `sourceColHits` と `middleRowHits` の union を「迂回すべき extent」として一括で最遠端 + DETOUR_MARGIN を取る
+- `opts` 省略時は既存ロジック (binary blocker 判定) そのまま → 既存テスト無変化
+- source-detour と both-detour.sourceDetourX に適用
+- target-detour / both-detour.tgtDetourX への対称対応は issue #375 でフォローアップ
+
+詳細設計: `docs/superpowers/specs/2026-05-23-arrow-routing-pickDetourX-middle-hits-design.md`
+
+## Test plan
+
+- [x] 新規ユニットテスト 4 ケース (detectDiagonalDetour)
+- [x] 新規統合テスト 1 ケース (buildArrowPath, issue #374 再現パターン)
+- [x] 既存テスト全部 PASS (後方互換)
+- [x] `/dev/render?fixture=grupura-phone` で目視確認: 中央 H が row 16 を跨がない
+- [x] lint + typecheck エラーなし
+- [x] LCP ≤ 1s
+
+Closes #374
+Related: #375
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL が表示される。
+
+- [ ] **Step 9.3: CI 完了待機**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: 全 check pass。fail があれば修正 → push → 再 watch を繰り返す。
+
+- [ ] **Step 9.4: レビュー依頼コメント**
+
+```bash
+gh pr comment --body '@claude PRをレビューして。
+以下の観点で確認すること：
+- バグ・ロジックの問題
+- コードの重複・共通化できる処理
+- 不要な複雑さ
+結果は最終行に [A:要修正] [B:条件つき承認] [C:承認OK] のいずれかで明記。'
+```
+
+Expected: コメント投稿成功。
+
+---
+
+## Task 10: 本番ビルド確認
+
+**Files:** （変更なし）
+
+- [ ] **Step 10.1: ~/.claude/skills/preview/SKILL.md を参照して本番ビルド確認**
+
+```bash
+cat ~/.claude/skills/preview/SKILL.md
+```
+
+その手順に従って本番ビルドをローカルで起動し、`/dev/render?fixture=grupura-phone` で再度目視確認。
+
+Expected: 本番ビルドでも同じ結果。
+
+---
+
+## Task 11: レビュー修正ループ (最大 10 回)
+
+**Files:** （レビュー指摘に応じて変更）
+
+- [ ] **Step 11.1: 1 分待機**
+
+```bash
+sleep 60
+```
+
+- [ ] **Step 11.2: レビュー結果取得**
+
+```bash
+gh pr view --json comments
+```
+
+`claude[bot]` の最新コメントを確認。jq パースエラー時は `--jq` を使わず生の JSON を読む。
+
+判定方法:
+- 再レビュー後の判定は、**再レビュー依頼コメントの `created_at` より後** の `claude[bot]` コメントだけを対象。古いレビュー判定文字列で誤って終了しないこと。
+- 自分自身のコメントで判定しない。
+
+- [ ] **Step 11.3: 判定に応じて分岐**
+
+- **[A:要修正] / [B:条件つき承認]**:
+  - 指摘内容を修正
+  - `git push`
+  - `gh pr checks --watch`
+  - 再レビュー依頼コメント (Step 9.4 と同じテンプレート)
+  - Step 11.1 に戻る (ループ加算)
+- **[C:承認OK]**: Task 12 へ進む
+- **10 回超過**: Task 12 進まず、人間へ報告
+
+---
+
+## Task 12: Merge + Deploy 確認
+
+**Files:** （変更なし）
+
+- [ ] **Step 12.1: Merge**
+
+```bash
+gh pr merge --merge
+```
+
+Expected: merge 成功。
+
+- [ ] **Step 12.2: main 最新化**
+
+```bash
+sleep 30
+MAIN=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
+git -C "$MAIN" fetch origin main
+git -C "$MAIN" merge --ff-only origin/main
+```
+
+Expected: main が PR commit を含む状態に。
+
+- [ ] **Step 12.3: deploy 確認**
+
+`~/.claude/skills/deploy/SKILL.md` の手順に従って deploy を確認。
+
+Expected: 本番デプロイ成功。状態不明なら人間へ報告。
+
+---
+
+## Task 13: Worktree Cleanup
+
+**Files:** （ファイル削除）
+
+- [ ] **Step 13.1: worktree 削除**
+
+```bash
+cd "$MAIN"
+git worktree remove .worktrees/fix-arrow-routing-pickDetourX-middle-hits
+git branch -d fix/arrow-routing-pickDetourX-middle-hits
+git worktree list
+```
+
+Expected: worktree 削除成功、残骸なし。
+
+- [ ] **Step 13.2: 「作業開始」ラベル外し**
+
+```bash
+gh issue edit 374 --remove-label "作業開始"
+```
+
+Expected: ラベル削除成功 (issue は close 済みのはずだがラベルだけクリーンアップ)。
+
+---
+
+## Summary
+
+- 新規テスト 5 (ユニット 4 + 統合 1)、既存テスト 7 全部 PASS (後方互換)
+- 実装変更箇所: `src/lib/arrow-routing.ts` の `pickDetourX` 本体 + 呼び出し側 2 箇所 + コメント 1 箇所
+- スコープ外 (follow-up #375): target-detour / both-detour.tgtDetourX / middle-only 分岐の対称対応
+- 関連: PR #372 (段階3・4 ジャンパー), PR #373 (薄いエッジセグメント除外)

--- a/docs/superpowers/specs/2026-05-23-arrow-routing-pickDetourX-middle-hits-design.md
+++ b/docs/superpowers/specs/2026-05-23-arrow-routing-pickDetourX-middle-hits-design.md
@@ -130,7 +130,7 @@ const sourceDetourX = pickDetourX(sourceColHits, srcBlockers, [s.y, my], obstacl
 1. **`should pick detourX past middle-row hit when source-col blocker exists on opposite side`**
    issue #374 の症状: sourceColHits は target 方向 (右) と反対 (左) に blocker を持つが、middle-row 障害が右にある。期待: `detourX = middleRowHits 最遠端 + DETOUR_MARGIN`、左迂回を選ばない。
 
-2. **`should pick detourX past middle-row hit even when source-col blocker is closer`** *(ユーザー追記要望)*
+2. **`should pick detourX past middle-row hit even when source-col blocker is closer`** _(ユーザー追記要望)_
    sourceColHits の最遠端 < middleRowHits の最遠端 のケース。「sourceColHits だけ見ていた旧ロジックでは middleRowHits を見落とす」リグレッション防止。期待: `detourX = max(sourceColHits 最遠端, middleRowHits 最遠端) + DETOUR_MARGIN`。
 
 3. **`should still respect leftBlocked/rightBlocked when opts is not given`**

--- a/docs/superpowers/specs/2026-05-23-arrow-routing-pickDetourX-middle-hits-design.md
+++ b/docs/superpowers/specs/2026-05-23-arrow-routing-pickDetourX-middle-hits-design.md
@@ -46,9 +46,10 @@ target 方向 (target が source の右なら +1) が明示された時のみ、
 ### 例 (本ケース)
 
 - sourceColHits: `[9 (x=597.5, w=152)]` → right edge = 673.5
-- middleRowHits: `[9, 8]` のうち中央 H が通過する 8 → right edge = 902.5
+- middleRowHits: `[8 (x=826.5, w=152)]` (9 は `sourceColSet` 経由で除外) → right edge = 902.5
+- extent = sourceColHits ∪ middleRowHits = `[9, 8]`
 - targetDirection: +1 (target.x=1055.5 > source.x=597.5)
-- 新ロジック: `detourX = max(673.5, 902.5) + 14 = 916.5`
+- 新ロジック: `detourX = max(extent.right edges) + 14 = max(673.5, 902.5) + 14 = 916.5`
 - 中央 H: `(916.5, 1456) → (1055.5, 1456)` ← row 16 を横切らない
 
 ## 変更内容

--- a/docs/superpowers/specs/2026-05-23-arrow-routing-pickDetourX-middle-hits-design.md
+++ b/docs/superpowers/specs/2026-05-23-arrow-routing-pickDetourX-middle-hits-design.md
@@ -1,0 +1,165 @@
+# Design: pickDetourX に middle-row 障害認識を追加 (issue #374)
+
+## 背景
+
+### 症状
+
+密集レイアウトで斜め配置の矢印 (`source-detour` kind) が、source 列 blocker の片側だけを見て反対方向へ迂回し、結果として中央水平セグメントが他ノードを貫通する。
+
+**再現例** (`fixture: grupura-phone.json`)
+
+- 矢印: `ステータス変更 (597.5, 1400, 店舗 row 15)` → `請求 グルプラ(2) (1055.5, 1512, グルプラ(2) row 17)`
+- 現状の SVG: `M597.5,1400 L597.5,1414 L507.5,1414 L507.5,1456 L1055.5,1456 L1055.5,1512`
+- target は右下方向にあるのに `detourX = 507.5` (左迂回) を選び、中央 H `y=1456` が `x=507.5 → 1055.5` で row 16 の 2 ノード (`x=[521.5, 673.5]`, `x=[750.5, 902.5]`) を貫通
+
+### 根本原因
+
+`pickDetourX` (src/lib/arrow-routing.ts L209-L231) は「迂回 V が物理的に通れる位置」しか考慮していない:
+
+- 片側 blocker (rightBlocked) → 反対方向 (左) を選ぶ
+- 中央水平セグメントが通る経路上の障害 (`middleRowHits`) を方向決定に組み込まない
+
+下流の `computeShiftedMy` は middleRowHits を回避するために my を上下シフトしようとするが、row 高さ制約 (`bboxHMax` を用いた range-check) で多くのケースで失敗し、my=row 中央のまま中央 H が貫通する。
+
+### 検討した他案 (C / C') が幾何的に不十分な理由
+
+issue 内推奨の C (source-detour → target-detour 切り替え) は本ケースで効かない:
+
+- target-detour の中央 H は `y=my` で `s.x → detourX` を辿る
+- my=1456 (row 16 中央) のままなら、detourX を target.x の右に取っても `s.x → detourX` の H 区間は依然として row 16 を横断
+- kind 切り替えだけでは my の位置が変わらない以上、貫通は解消しない
+- C' (kind 切り替え + range-check 緩和) は影響範囲が大きく、本 issue とは別の構造的課題
+
+## 設計方針: A' (採用案)
+
+`pickDetourX` に **「detourX 以降の中央水平 H が通過すべきでない障害」** を渡す API を追加し、source-col blockers と middle-row blockers を **同等の「迂回すべき extent」** として一括で最遠端を取る。
+
+target 方向 (target が source の右なら +1) が明示された時のみ、binary blocker 判定をスキップして新ロジックを使う。
+
+### 利点
+
+- source-detour pattern を維持したまま、detourX 計算だけの変更で本ケースを解消
+- `computeShiftedMy` / `detectDiagonalDetour` の kind 選択ロジックには手を入れない
+- 既存呼び出しは `opts` 省略で完全な後方互換 → 既存テスト 7 ケースは無変更で pass
+- target-detour / both-detour への対称対応 (issue #375) も同じ `opts` API を渡すだけで実現可能
+
+### 例 (本ケース)
+
+- sourceColHits: `[9 (x=597.5, w=152)]` → right edge = 673.5
+- middleRowHits: `[9, 8]` のうち中央 H が通過する 8 → right edge = 902.5
+- targetDirection: +1 (target.x=1055.5 > source.x=597.5)
+- 新ロジック: `detourX = max(673.5, 902.5) + 14 = 916.5`
+- 中央 H: `(916.5, 1456) → (1055.5, 1456)` ← row 16 を横切らない
+
+## 変更内容
+
+### 1. `pickDetourX` シグネチャ拡張
+
+```ts
+function pickDetourX(
+  hits: Bbox[],
+  blockers: Bbox[],
+  crossRange: [number, number],
+  obstacles: Bbox[],
+  opts?: {
+    /** target が source の右なら +1、左なら -1。指定時は rightBlocked/leftBlocked による方向判定をスキップ */
+    targetDirection: 1 | -1
+    /** 結果として生成される中央水平 H が同じ y で通過すべきでない障害物 */
+    middleHitsToClear: Bbox[]
+  },
+): number
+```
+
+`opts` 自体は optional だが、渡す場合は両フィールド必須。片方だけ渡すバグを TypeScript の構造的型付けで防ぐ。
+
+### 2. 新ロジック (opts 指定時)
+
+```
+direction = opts.targetDirection
+extent = hits ∪ opts.middleHitsToClear
+if direction === +1:
+  initialDetourX = max(extent.map(o => o.x + o.w/2)) + DETOUR_MARGIN
+else:
+  initialDetourX = min(extent.map(o => o.x - o.w/2)) - DETOUR_MARGIN
+return escalateDetourTrack(initialDetourX, crossRange, 'v', obstacles, direction)
+```
+
+opts 未指定時は既存ロジック (rightBlocked/leftBlocked による binary 判定) をそのまま使う。
+
+### 3. 呼び出し側の変更
+
+**source-detour 分岐 (L386 付近)** — opts を渡す:
+
+```ts
+const detourX = pickDetourX(sourceColHits, obstacles, [s.y, my], obstacles, {
+  targetDirection: e.x > s.x ? 1 : -1,
+  middleHitsToClear: middleRowHits,
+})
+```
+
+**both-detour の sourceDetourX (L370)** — 同様に opts を渡す:
+
+```ts
+const sourceDetourX = pickDetourX(sourceColHits, srcBlockers, [s.y, my], obstacles, {
+  targetDirection: e.x > s.x ? 1 : -1,
+  middleHitsToClear: middleRowHits,
+})
+```
+
+**target-detour (L379) / both-detour の targetDetourX (L371) / middle-only (L425)** — 本 PR スコープ外。既存ロジック維持。コードコメントで follow-up issue #375 を参照:
+
+```ts
+// 注: target-detour の detourX 計算は対称的に middleHitsToClear を渡せる API を持つが、
+// 本 PR (issue #374) では source-detour のみに適用してリグレッションリスクを抑える。
+// target-detour / both-detour.tgtDetourX への対称対応は issue #375 でフォローアップ予定。
+```
+
+### 4. range-check 関連は触らない
+
+`computeShiftedMy` の `bboxHMax` を用いた range-check は変更しない。A' は **shift-my を介さずに source-detour の detourX 段階で問題を解く** ため、computeShiftedMy の振る舞いを変える必要がない。
+
+`escalateDetourTrack` の `i > 0` ガード (薄いセグメント / ノード衝突判定) も本 PR では touch しない (別 issue として将来検討)。
+
+## テスト計画
+
+### 新規ユニットテスト (`src/lib/arrow-routing.test.ts`)
+
+`describe('pickDetourX with opts')` ブロックを追加:
+
+1. **`should pick detourX past middle-row hit when source-col blocker exists on opposite side`**
+   issue #374 の症状: sourceColHits は target 方向 (右) と反対 (左) に blocker を持つが、middle-row 障害が右にある。期待: `detourX = middleRowHits 最遠端 + DETOUR_MARGIN`、左迂回を選ばない。
+
+2. **`should pick detourX past middle-row hit even when source-col blocker is closer`** *(ユーザー追記要望)*
+   sourceColHits の最遠端 < middleRowHits の最遠端 のケース。「sourceColHits だけ見ていた旧ロジックでは middleRowHits を見落とす」リグレッション防止。期待: `detourX = max(sourceColHits 最遠端, middleRowHits 最遠端) + DETOUR_MARGIN`。
+
+3. **`should still respect leftBlocked/rightBlocked when opts is not given`**
+   opts 未指定時は既存 binary blocker ロジックそのまま (後方互換)。
+
+4. **`should mirror correctly for right-to-left diagonal with middle-row hit`**
+   target が source の左にあるケース。`targetDirection: -1`、`min(...) - DETOUR_MARGIN` を取る対称検証。
+
+### 統合テスト
+
+`buildArrowPath - 斜め迂回（異行×異レーン）` ブロックに以下を追加:
+
+5. **`should not cross row obstacles when source has single-side blocker and target is on blocked side`**
+   再現フロー (grupura-phone) に近い構成で `buildArrowPath` の出力 SVG path をスナップショット検証。
+
+### 既存テストの非回帰
+
+- `src/lib/arrow-routing.test.ts` の既存 source-detour / target-detour / both-detour / shift-my テストはすべて変化なしで pass する想定 (opts 省略呼び出しなので)
+
+### `/dev/render?fixture=grupura-phone` での目視検証
+
+CLAUDE.md Workflow Step 6 で Playwright スクリーンショット確認。本症状の矢印が row 16 を貫通せず source-detour で正しく右迂回することを目視確認。
+
+## スコープ外 (follow-up)
+
+- **issue #375**: target-detour / both-detour の `tgtDetourX` への同等対応
+- `escalateDetourTrack` の `i > 0` ガード強化 (別 issue として将来)
+
+## 関連
+
+- 親 issue: #374
+- フォローアップ issue: #375
+- 関連 PR: #372 (段階3・段階4 ジャンパー), #373 (薄いエッジセグメント除外)

--- a/src/dev/fixtures/grupura-phone.json
+++ b/src/dev/fixtures/grupura-phone.json
@@ -1,0 +1,397 @@
+{
+  "id": "grupura-phone",
+  "title": "グルプラ-電話",
+  "themeId": "cloud",
+  "shareToken": null,
+  "projectId": null,
+  "createdAt": "2026-05-23T00:00:00Z",
+  "updatedAt": "2026-05-23T00:00:00Z",
+  "lanes": [
+    {
+      "id": "002c120c-482c-4e65-8cea-27a31a01d97f",
+      "name": "ユーザー",
+      "colorIndex": 0,
+      "position": 0,
+      "groupId": "c25abf8f-a5fe-45a9-b85c-9493753d50aa",
+      "groupRole": "parent"
+    },
+    {
+      "id": "538482df-14dc-47f0-8680-7739b01f1a8f",
+      "name": "ユーザー (2)",
+      "colorIndex": 0,
+      "position": 1,
+      "groupId": "c25abf8f-a5fe-45a9-b85c-9493753d50aa",
+      "groupRole": "sub"
+    },
+    {
+      "id": "9f83083b-80a4-4052-9219-81f363976661",
+      "name": "店舗",
+      "colorIndex": 1,
+      "position": 2,
+      "groupId": null,
+      "groupRole": null
+    },
+    {
+      "id": "f258fe85-5d7b-4271-a12f-66062c8e4576",
+      "name": "グルプラ",
+      "colorIndex": 2,
+      "position": 3,
+      "groupId": "e08b4827-97f4-4f49-91e5-14de186c89a8",
+      "groupRole": "parent"
+    },
+    {
+      "id": "c6e3aae5-337c-4e1f-a39d-e4a82665c839",
+      "name": "グルプラ (2)",
+      "colorIndex": 2,
+      "position": 4,
+      "groupId": "e08b4827-97f4-4f49-91e5-14de186c89a8",
+      "groupRole": "sub"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "04cd1781-50ac-4f52-b532-d12043134188",
+      "laneId": "002c120c-482c-4e65-8cea-27a31a01d97f",
+      "rowIndex": 1,
+      "label": "一覧ページ",
+      "note": null,
+      "orderIndex": 0
+    },
+    {
+      "id": "662c3f36-c0b5-4201-8895-55d705a900c0",
+      "laneId": "002c120c-482c-4e65-8cea-27a31a01d97f",
+      "rowIndex": 0,
+      "label": "本体サイト\n流入",
+      "note": null,
+      "orderIndex": 1
+    },
+    {
+      "id": "5c527b64-2fe8-4f05-97ba-34d747a2a49f",
+      "laneId": "002c120c-482c-4e65-8cea-27a31a01d97f",
+      "rowIndex": 2,
+      "label": "店舗詳細",
+      "note": null,
+      "orderIndex": 2
+    },
+    {
+      "id": "8722bbba-546c-4c93-8865-74004861372b",
+      "laneId": "002c120c-482c-4e65-8cea-27a31a01d97f",
+      "rowIndex": 3,
+      "label": "電話予約",
+      "note": null,
+      "orderIndex": 3
+    },
+    {
+      "id": "79e7f3e8-fcba-44c2-b671-415b46e94113",
+      "laneId": "002c120c-482c-4e65-8cea-27a31a01d97f",
+      "rowIndex": 14,
+      "label": "宴会実施",
+      "note": null,
+      "orderIndex": 4
+    },
+    {
+      "id": "3bcefd63-5083-4b88-815b-64219dedc31f",
+      "laneId": "9f83083b-80a4-4052-9219-81f363976661",
+      "rowIndex": 14,
+      "label": "宴会実施",
+      "note": null,
+      "orderIndex": 5
+    },
+    {
+      "id": "3cbf6528-3a32-491b-a52f-184740ad1011",
+      "laneId": "9f83083b-80a4-4052-9219-81f363976661",
+      "rowIndex": 15,
+      "label": "ステータス変更",
+      "note": null,
+      "orderIndex": 6
+    },
+    {
+      "id": "28edc092-65aa-4bb3-acb2-4ddde2802c3b",
+      "laneId": "f258fe85-5d7b-4271-a12f-66062c8e4576",
+      "rowIndex": 16,
+      "label": "確認連絡",
+      "note": null,
+      "orderIndex": 7
+    },
+    {
+      "id": "3ec80ce7-1b8b-4343-b412-bf55fc5b235b",
+      "laneId": "9f83083b-80a4-4052-9219-81f363976661",
+      "rowIndex": 16,
+      "label": "確認連絡",
+      "note": null,
+      "orderIndex": 8
+    },
+    {
+      "id": "4300b260-7260-4b5b-83f7-8ddcdf0030a5",
+      "laneId": "c6e3aae5-337c-4e1f-a39d-e4a82665c839",
+      "rowIndex": 17,
+      "label": "請求",
+      "note": null,
+      "orderIndex": 9
+    },
+    {
+      "id": "1f97a3b9-fea7-4efb-bcc2-45290e46d8b7",
+      "laneId": "9f83083b-80a4-4052-9219-81f363976661",
+      "rowIndex": 17,
+      "label": "請求",
+      "note": null,
+      "orderIndex": 10
+    },
+    {
+      "id": "bc0028f1-57d9-465f-87c3-bcad6f603cb3",
+      "laneId": "538482df-14dc-47f0-8680-7739b01f1a8f",
+      "rowIndex": 0,
+      "label": "ガイド\n流入",
+      "note": null,
+      "orderIndex": 11
+    },
+    {
+      "id": "42432d1d-1c76-4016-b8d9-e2fc81f6d5b3",
+      "laneId": "f258fe85-5d7b-4271-a12f-66062c8e4576",
+      "rowIndex": 5,
+      "label": "ガイダンス\n（名前）",
+      "note": null,
+      "orderIndex": 12
+    },
+    {
+      "id": "f58efc6d-d1a4-4f16-ae64-527e31b01533",
+      "laneId": "002c120c-482c-4e65-8cea-27a31a01d97f",
+      "rowIndex": 5,
+      "label": "ガイダンス\n（名前/日付・人数）",
+      "note": null,
+      "orderIndex": 13
+    },
+    {
+      "id": "39047c2d-5ba3-439a-91a2-4bdf713ca713",
+      "laneId": "002c120c-482c-4e65-8cea-27a31a01d97f",
+      "rowIndex": 4,
+      "label": "コール",
+      "note": null,
+      "orderIndex": 14
+    },
+    {
+      "id": "a7e070aa-b520-4047-8fbf-1bfa956e82b2",
+      "laneId": "f258fe85-5d7b-4271-a12f-66062c8e4576",
+      "rowIndex": 4,
+      "label": "コール",
+      "note": null,
+      "orderIndex": 15
+    },
+    {
+      "id": "c9e3425a-4cf0-4d74-8bc6-2c19b9a824de",
+      "laneId": "f258fe85-5d7b-4271-a12f-66062c8e4576",
+      "rowIndex": 6,
+      "label": "ガイダンス\n（日付・人数）",
+      "note": null,
+      "orderIndex": 16
+    },
+    {
+      "id": "5b844c8c-668c-4904-8610-a5fd11f96d7b",
+      "laneId": "002c120c-482c-4e65-8cea-27a31a01d97f",
+      "rowIndex": 6,
+      "label": "ガイダンス\n（日付・人数）",
+      "note": null,
+      "orderIndex": 17
+    },
+    {
+      "id": "7a72ee73-5e3b-4bdc-b105-abbc8681817c",
+      "laneId": "9f83083b-80a4-4052-9219-81f363976661",
+      "rowIndex": 7,
+      "label": "店舗へ接続",
+      "note": null,
+      "orderIndex": 18
+    },
+    {
+      "id": "d729d944-5422-4976-ae6c-f3d71729e883",
+      "laneId": "002c120c-482c-4e65-8cea-27a31a01d97f",
+      "rowIndex": 10,
+      "label": "問い合わせ・予約",
+      "note": null,
+      "orderIndex": 19
+    },
+    {
+      "id": "a570ebe3-de51-4f17-986f-249b37e41ec7",
+      "laneId": "9f83083b-80a4-4052-9219-81f363976661",
+      "rowIndex": 10,
+      "label": "問い合わせ・予約",
+      "note": null,
+      "orderIndex": 20
+    },
+    {
+      "id": "7ffb8479-9dae-4213-8b11-147d15d98fc9",
+      "laneId": "9f83083b-80a4-4052-9219-81f363976661",
+      "rowIndex": 8,
+      "label": "接続可否",
+      "note": null,
+      "orderIndex": 21
+    },
+    {
+      "id": "2d9a56a6-4d35-4508-9a52-7a6009312d55",
+      "laneId": "f258fe85-5d7b-4271-a12f-66062c8e4576",
+      "rowIndex": 11,
+      "label": "折り返し電話",
+      "note": null,
+      "orderIndex": 22
+    },
+    {
+      "id": "9237388d-fbff-45a2-bd1e-f78a3b07e954",
+      "laneId": "002c120c-482c-4e65-8cea-27a31a01d97f",
+      "rowIndex": 11,
+      "label": "折り返し電話",
+      "note": null,
+      "orderIndex": 23
+    }
+  ],
+  "arrows": [
+    {
+      "id": "d82be009-f374-4153-a6a5-6aeec56844ab",
+      "fromNodeId": "662c3f36-c0b5-4201-8895-55d705a900c0",
+      "toNodeId": "04cd1781-50ac-4f52-b532-d12043134188",
+      "comment": null
+    },
+    {
+      "id": "ccebd51f-c9eb-41e6-a75c-db8129a77f6d",
+      "fromNodeId": "04cd1781-50ac-4f52-b532-d12043134188",
+      "toNodeId": "5c527b64-2fe8-4f05-97ba-34d747a2a49f",
+      "comment": null
+    },
+    {
+      "id": "f78d5b8d-c7bd-4fea-a7a3-57ab5d6bff3c",
+      "fromNodeId": "79e7f3e8-fcba-44c2-b671-415b46e94113",
+      "toNodeId": "3bcefd63-5083-4b88-815b-64219dedc31f",
+      "comment": null
+    },
+    {
+      "id": "8d099615-d665-4dff-b99d-d827034c15d5",
+      "fromNodeId": "28edc092-65aa-4bb3-acb2-4ddde2802c3b",
+      "toNodeId": "4300b260-7260-4b5b-83f7-8ddcdf0030a5",
+      "comment": null
+    },
+    {
+      "id": "18bc205f-a74d-44f9-bc71-b7e5bf001885",
+      "fromNodeId": "4300b260-7260-4b5b-83f7-8ddcdf0030a5",
+      "toNodeId": "1f97a3b9-fea7-4efb-bcc2-45290e46d8b7",
+      "comment": null
+    },
+    {
+      "id": "03ede925-4ba5-4b60-8c0b-f37059e8652f",
+      "fromNodeId": "5c527b64-2fe8-4f05-97ba-34d747a2a49f",
+      "toNodeId": "8722bbba-546c-4c93-8865-74004861372b",
+      "comment": null
+    },
+    {
+      "id": "5aec0a21-4d0b-4770-af59-d3bcb49f6426",
+      "fromNodeId": "3bcefd63-5083-4b88-815b-64219dedc31f",
+      "toNodeId": "3cbf6528-3a32-491b-a52f-184740ad1011",
+      "comment": null
+    },
+    {
+      "id": "3015bb20-6877-424b-af9c-7253e93b4192",
+      "fromNodeId": "28edc092-65aa-4bb3-acb2-4ddde2802c3b",
+      "toNodeId": "3ec80ce7-1b8b-4343-b412-bf55fc5b235b",
+      "comment": null
+    },
+    {
+      "id": "b2cac713-a0f6-44eb-bf35-5b1f27c00538",
+      "fromNodeId": "3cbf6528-3a32-491b-a52f-184740ad1011",
+      "toNodeId": "28edc092-65aa-4bb3-acb2-4ddde2802c3b",
+      "comment": null
+    },
+    {
+      "id": "fcda877d-4003-48ef-80ce-d879fda769d1",
+      "fromNodeId": "3cbf6528-3a32-491b-a52f-184740ad1011",
+      "toNodeId": "28edc092-65aa-4bb3-acb2-4ddde2802c3b",
+      "comment": null
+    },
+    {
+      "id": "87a7bd6a-1da9-4bb9-aaf8-22380dcb5ac0",
+      "fromNodeId": "bc0028f1-57d9-465f-87c3-bcad6f603cb3",
+      "toNodeId": "5c527b64-2fe8-4f05-97ba-34d747a2a49f",
+      "comment": null
+    },
+    {
+      "id": "5e634294-8d72-4a82-bd24-591af9878944",
+      "fromNodeId": "3cbf6528-3a32-491b-a52f-184740ad1011",
+      "toNodeId": "4300b260-7260-4b5b-83f7-8ddcdf0030a5",
+      "comment": null
+    },
+    {
+      "id": "687ad799-5012-43a2-936a-207917313d81",
+      "fromNodeId": "42432d1d-1c76-4016-b8d9-e2fc81f6d5b3",
+      "toNodeId": "f58efc6d-d1a4-4f16-ae64-527e31b01533",
+      "comment": null
+    },
+    {
+      "id": "ee2bc6c5-1ab2-4f93-8183-f91222755c6a",
+      "fromNodeId": "8722bbba-546c-4c93-8865-74004861372b",
+      "toNodeId": "39047c2d-5ba3-439a-91a2-4bdf713ca713",
+      "comment": null
+    },
+    {
+      "id": "3d5723d2-d575-4a26-8aec-7cc7bc5dd379",
+      "fromNodeId": "39047c2d-5ba3-439a-91a2-4bdf713ca713",
+      "toNodeId": "a7e070aa-b520-4047-8fbf-1bfa956e82b2",
+      "comment": null
+    },
+    {
+      "id": "2dcfb249-a330-47e3-8db5-c79fe07741f6",
+      "fromNodeId": "a7e070aa-b520-4047-8fbf-1bfa956e82b2",
+      "toNodeId": "42432d1d-1c76-4016-b8d9-e2fc81f6d5b3",
+      "comment": null
+    },
+    {
+      "id": "0e42eca8-9668-41c7-b949-fc79c659898d",
+      "fromNodeId": "42432d1d-1c76-4016-b8d9-e2fc81f6d5b3",
+      "toNodeId": "c9e3425a-4cf0-4d74-8bc6-2c19b9a824de",
+      "comment": null
+    },
+    {
+      "id": "a5df137c-b2b1-41c6-8443-3010440e98ce",
+      "fromNodeId": "c9e3425a-4cf0-4d74-8bc6-2c19b9a824de",
+      "toNodeId": "5b844c8c-668c-4904-8610-a5fd11f96d7b",
+      "comment": null
+    },
+    {
+      "id": "14afdfec-3359-4671-9e68-96f9251a6974",
+      "fromNodeId": "c9e3425a-4cf0-4d74-8bc6-2c19b9a824de",
+      "toNodeId": "7a72ee73-5e3b-4bdc-b105-abbc8681817c",
+      "comment": null
+    },
+    {
+      "id": "2c18fe61-3b8c-498e-9693-5e9c4dfd3aff",
+      "fromNodeId": "d729d944-5422-4976-ae6c-f3d71729e883",
+      "toNodeId": "a570ebe3-de51-4f17-986f-249b37e41ec7",
+      "comment": null
+    },
+    {
+      "id": "a06d8cbc-4103-44e0-881b-97687216110e",
+      "fromNodeId": "7a72ee73-5e3b-4bdc-b105-abbc8681817c",
+      "toNodeId": "7ffb8479-9dae-4213-8b11-147d15d98fc9",
+      "comment": null
+    },
+    {
+      "id": "677e8a96-4711-4426-809f-78219492daee",
+      "fromNodeId": "7ffb8479-9dae-4213-8b11-147d15d98fc9",
+      "toNodeId": "a570ebe3-de51-4f17-986f-249b37e41ec7",
+      "comment": "接続"
+    },
+    {
+      "id": "e2c7d47b-558e-4ca3-8b1a-930f6bdb88a0",
+      "fromNodeId": "7ffb8479-9dae-4213-8b11-147d15d98fc9",
+      "toNodeId": "2d9a56a6-4d35-4508-9a52-7a6009312d55",
+      "comment": "繋がらず"
+    },
+    {
+      "id": "9ac832a9-d166-4a0f-a4ff-5178b06ded01",
+      "fromNodeId": "2d9a56a6-4d35-4508-9a52-7a6009312d55",
+      "toNodeId": "9237388d-fbff-45a2-bd1e-f78a3b07e954",
+      "comment": null
+    },
+    {
+      "id": "57aa7072-921f-4400-b781-e39176916a8f",
+      "fromNodeId": "a570ebe3-de51-4f17-986f-249b37e41ec7",
+      "toNodeId": "3bcefd63-5083-4b88-815b-64219dedc31f",
+      "comment": "この間、連絡しないのはOK？"
+    }
+  ]
+}

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -660,6 +660,26 @@ describe('buildArrowPath - 斜め迂回（異行×異レーン）', () => {
     const r = buildArrowPath(sDia, eDia, { x: 200, y: 100 }, { x: 600, y: 400 }, [B])
     expect(r.d).toBe('M200,134 L200,250 L690,250 L690,352 L600,352 L600,366')
   })
+
+  it('should not cross row obstacles when source has single-side blocker and target is on opposite side (issue #374)', () => {
+    // issue #374 再現: source-col blocker と middle-row blocker が同じ行にあり、
+    // 旧ロジックは左迂回して中央 H が両 blocker を貫通していた。
+    // 新ロジックは sourceCol + middleRow の union 最遠端まで detourX を張り出して
+    // 中央 H が他ノードを跨がない source-detour パスを生成する。
+    const sBug = { x: 100, y: 100 }
+    const eBug = { x: 300, y: 300 }
+    const fcBug = { x: 100, y: 50 }
+    const tcBug = { x: 300, y: 350 }
+    const obstacles: Bbox[] = [
+      { x: 100, y: 200, w: 80, h: 40 }, // sourceColHit (row y=200, source col=100)
+      { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit (row y=200, middle col)
+    ]
+    const r = buildArrowPath(sBug, eBug, fcBug, tcBug, obstacles)
+    // 中央水平 H は y=234 (shift-my) で detourX=254 → e.x=300 を辿るので
+    // middleRowHit (x=160-240, y=200, h=40 → y=180-220) には触れない。
+    // departY = clampOffset(100, 234, 14) = 114
+    expect(r.d).toBe('M100,100 L100,114 L254,114 L254,234 L300,234 L300,300')
+  })
 })
 
 describe('collectDiagonalObstacles', () => {
@@ -1010,6 +1030,82 @@ describe('detectDiagonalDetour', () => {
       expect(r.my).toBe(239) // shifted: 200 (障害中心) + 25 (h/2) + 14 (DETOUR_MARGIN)
       expect(r.departY).toBe(114) // clampOffset(100, 239, 14)
       expect(r.approachY).toBe(286) // clampOffset(300, 239, 14)
+    }
+  })
+
+  // --- issue #374: pickDetourX に middle-row 障害認識を追加 ---
+
+  it('should pick detourX past middle-row hit when source-detour selected and middle-row hit is on target side', () => {
+    // issue #374 再現: source-col blocker (片側)、中央 H が他ノードを貫通するケース。
+    // s=(100, 100), e=(300, 300), my=200。target は右にある (e.x > s.x)。
+    // sourceColHits: (100, 200) → 旧来は左迂回 (左に blocker なし、右に middleRow があるため右 blocked と判定)
+    // middleRowHits: (200, 200) → これも detourX の extent に含めるべき
+    // 期待: 新ロジックで detourX = max(140, 240) + 14 = 254 (sourceCol + middleRow の union 最遠端 + DETOUR_MARGIN)
+    const obstacles: Bbox[] = [
+      { x: 100, y: 200, w: 80, h: 40 }, // sourceColHit (source col=100, row y=200)
+      { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit (row y=200, source/target col 以外)
+    ]
+    const r = detectDiagonalDetour({ x: 100, y: 100 }, { x: 300, y: 300 }, obstacles)
+    expect(r?.kind).toBe('source-detour')
+    if (r?.kind === 'source-detour') {
+      // detourX = max(sourceColHit.right=140, middleRowHit.right=240) + 14 = 254
+      expect(r.detourX).toBe(254)
+      // h=40, yLow=100, yHigh=300, bboxHMax=40, lo=121, hi=279 → shift-my OK
+      // shift-my で goDown=true → 200 + 20 + 14 = 234 (range 内)
+      expect(r.my).toBe(234)
+    }
+  })
+
+  it('should pick detourX past middle-row hit even when source-col blocker is closer than middle-row hit', () => {
+    // sourceColHits.right < middleRowHits.right となるケース。
+    // 旧ロジックは sourceColHits だけ見て detourX=140 (sourceCol 右迂回) を選ぶが、
+    // それでは中央 H (140 → 300) が middleRowHit (160-240) を貫通する。
+    // 新ロジックは union extent の最遠端を取って detourX=254 を選ぶ (リグレッション防止)。
+    const obstacles: Bbox[] = [
+      { x: 100, y: 200, w: 80, h: 40 }, // sourceColHit, right=140
+      { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit, right=240
+    ]
+    const r = detectDiagonalDetour({ x: 100, y: 100 }, { x: 300, y: 300 }, obstacles)
+    expect(r?.kind).toBe('source-detour')
+    if (r?.kind === 'source-detour') {
+      expect(r.detourX).toBe(254)
+    }
+  })
+
+  it('should mirror correctly for right-to-left diagonal source-detour with middle-row hit on left', () => {
+    // source.x > target.x: target は左にある (targetDirection=-1)。
+    // s=(300, 100), e=(100, 300), my=200。
+    // sourceColHits: (300, 200) → source col=300
+    // middleRowHits: (200, 200) → middle col
+    // 期待: detourX = min(sourceCol.left=260, middleRow.left=160) - 14 = 146 (左迂回 + middleRow を回避)
+    const obstacles: Bbox[] = [
+      { x: 300, y: 200, w: 80, h: 40 }, // sourceColHit, left=260
+      { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit, left=160
+    ]
+    const r = detectDiagonalDetour({ x: 300, y: 100 }, { x: 100, y: 300 }, obstacles)
+    expect(r?.kind).toBe('source-detour')
+    if (r?.kind === 'source-detour') {
+      // detourX = min(260, 160) - 14 = 146
+      expect(r.detourX).toBe(146)
+    }
+  })
+
+  it('should pick sourceDetourX past middle-row hit in both-detour when middle-row hit exists on target side', () => {
+    // both-detour: source col と target col 両方に障害あり、加えて middle 行にも障害あり。
+    // s=(100, 100), e=(300, 300), my=200。
+    // sourceColHit: (100, 200), targetColHit: (300, 200), middleRowHit: (200, 200)
+    // 期待: sourceDetourX = max(sourceCol.right=140, middleRow.right=240) + 14 = 254
+    //       targetDetourX = 既存ロジック (本 PR 対象外) = 300 + 40 + 14 = 354
+    const obstacles: Bbox[] = [
+      { x: 100, y: 200, w: 80, h: 40 }, // sourceColHit
+      { x: 300, y: 200, w: 80, h: 40 }, // targetColHit
+      { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit
+    ]
+    const r = detectDiagonalDetour({ x: 100, y: 100 }, { x: 300, y: 300 }, obstacles)
+    expect(r?.kind).toBe('both-detour')
+    if (r?.kind === 'both-detour') {
+      expect(r.sourceDetourX).toBe(254) // 新ロジック適用
+      expect(r.targetDetourX).toBe(354) // 旧ロジック維持 (issue #375 で対応)
     }
   })
 

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -1056,22 +1056,6 @@ describe('detectDiagonalDetour', () => {
     }
   })
 
-  it('should pick detourX past middle-row hit even when source-col blocker is closer than middle-row hit', () => {
-    // sourceColHits.right < middleRowHits.right となるケース。
-    // 旧ロジックは sourceColHits だけ見て detourX=140 (sourceCol 右迂回) を選ぶが、
-    // それでは中央 H (140 → 300) が middleRowHit (160-240) を貫通する。
-    // 新ロジックは union extent の最遠端を取って detourX=254 を選ぶ (リグレッション防止)。
-    const obstacles: Bbox[] = [
-      { x: 100, y: 200, w: 80, h: 40 }, // sourceColHit, right=140
-      { x: 200, y: 200, w: 80, h: 40 }, // middleRowHit, right=240
-    ]
-    const r = detectDiagonalDetour({ x: 100, y: 100 }, { x: 300, y: 300 }, obstacles)
-    expect(r?.kind).toBe('source-detour')
-    if (r?.kind === 'source-detour') {
-      expect(r.detourX).toBe(254)
-    }
-  })
-
   it('should mirror correctly for right-to-left diagonal source-detour with middle-row hit on left', () => {
     // source.x > target.x: target は左にある (targetDirection=-1)。
     // s=(300, 100), e=(100, 300), my=200。

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -1074,6 +1074,25 @@ describe('detectDiagonalDetour', () => {
     }
   })
 
+  it('should fall back to blocker-aware logic when middle-row hit is empty (regression guard)', () => {
+    // Codex P1 リグレッション: source-detour で middleRowHits が空 のとき opts を渡すと
+    // pickDetourX が targetDirection 側に detourX を強制し、隣接列の blocker を貫通する。
+    // 期待: middleRowHits 空 → 旧ロジック (binary blocker 判定) に戻り、左迂回を選択。
+    // s=(200,128), e=(600,372): sourceColHit (200,170) + additionalBlocker (350,170, 隣接列)。
+    // additionalBlocker は y=170 → my=250 から |170-250|=80 で middle row 圏外 (h/2+2=30)。
+    const obstacles: Bbox[] = [
+      { x: 200, y: 170, w: 152, h: 56 }, // sourceColHit, right=276
+      { x: 350, y: 170, w: 152, h: 56 }, // 隣接列 blocker, range [274, 426]
+    ]
+    const r = detectDiagonalDetour({ x: 200, y: 128 }, { x: 600, y: 372 }, obstacles)
+    expect(r?.kind).toBe('source-detour')
+    if (r?.kind === 'source-detour') {
+      // 旧ロジック: rightBlocked=true → 左迂回 = 200 - 76 - 14 = 110
+      // 新ロジック (バグ): targetDirection=+1 強制 = 276 + 14 = 290 (additionalBlocker を貫通)
+      expect(r.detourX).toBe(110)
+    }
+  })
+
   it('should pick sourceDetourX past middle-row hit in both-detour when middle-row hit exists on target side', () => {
     // both-detour: source col と target col 両方に障害あり、加えて middle 行にも障害あり。
     // s=(100, 100), e=(300, 300), my=200。

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -226,13 +226,34 @@ type DiagonalDetourResult =
  *
  * blockers は方向判定対象のブロッカー候補。target/source 列同士の相互ブロッキングを防ぐ
  * ため、both-detour では呼び出し側が反対側列の hits を除外した blockers を渡す。
+ *
+ * opts (issue #374):
+ *   指定時は binary blocker 判定をスキップし、targetDirection 方向に hits ∪ middleHitsToClear の
+ *   union 最遠端 + DETOUR_MARGIN を取る新ロジックを使う。これにより source-detour で中央水平
+ *   セグメントが middle-row 障害を貫通するバグを解消する。両フィールド必須。
  */
 function pickDetourX(
   hits: Bbox[],
   blockers: Bbox[],
   crossRange: [number, number],
   obstacles: Bbox[],
+  opts?: {
+    targetDirection: 1 | -1
+    middleHitsToClear: Bbox[]
+  },
 ): number {
+  if (opts) {
+    // 新ロジック (issue #374): hits ∪ middleHitsToClear の最遠端を取る。
+    // sourceColHits だけ見ていた旧ロジックでは middleRowHits を貫通する detourX を選んでしまう。
+    const extent = [...hits, ...opts.middleHitsToClear]
+    const initialDetourX =
+      opts.targetDirection === 1
+        ? Math.max(...extent.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
+        : Math.min(...extent.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
+    return escalateDetourTrack(initialDetourX, crossRange, 'v', obstacles, opts.targetDirection)
+  }
+
+  // 既存ロジック (opts 未指定時): binary blocker 判定による方向決定。
   // 薄い線分 (エッジセグメント由来 Bbox) は方向判定から除外。
   // detectDetour / detectVerticalDetour と同じ理由 (yOverlap 誤判定を防ぐ)。
   const rightBlocked = hits.some((obs) =>

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -389,14 +389,22 @@ export function detectDiagonalDetour(
 
   if (sourceColHits.length > 0 && targetColHits.length > 0) {
     // 相互ブロッキング回避: 反対側列の hits は方向判定から除外。対応する迂回パスで既に回避済み。
+    // srcBlockers / tgtBlockers は opts 未指定時 (= middleRowHits 空) の binary blocker 判定で
+    // 使われる。opts 指定時は pickDetourX 内で参照されないが、両ルートに対応するため両方で
+    // 渡しておく。
+    const targetIds = new Set(targetColHits)
     const sourceIds = new Set(sourceColHits)
+    const srcBlockers = obstacles.filter((b) => !targetIds.has(b))
     const tgtBlockers = obstacles.filter((b) => !sourceIds.has(b))
-    // sourceDetourX: 新ロジック (issue #374)。opts 指定時は pickDetourX 内で blockers が
-    // 参照されないため第 2 引数には obstacles を渡す (dead code 防止)。
-    const sourceDetourX = pickDetourX(sourceColHits, obstacles, [s.y, my], obstacles, {
-      targetDirection,
-      middleHitsToClear: middleRowHits,
-    })
+    // sourceDetourX: middleRowHits が非空 → 新ロジック (issue #374)、空 → 旧ロジック (blocker 回避)。
+    // 旧ロジック fallback は sourceColHit の隣接列 blocker による貫通リグレッションを防ぐため。
+    const sourceDetourX = pickDetourX(
+      sourceColHits,
+      srcBlockers,
+      [s.y, my],
+      obstacles,
+      middleRowHits.length > 0 ? { targetDirection, middleHitsToClear: middleRowHits } : undefined,
+    )
     // targetDetourX: 旧ロジック維持。target-detour 系の対称対応は issue #375 で別途。
     const targetDetourX = pickDetourX(targetColHits, tgtBlockers, [my, e.y], obstacles)
     const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
@@ -416,10 +424,16 @@ export function detectDiagonalDetour(
   }
 
   if (sourceColHits.length > 0 && targetColHits.length === 0) {
-    const detourX = pickDetourX(sourceColHits, obstacles, [s.y, my], obstacles, {
-      targetDirection,
-      middleHitsToClear: middleRowHits,
-    })
+    // middleRowHits が空のときは新ロジック (target 方向強制) を使わず旧ロジックに戻す:
+    // sourceColHit の隣接列に blocker があるケースで V セグメントが blocker を貫通する
+    // リグレッションを防ぐため。
+    const detourX = pickDetourX(
+      sourceColHits,
+      obstacles,
+      [s.y, my],
+      obstacles,
+      middleRowHits.length > 0 ? { targetDirection, middleHitsToClear: middleRowHits } : undefined,
+    )
     const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
     const departY = clampOffset(s.y, shiftedMy, DEPART_GAP)
     return { kind: 'source-detour', departY, detourX, my: shiftedMy }

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -231,6 +231,7 @@ type DiagonalDetourResult =
  *   指定時は binary blocker 判定をスキップし、targetDirection 方向に hits ∪ middleHitsToClear の
  *   union 最遠端 + DETOUR_MARGIN を取る新ロジックを使う。これにより source-detour で中央水平
  *   セグメントが middle-row 障害を貫通するバグを解消する。両フィールド必須。
+ *   opts 指定時 blockers 引数は参照されない (呼び出し側は obstacles など任意の値を渡せる)。
  */
 function pickDetourX(
   hits: Bbox[],
@@ -382,15 +383,18 @@ export function detectDiagonalDetour(
     return Math.abs(b.y - my) < b.h / 2 + 2 && b.x - b.w / 2 < xHigh - 1 && b.x + b.w / 2 > xLow + 1
   })
 
+  // issue #374 の新ロジック pickDetourX(opts) に渡す target 方向。source-detour と
+  // both-detour.sourceDetourX で共通。
+  const targetDirection: 1 | -1 = e.x > s.x ? 1 : -1
+
   if (sourceColHits.length > 0 && targetColHits.length > 0) {
     // 相互ブロッキング回避: 反対側列の hits は方向判定から除外。対応する迂回パスで既に回避済み。
-    const targetIds = new Set(targetColHits)
     const sourceIds = new Set(sourceColHits)
-    const srcBlockers = obstacles.filter((b) => !targetIds.has(b))
     const tgtBlockers = obstacles.filter((b) => !sourceIds.has(b))
-    // sourceDetourX: 新ロジック (issue #374) で middleRowHits も extent に含める。
-    const sourceDetourX = pickDetourX(sourceColHits, srcBlockers, [s.y, my], obstacles, {
-      targetDirection: e.x > s.x ? 1 : -1,
+    // sourceDetourX: 新ロジック (issue #374)。opts 指定時は pickDetourX 内で blockers が
+    // 参照されないため第 2 引数には obstacles を渡す (dead code 防止)。
+    const sourceDetourX = pickDetourX(sourceColHits, obstacles, [s.y, my], obstacles, {
+      targetDirection,
       middleHitsToClear: middleRowHits,
     })
     // targetDetourX: 旧ロジック維持。target-detour 系の対称対応は issue #375 で別途。
@@ -413,7 +417,7 @@ export function detectDiagonalDetour(
 
   if (sourceColHits.length > 0 && targetColHits.length === 0) {
     const detourX = pickDetourX(sourceColHits, obstacles, [s.y, my], obstacles, {
-      targetDirection: e.x > s.x ? 1 : -1,
+      targetDirection,
       middleHitsToClear: middleRowHits,
     })
     const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -388,7 +388,12 @@ export function detectDiagonalDetour(
     const sourceIds = new Set(sourceColHits)
     const srcBlockers = obstacles.filter((b) => !targetIds.has(b))
     const tgtBlockers = obstacles.filter((b) => !sourceIds.has(b))
-    const sourceDetourX = pickDetourX(sourceColHits, srcBlockers, [s.y, my], obstacles)
+    // sourceDetourX: 新ロジック (issue #374) で middleRowHits も extent に含める。
+    const sourceDetourX = pickDetourX(sourceColHits, srcBlockers, [s.y, my], obstacles, {
+      targetDirection: e.x > s.x ? 1 : -1,
+      middleHitsToClear: middleRowHits,
+    })
+    // targetDetourX: 旧ロジック維持。target-detour 系の対称対応は issue #375 で別途。
     const targetDetourX = pickDetourX(targetColHits, tgtBlockers, [my, e.y], obstacles)
     const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
     const departY = clampOffset(s.y, shiftedMy, DEPART_GAP)
@@ -396,6 +401,9 @@ export function detectDiagonalDetour(
     return { kind: 'both-detour', departY, sourceDetourX, my: shiftedMy, targetDetourX, approachY }
   }
 
+  // 注: target-detour の detourX 計算は対称的に opts { targetDirection, middleHitsToClear } を
+  // 渡せる API を持つが、本 PR (issue #374) では source-detour のみに適用してリグレッションリスクを
+  // 抑える。target-detour / both-detour.tgtDetourX の対称対応は issue #375 でフォローアップ予定。
   if (targetColHits.length > 0 && sourceColHits.length === 0) {
     const detourX = pickDetourX(targetColHits, obstacles, [my, e.y], obstacles)
     const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
@@ -404,7 +412,10 @@ export function detectDiagonalDetour(
   }
 
   if (sourceColHits.length > 0 && targetColHits.length === 0) {
-    const detourX = pickDetourX(sourceColHits, obstacles, [s.y, my], obstacles)
+    const detourX = pickDetourX(sourceColHits, obstacles, [s.y, my], obstacles, {
+      targetDirection: e.x > s.x ? 1 : -1,
+      middleHitsToClear: middleRowHits,
+    })
     const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
     const departY = clampOffset(s.y, shiftedMy, DEPART_GAP)
     return { kind: 'source-detour', departY, detourX, my: shiftedMy }


### PR DESCRIPTION
## Summary

issue #374 の修正。密集レイアウトで斜め配置の矢印が source 列 blocker により target と反対方向へ迂回し、中央水平セグメントが他ノードを貫通する問題を解消する。

設計案 A' (`pickDetourX` に `opts { targetDirection, middleHitsToClear }` を追加する後方互換 API) で対応:

- `sourceColHits` と `middleRowHits` の union を「迂回すべき extent」として一括で最遠端 + DETOUR_MARGIN を取る
- `opts` 省略時は既存ロジック (binary blocker 判定) そのまま → 既存テスト 166 無変化
- source-detour と both-detour.sourceDetourX に適用
- target-detour / both-detour.tgtDetourX への対称対応は issue #375 でフォローアップ

### 修正前後の path 比較 (grupura-phone fixture)

```
旧: M600,1400 L600,1414 L510,1414 L510,1456 L1060,1456 L1060,1512 (中央 H が row 16 を貫通)
新: M600,1400 L600,1414 L920,1414 L920,1456 L1060,1456 L1060,1512 (detourX=920 で row 16 を回避)
```

詳細設計: `docs/superpowers/specs/2026-05-23-arrow-routing-pickDetourX-middle-hits-design.md`
実装計画: `docs/superpowers/plans/2026-05-23-arrow-routing-pickDetourX-middle-hits-plan.md`

## Test plan

- [x] 新規ユニットテスト 4 ケース (detectDiagonalDetour)
- [x] 新規統合テスト 1 ケース (buildArrowPath, issue #374 再現パターン)
- [x] 既存テスト 1750 PASS (1 skipped) — 後方互換 OK
- [x] \`/dev/render?fixture=grupura-phone\` で目視確認: 中央 H が row 16 を跨がない (\`detourX=920\`)
- [x] lint + typecheck エラーなし
- [x] LCP = 448ms (≤ 1s 目標達成)

Closes #374
Related: #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)