### PR TITLE
fix(#353): target-detour の中央水平が target 列ノードを貫通する不具合を修正

### DIFF
--- a/src/dev/fixtures/grupura-phone-353.json
+++ b/src/dev/fixtures/grupura-phone-353.json
@@ -1,0 +1,253 @@
+{
+  "id": "fixture-353",
+  "title": "グルプラ-電話 (#353 repro)",
+  "themeId": "cloud",
+  "shareToken": "dev-353",
+  "projectId": null,
+  "createdAt": "2026-06-22T00:00:00.000Z",
+  "updatedAt": "2026-06-22T00:00:00.000Z",
+  "lanes": [
+    {
+      "id": "44167e0e-5fea-4b0c-bb6d-ec91bdd0369f",
+      "name": "ユーザー",
+      "colorIndex": 0,
+      "position": 0
+    },
+    {
+      "id": "e0a8c1d5-4fad-4824-92d8-7deb99d64b70",
+      "name": "電話",
+      "colorIndex": 1,
+      "position": 1,
+      "groupId": "83c1053c-62ed-4398-9a1e-0766274d4547",
+      "groupRole": "parent"
+    },
+    {
+      "id": "23fb388a-02c7-4f77-b270-6a23ca276e17",
+      "name": "電話 (2)",
+      "colorIndex": 1,
+      "position": 2,
+      "groupId": "83c1053c-62ed-4398-9a1e-0766274d4547",
+      "groupRole": "sub"
+    },
+    {
+      "id": "35261338-abef-4fdc-a5bf-0fec761ea861",
+      "name": "lane3",
+      "colorIndex": 2,
+      "position": 3
+    },
+    {
+      "id": "0686b03c-b6c6-4c80-88ea-7da5e0c7fb5f",
+      "name": "lane4",
+      "colorIndex": 3,
+      "position": 4
+    }
+  ],
+  "nodes": [
+    {
+      "id": "396271ca-60eb-4a8b-946f-61b4a6af3528",
+      "laneId": "44167e0e-5fea-4b0c-bb6d-ec91bdd0369f",
+      "rowIndex": 0,
+      "label": "サイト訪問",
+      "note": null,
+      "orderIndex": 0
+    },
+    {
+      "id": "e3a20503-38d9-4914-8fa8-4fb3c335dd23",
+      "laneId": "44167e0e-5fea-4b0c-bb6d-ec91bdd0369f",
+      "rowIndex": 1,
+      "label": "会員",
+      "note": null,
+      "orderIndex": 1,
+      "shape": "diamond"
+    },
+    {
+      "id": "ca69a2ef-e8b4-45db-9644-94dfb4fd036a",
+      "laneId": "44167e0e-5fea-4b0c-bb6d-ec91bdd0369f",
+      "rowIndex": 2,
+      "label": "そ",
+      "note": null,
+      "orderIndex": 2
+    },
+    {
+      "id": "d4b8931e-418c-4b3e-b082-daede216dc26",
+      "laneId": "44167e0e-5fea-4b0c-bb6d-ec91bdd0369f",
+      "rowIndex": 3,
+      "label": "作業",
+      "note": null,
+      "orderIndex": 3
+    },
+    {
+      "id": "f4e947e4-37a0-4abc-816f-d52c323e0b8e",
+      "laneId": "e0a8c1d5-4fad-4824-92d8-7deb99d64b70",
+      "rowIndex": 2,
+      "label": "電話する",
+      "note": null,
+      "orderIndex": 4
+    },
+    {
+      "id": "622766d4-35e4-4780-87e2-b59cacfe5b68",
+      "laneId": "e0a8c1d5-4fad-4824-92d8-7deb99d64b70",
+      "rowIndex": 3,
+      "label": "会員か否か",
+      "note": null,
+      "orderIndex": 5,
+      "shape": "diamond"
+    },
+    {
+      "id": "fba329be-d103-4990-9605-b50a81e2ab12",
+      "laneId": "23fb388a-02c7-4f77-b270-6a23ca276e17",
+      "rowIndex": 4,
+      "label": "会員登録",
+      "note": null,
+      "orderIndex": 6
+    },
+    {
+      "id": "09cc3897-2705-44b3-923c-940aaf66ce94",
+      "laneId": "e0a8c1d5-4fad-4824-92d8-7deb99d64b70",
+      "rowIndex": 5,
+      "label": "電話番号と\n確認番号表示",
+      "note": null,
+      "orderIndex": 7
+    },
+    {
+      "id": "b2165b88-a35e-430f-a131-35063e0487ad",
+      "laneId": "e0a8c1d5-4fad-4824-92d8-7deb99d64b70",
+      "rowIndex": 6,
+      "label": "架電",
+      "note": null,
+      "orderIndex": 8
+    },
+    {
+      "id": "4a62c952-9024-422d-8b0b-85bc51099943",
+      "laneId": "e0a8c1d5-4fad-4824-92d8-7deb99d64b70",
+      "rowIndex": 8,
+      "label": "telタグから",
+      "note": null,
+      "orderIndex": 9
+    },
+    {
+      "id": "97d43681-7e51-4381-9fdd-13e7481b15ed",
+      "laneId": "23fb388a-02c7-4f77-b270-6a23ca276e17",
+      "rowIndex": 8,
+      "label": "別電話から",
+      "note": null,
+      "orderIndex": 10
+    },
+    {
+      "id": "c271f406-6ce2-40e5-b317-858cfe334ea2",
+      "laneId": "23fb388a-02c7-4f77-b270-6a23ca276e17",
+      "rowIndex": 9,
+      "label": "確認番号入力",
+      "note": null,
+      "orderIndex": 11
+    },
+    {
+      "id": "9f1e85bf-14a7-4dd8-ba42-e469f73c467d",
+      "laneId": "23fb388a-02c7-4f77-b270-6a23ca276e17",
+      "rowIndex": 10,
+      "label": "電話がつながる",
+      "note": null,
+      "orderIndex": 12
+    }
+  ],
+  "arrows": [
+    {
+      "id": "0085f156-afd7-48aa-b661-fc8cd04134a5",
+      "fromNodeId": "396271ca-60eb-4a8b-946f-61b4a6af3528",
+      "toNodeId": "e3a20503-38d9-4914-8fa8-4fb3c335dd23",
+      "comment": null
+    },
+    {
+      "id": "e91e1b88-8944-4a9b-a44e-c85a81cdaee1",
+      "fromNodeId": "e3a20503-38d9-4914-8fa8-4fb3c335dd23",
+      "toNodeId": "ca69a2ef-e8b4-45db-9644-94dfb4fd036a",
+      "comment": null
+    },
+    {
+      "id": "9c0f1af3-6315-423e-9011-2571ee217e2b",
+      "fromNodeId": "ca69a2ef-e8b4-45db-9644-94dfb4fd036a",
+      "toNodeId": "d4b8931e-418c-4b3e-b082-daede216dc26",
+      "comment": null
+    },
+    {
+      "id": "0eb951b1-1501-4f7c-82ef-f24ff4b8704a",
+      "fromNodeId": "622766d4-35e4-4780-87e2-b59cacfe5b68",
+      "toNodeId": "09cc3897-2705-44b3-923c-940aaf66ce94",
+      "comment": null,
+      "fromSide": "bottom",
+      "toSide": "top"
+    },
+    {
+      "id": "1378eece-35a4-4413-99cb-5626492a21ef",
+      "fromNodeId": "622766d4-35e4-4780-87e2-b59cacfe5b68",
+      "toNodeId": "fba329be-d103-4990-9605-b50a81e2ab12",
+      "comment": null,
+      "fromSide": "right",
+      "toSide": "top"
+    },
+    {
+      "id": "09c26894-0872-4c75-9497-02bc735e8ee6",
+      "fromNodeId": "fba329be-d103-4990-9605-b50a81e2ab12",
+      "toNodeId": "09cc3897-2705-44b3-923c-940aaf66ce94",
+      "comment": null,
+      "fromSide": "bottom",
+      "toSide": "right"
+    },
+    {
+      "id": "4bd1e786-4fa6-462c-8981-12b5fec83897",
+      "fromNodeId": "f4e947e4-37a0-4abc-816f-d52c323e0b8e",
+      "toNodeId": "622766d4-35e4-4780-87e2-b59cacfe5b68",
+      "comment": null,
+      "fromSide": "bottom",
+      "toSide": "top"
+    },
+    {
+      "id": "3bea0583-41e9-4075-87ae-1af6143e7844",
+      "fromNodeId": "09cc3897-2705-44b3-923c-940aaf66ce94",
+      "toNodeId": "b2165b88-a35e-430f-a131-35063e0487ad",
+      "comment": null,
+      "fromSide": "bottom",
+      "toSide": "top"
+    },
+    {
+      "id": "eb84409f-e9be-4a4f-bc88-c1f33269e4b9",
+      "fromNodeId": "b2165b88-a35e-430f-a131-35063e0487ad",
+      "toNodeId": "4a62c952-9024-422d-8b0b-85bc51099943",
+      "comment": null,
+      "fromSide": "bottom",
+      "toSide": "top"
+    },
+    {
+      "id": "45e5d518-bb79-439b-8a2a-ac519862a33a",
+      "fromNodeId": "b2165b88-a35e-430f-a131-35063e0487ad",
+      "toNodeId": "97d43681-7e51-4381-9fdd-13e7481b15ed",
+      "comment": null,
+      "fromSide": "bottom",
+      "toSide": "top"
+    },
+    {
+      "id": "ba05ccc8-b870-4c81-a843-703452b3d3c2",
+      "fromNodeId": "97d43681-7e51-4381-9fdd-13e7481b15ed",
+      "toNodeId": "c271f406-6ce2-40e5-b317-858cfe334ea2",
+      "comment": null,
+      "fromSide": "bottom",
+      "toSide": "top"
+    },
+    {
+      "id": "1564f784-f290-4739-bb95-32c8f485fced",
+      "fromNodeId": "c271f406-6ce2-40e5-b317-858cfe334ea2",
+      "toNodeId": "9f1e85bf-14a7-4dd8-ba42-e469f73c467d",
+      "comment": null,
+      "fromSide": "bottom",
+      "toSide": "top"
+    },
+    {
+      "id": "64331fe8-686f-44f8-a316-909b886750a9",
+      "fromNodeId": "4a62c952-9024-422d-8b0b-85bc51099943",
+      "toNodeId": "9f1e85bf-14a7-4dd8-ba42-e469f73c467d",
+      "comment": null,
+      "fromSide": "bottom",
+      "toSide": "top"
+    }
+  ]
+}

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -594,8 +594,10 @@ describe('buildArrowPath - 斜め迂回（異行×異レーン）', () => {
   it('should produce 6-segment target-detour path when obstacle in target column (core bug case)', () => {
     const B: Bbox = { x: 600, y: 250, w: 152, h: 56 }
     const r = buildArrowPath(s, e, fc, tc, [B])
-    expect(r.d).toBe('M200,128 L200,250 L690,250 L690,358 L600,358 L600,372')
-    expect(r.mx).toBe((200 + 690) / 2)
+    // #353: detourX は source 側 (510 = 障害左端 524 - DETOUR_MARGIN)。中央水平 [200,510] は
+    // targetColHit の x 範囲 [524,676] に侵入しない。
+    expect(r.d).toBe('M200,128 L200,250 L510,250 L510,358 L600,358 L600,372')
+    expect(r.mx).toBe((200 + 510) / 2)
     expect(r.my).toBe(250)
   })
 
@@ -658,7 +660,8 @@ describe('buildArrowPath - 斜め迂回（異行×異レーン）', () => {
     const eDia = { x: 600, y: 366 } // approx 中心 (600,400) - DS(34) 上
     const B: Bbox = { x: 600, y: 250, w: 152, h: 56 } // target 列障害
     const r = buildArrowPath(sDia, eDia, { x: 200, y: 100 }, { x: 600, y: 400 }, [B])
-    expect(r.d).toBe('M200,134 L200,250 L690,250 L690,352 L600,352 L600,366')
+    // #353: detourX は source 側 (510)。中央水平が targetColHit を貫通しない。
+    expect(r.d).toBe('M200,134 L200,250 L510,250 L510,352 L600,352 L600,366')
   })
 
   it('should not cross row obstacles when source has single-side blocker and target is on opposite side (issue #374)', () => {
@@ -850,21 +853,41 @@ describe('detectDiagonalDetour', () => {
     expect(r).toEqual({
       kind: 'target-detour',
       my: 250,
-      detourX: 600 + 76 + 14, // 690 (右迂回: 障害右端 + DETOUR_MARGIN)
+      // #353: my (=250) が targetColHit (y=250) の Y 範囲内に残るため、detourX を右に置くと
+      // 中央水平 [s.x=200, detourX] が targetColHit を貫通する。→ source 側 (左) へ迂回。
+      detourX: 600 - 76 - 14, // 510 (source 側迂回: 障害左端 - DETOUR_MARGIN)
       approachY: 372 - 14, // 358
     })
   })
 
-  it('should return target-detour with left-side detourX when target column is right-blocked', () => {
-    const B: Bbox = { x: 600, y: 250, w: 152, h: 56 }
-    const R: Bbox = { x: 800, y: 250, w: 152, h: 56 }
-    const r = detectDiagonalDetour(s, e, [B, R])
-    expect(r).toEqual({
-      kind: 'target-detour',
-      my: 250,
-      detourX: 600 - 76 - 14, // 510 (左迂回)
-      approachY: 358,
-    })
+  it('should route detourX to source side so middle horizontal never penetrates target-column node (#353)', () => {
+    // 実フロー再現 (grupura-phone): source=左列, target=右列。target 列に target ノードの
+    // 真上ブロッカー (node12「確認番号入力」相当) があり、中央行には他障害が無い。
+    // my はシフトされず targetColHit の Y 範囲内に残るため detourX は source 側に寄せる。
+    const B: Bbox = { x: 600, y: 250, w: 152, h: 56 } // target col blocker, x-extent [524, 676]
+    const r = detectDiagonalDetour(s, e, [B])
+    expect(r?.kind).toBe('target-detour')
+    if (r?.kind === 'target-detour') {
+      expect(r.detourX).toBe(510) // 524 - 14, source 側
+      // 中央水平 [s.x, detourX] が targetColHit の x 範囲 [524, 676] に侵入しないこと
+      const hMax = Math.max(s.x, r.detourX)
+      expect(hMax).toBeLessThanOrEqual(B.x - B.w / 2) // 510 <= 524
+    }
+  })
+
+  it('should still detour to source side when arrow runs right-to-left (#353 mirror)', () => {
+    // 右→左対角線。source が右、target が左。中央水平 [s.x, detourX] が target 列ノードを
+    // 貫通しないよう detourX は source 側 (右) へ寄せる。
+    const sR = { x: 600, y: 128 }
+    const eR = { x: 200, y: 372 }
+    const B: Bbox = { x: 200, y: 250, w: 152, h: 56 } // target col (左) blocker, x-extent [124, 276]
+    const r = detectDiagonalDetour(sR, eR, [B])
+    expect(r?.kind).toBe('target-detour')
+    if (r?.kind === 'target-detour') {
+      expect(r.detourX).toBe(200 + 76 + 14) // 290 (source 側 = 右), 障害右端 + DETOUR_MARGIN
+      const hMin = Math.min(sR.x, r.detourX)
+      expect(hMin).toBeGreaterThanOrEqual(B.x + B.w / 2) // 290 >= 276
+    }
   })
 
   it('should prefer right detour when both sides of target column are blocked', () => {
@@ -872,12 +895,13 @@ describe('detectDiagonalDetour', () => {
     const R: Bbox = { x: 800, y: 250, w: 152, h: 56 }
     const L: Bbox = { x: 400, y: 250, w: 152, h: 56 }
     const r = detectDiagonalDetour(s, e, [B, R, L])
-    // L は中央行 (y=my=250) 上にあり target-detour の中央水平セグメント [s.x=200, detourX=690]
-    // を貫通するため、my を shiftedMy=292 (#366 修正) にシフトする。direction (right) は detourX で検証。
+    // L は中央行 (y=my=250) 上にあり、my を shiftedMy=292 (#366 修正) にシフトする。
+    // シフト後 my=292 は targetColHit B (y∈[222,278]) の範囲外に抜けるため中央水平は B を
+    // 貫通せず、#353 の source 側強制は発動しない (over-forcing 回避)。よって right 優先のまま。
     expect(r).toEqual({
       kind: 'target-detour',
       my: 292, // 250 + 28 + 14 (障害下端 + DETOUR_MARGIN)
-      detourX: 690, // 右優先
+      detourX: 690, // 右優先 (shift で貫通解消済み)
       approachY: 358, // clampOffset(372, 292, 14) = 372 - 14 = 358 (偶然 unshift と同値)
     })
   })

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -390,8 +390,9 @@ export function detectDiagonalDetour(
   // - targetDirection (target 方向): source-detour / both-detour.sourceDetourX 用 (#374)。
   // - sourceDirection (source 方向): target-detour 用 (#353)。中央水平 [s.x, detourX] が
   //   targetColHit を貫通しないよう detourX を source 側へ寄せる。
+  // 冒頭で |e.x - s.x| < 2 を早期 return 済みのため両者は常に符号反転の関係 (片方更新漏れを防ぐ)。
   const targetDirection: 1 | -1 = e.x > s.x ? 1 : -1
-  const sourceDirection: 1 | -1 = s.x > e.x ? 1 : -1
+  const sourceDirection: 1 | -1 = -targetDirection as 1 | -1
 
   if (sourceColHits.length > 0 && targetColHits.length > 0) {
     // 相互ブロッキング回避: 反対側列の hits は方向判定から除外。対応する迂回パスで既に回避済み。
@@ -431,12 +432,10 @@ export function detectDiagonalDetour(
     const middleHThroughTargetCol = targetColHits.some(
       (b) => Math.abs(b.y - shiftedMy) < b.h / 2 + 2,
     )
-    const detourX = middleHThroughTargetCol
-      ? pickDetourX(targetColHits, obstacles, [my, e.y], obstacles, {
-          detourDirection: sourceDirection,
-          middleHitsToClear: middleRowHits,
-        })
-      : pickDetourX(targetColHits, obstacles, [my, e.y], obstacles)
+    const detourOpts = middleHThroughTargetCol
+      ? { detourDirection: sourceDirection, middleHitsToClear: middleRowHits }
+      : undefined
+    const detourX = pickDetourX(targetColHits, obstacles, [my, e.y], obstacles, detourOpts)
     const approachY = clampOffset(e.y, shiftedMy, APPROACH_GAP)
     return { kind: 'target-detour', my: shiftedMy, detourX, approachY }
   }

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -227,11 +227,14 @@ type DiagonalDetourResult =
  * blockers は方向判定対象のブロッカー候補。target/source 列同士の相互ブロッキングを防ぐ
  * ため、both-detour では呼び出し側が反対側列の hits を除外した blockers を渡す。
  *
- * opts (issue #374):
- *   指定時は binary blocker 判定をスキップし、targetDirection 方向に hits ∪ middleHitsToClear の
- *   union 最遠端 + DETOUR_MARGIN を取る新ロジックを使う。これにより source-detour で中央水平
- *   セグメントが middle-row 障害を貫通するバグを解消する。両フィールド必須。
- *   opts 指定時 blockers 引数は参照されない (呼び出し側は obstacles など任意の値を渡せる)。
+ * opts (issue #374 / #353):
+ *   指定時は binary blocker 判定をスキップし、detourDirection 方向に hits ∪ middleHitsToClear の
+ *   union 最遠端 + DETOUR_MARGIN を取る新ロジックを使う。
+ *   - source-detour: detourDirection = target 方向。中央水平 [detourX, e.x] が middle-row 障害を
+ *     貫通するバグ (#374) を解消。
+ *   - target-detour: detourDirection = source 方向。中央水平 [s.x, detourX] が targetColHit を
+ *     貫通するバグ (#353) を解消。
+ *   両フィールド必須。opts 指定時 blockers 引数は参照されない (呼び出し側は obstacles など任意の値を渡せる)。
  */
 function pickDetourX(
   hits: Bbox[],
@@ -239,19 +242,19 @@ function pickDetourX(
   crossRange: [number, number],
   obstacles: Bbox[],
   opts?: {
-    targetDirection: 1 | -1
+    detourDirection: 1 | -1
     middleHitsToClear: Bbox[]
   },
 ): number {
   if (opts) {
-    // 新ロジック (issue #374): hits ∪ middleHitsToClear の最遠端を取る。
-    // sourceColHits だけ見ていた旧ロジックでは middleRowHits を貫通する detourX を選んでしまう。
+    // 新ロジック (issue #374 / #353): hits ∪ middleHitsToClear の最遠端を取る。
+    // 旧ロジック (binary blocker 判定) では中央水平セグメントが障害を貫通する detourX を選びうる。
     const extent = [...hits, ...opts.middleHitsToClear]
     const initialDetourX =
-      opts.targetDirection === 1
+      opts.detourDirection === 1
         ? Math.max(...extent.map((o) => o.x + o.w / 2)) + DETOUR_MARGIN
         : Math.min(...extent.map((o) => o.x - o.w / 2)) - DETOUR_MARGIN
-    return escalateDetourTrack(initialDetourX, crossRange, 'v', obstacles, opts.targetDirection)
+    return escalateDetourTrack(initialDetourX, crossRange, 'v', obstacles, opts.detourDirection)
   }
 
   // 既存ロジック (opts 未指定時): binary blocker 判定による方向決定。
@@ -383,9 +386,12 @@ export function detectDiagonalDetour(
     return Math.abs(b.y - my) < b.h / 2 + 2 && b.x - b.w / 2 < xHigh - 1 && b.x + b.w / 2 > xLow + 1
   })
 
-  // issue #374 の新ロジック pickDetourX(opts) に渡す target 方向。source-detour と
-  // both-detour.sourceDetourX で共通。
+  // pickDetourX(opts) に渡す迂回方向。
+  // - targetDirection (target 方向): source-detour / both-detour.sourceDetourX 用 (#374)。
+  // - sourceDirection (source 方向): target-detour 用 (#353)。中央水平 [s.x, detourX] が
+  //   targetColHit を貫通しないよう detourX を source 側へ寄せる。
   const targetDirection: 1 | -1 = e.x > s.x ? 1 : -1
+  const sourceDirection: 1 | -1 = s.x > e.x ? 1 : -1
 
   if (sourceColHits.length > 0 && targetColHits.length > 0) {
     // 相互ブロッキング回避: 反対側列の hits は方向判定から除外。対応する迂回パスで既に回避済み。
@@ -403,9 +409,12 @@ export function detectDiagonalDetour(
       srcBlockers,
       [s.y, my],
       obstacles,
-      middleRowHits.length > 0 ? { targetDirection, middleHitsToClear: middleRowHits } : undefined,
+      middleRowHits.length > 0
+        ? { detourDirection: targetDirection, middleHitsToClear: middleRowHits }
+        : undefined,
     )
-    // targetDetourX: 旧ロジック維持。target-detour 系の対称対応は issue #375 で別途。
+    // targetDetourX: 旧ロジック維持。both-detour は中央行 hit があると sourceDetourX/targetDetourX が
+    // 同じ middle hit を両側から避けて交差しうるため、対称対応は issue #375 で別途扱う。
     const targetDetourX = pickDetourX(targetColHits, tgtBlockers, [my, e.y], obstacles)
     const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
     const departY = clampOffset(s.y, shiftedMy, DEPART_GAP)
@@ -413,12 +422,21 @@ export function detectDiagonalDetour(
     return { kind: 'both-detour', departY, sourceDetourX, my: shiftedMy, targetDetourX, approachY }
   }
 
-  // 注: target-detour の detourX 計算は対称的に opts { targetDirection, middleHitsToClear } を
-  // 渡せる API を持つが、本 PR (issue #374) では source-detour のみに適用してリグレッションリスクを
-  // 抑える。target-detour / both-detour.tgtDetourX の対称対応は issue #375 でフォローアップ予定。
   if (targetColHits.length > 0 && sourceColHits.length === 0) {
-    const detourX = pickDetourX(targetColHits, obstacles, [my, e.y], obstacles)
     const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
+    // #353: target-detour の中央水平は [s.x, detourX]。shiftedMy が targetColHit の Y 範囲内に
+    // 残るとき、detourX を target 側 (旧ロジックの右優先) へ置くと中央水平が targetColHit を貫通する。
+    // この場合のみ detourX を source 側へ強制して貫通を防ぐ。
+    // shift で targetColHit の Y 範囲外へ抜けている場合は貫通しないため旧ロジックを維持し over-forcing を避ける。
+    const middleHThroughTargetCol = targetColHits.some(
+      (b) => Math.abs(b.y - shiftedMy) < b.h / 2 + 2,
+    )
+    const detourX = middleHThroughTargetCol
+      ? pickDetourX(targetColHits, obstacles, [my, e.y], obstacles, {
+          detourDirection: sourceDirection,
+          middleHitsToClear: middleRowHits,
+        })
+      : pickDetourX(targetColHits, obstacles, [my, e.y], obstacles)
     const approachY = clampOffset(e.y, shiftedMy, APPROACH_GAP)
     return { kind: 'target-detour', my: shiftedMy, detourX, approachY }
   }
@@ -432,7 +450,9 @@ export function detectDiagonalDetour(
       obstacles,
       [s.y, my],
       obstacles,
-      middleRowHits.length > 0 ? { targetDirection, middleHitsToClear: middleRowHits } : undefined,
+      middleRowHits.length > 0
+        ? { detourDirection: targetDirection, middleHitsToClear: middleRowHits }
+        : undefined,
     )
     const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
     const departY = clampOffset(s.y, shiftedMy, DEPART_GAP)


### PR DESCRIPTION
## 概要

issue #353 の修正。斜め矢印 (異行×異レーン) の **target-detour** で、中央水平セグメント `[s.x, detourX]` が target 列のブロッカーノードを貫通する不具合を解消する。

実フロー (grupura-phone) で確認された再現: 「10 (telタグから) → 13 (電話がつながる) のラインが 12 (確認番号入力) の上を通る」(issue #353 のコメント参照)。

## 原因

target-detour の中央水平は常に source 側 (`s.x`) から伸びるが、旧 `pickDetourX` は binary blocker 判定で「右が空いていれば右」へ `detourX` を置く。`s.x < e.x` のとき detourX を右 (target 側) に置くと、target 列の targetColHit (target ノード直上のブロッカー) を中央水平がまたいで貫通していた。さらに targetColHit は `targetColSet` に入り `middleRowHits` から除外されるため `computeShiftedMy` の Y シフトも効かなかった。

## 修正

`detectDiagonalDetour` の target-detour 分岐で、`shiftedMy` が targetColHit の Y 範囲内に残るときだけ `detourX` を **source 方向**へ強制する (#374 で導入した `pickDetourX(opts)` を流用)。

- `shiftedMy` が targetColHit の Y 範囲外へ抜けている場合 (中央行 hit で shift 済み等) は貫通しないため**旧ロジックを維持**し over-forcing を避ける。
- opts フィールドを `targetDirection` → `detourDirection` に改名し、source-detour (target 方向) / target-detour (source 方向) の双方向を表現。

## テスト

- `detectDiagonalDetour`: #353 再現 (source 側迂回 + 非貫通アサート)、右→左ミラー、over-forcing 回避 (shift で抜けたら右維持) を追加。既存の貫通固定値テスト (detourX=690) を修正後の値 (510) に更新。
- `buildArrowPath` 統合テスト 2 件 (core bug case / diamond) の貫通パスを修正後パスに更新。
- `src/lib/arrow-routing.test.ts` 全 172 件 pass。変更影響領域 (src/lib, src/features) 計 1013 件 pass。

## 目視確認

`/dev/render?fixture=grupura-phone-353` で実フローを描画し、telタグから→電話がつながる の矢印が確認番号入力の左側を迂回し**貫通しない**ことを確認 (中央水平 x[406,570] vs node12 x[584,736] = 非重複)。

## スコープ外

both-detour の `targetDetourX` 対称対応は、中央行 hit があると sourceDetourX/targetDetourX が同じ hit を両側から避けて交差しうる別問題のため #375 で別途扱う。

## 関連
- closes #353
- #374 (pickDetourX opts 基盤) / #375 (both-detour 対称対応のフォローアップ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)