### PR TITLE
fix(#375): both-detour の targetDetourX を gate 化し中央水平の target 列貫通を解消

### DIFF
--- a/src/dev/fixtures/both-detour-375.json
+++ b/src/dev/fixtures/both-detour-375.json
@@ -1,0 +1,23 @@
+{
+  "id": "fixture-375",
+  "title": "both-detour (#375 repro)",
+  "themeId": "cloud",
+  "shareToken": "dev-375",
+  "projectId": null,
+  "createdAt": "2026-06-23T00:00:00.000Z",
+  "updatedAt": "2026-06-23T00:00:00.000Z",
+  "lanes": [
+    { "id": "laneA", "name": "A", "colorIndex": 0, "position": 0 },
+    { "id": "laneB", "name": "B", "colorIndex": 1, "position": 1 },
+    { "id": "laneC", "name": "C", "colorIndex": 2, "position": 2 }
+  ],
+  "nodes": [
+    { "id": "nA", "laneId": "laneA", "rowIndex": 0, "label": "開始", "note": null, "orderIndex": 0 },
+    { "id": "nSrcBlk", "laneId": "laneA", "rowIndex": 1, "label": "源ブロッカー", "note": null, "orderIndex": 1 },
+    { "id": "nTgtBlk", "laneId": "laneC", "rowIndex": 1, "label": "標的ブロッカー", "note": null, "orderIndex": 2 },
+    { "id": "nD", "laneId": "laneC", "rowIndex": 2, "label": "終了", "note": null, "orderIndex": 3 }
+  ],
+  "arrows": [
+    { "id": "aBoth", "fromNodeId": "nA", "toNodeId": "nD", "comment": null, "fromSide": "bottom", "toSide": "top" }
+  ]
+}

--- a/src/dev/fixtures/both-detour-375.json
+++ b/src/dev/fixtures/both-detour-375.json
@@ -12,12 +12,40 @@
     { "id": "laneC", "name": "C", "colorIndex": 2, "position": 2 }
   ],
   "nodes": [
-    { "id": "nA", "laneId": "laneA", "rowIndex": 0, "label": "開始", "note": null, "orderIndex": 0 },
-    { "id": "nSrcBlk", "laneId": "laneA", "rowIndex": 1, "label": "源ブロッカー", "note": null, "orderIndex": 1 },
-    { "id": "nTgtBlk", "laneId": "laneC", "rowIndex": 1, "label": "標的ブロッカー", "note": null, "orderIndex": 2 },
+    {
+      "id": "nA",
+      "laneId": "laneA",
+      "rowIndex": 0,
+      "label": "開始",
+      "note": null,
+      "orderIndex": 0
+    },
+    {
+      "id": "nSrcBlk",
+      "laneId": "laneA",
+      "rowIndex": 1,
+      "label": "源ブロッカー",
+      "note": null,
+      "orderIndex": 1
+    },
+    {
+      "id": "nTgtBlk",
+      "laneId": "laneC",
+      "rowIndex": 1,
+      "label": "標的ブロッカー",
+      "note": null,
+      "orderIndex": 2
+    },
     { "id": "nD", "laneId": "laneC", "rowIndex": 2, "label": "終了", "note": null, "orderIndex": 3 }
   ],
   "arrows": [
-    { "id": "aBoth", "fromNodeId": "nA", "toNodeId": "nD", "comment": null, "fromSide": "bottom", "toSide": "top" }
+    {
+      "id": "aBoth",
+      "fromNodeId": "nA",
+      "toNodeId": "nD",
+      "comment": null,
+      "fromSide": "bottom",
+      "toSide": "top"
+    }
   ]
 }

--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -618,8 +618,9 @@ describe('buildArrowPath - 斜め迂回（異行×異レーン）', () => {
     const Bs: Bbox = { x: 200, y: 250, w: 152, h: 56 }
     const Bt: Bbox = { x: 600, y: 250, w: 152, h: 56 }
     const r = buildArrowPath(s, e, fc, tc, [Bs, Bt])
-    expect(r.d).toBe('M200,128 L200,142 L290,142 L290,250 L690,250 L690,358 L600,358 L600,372')
-    expect(r.mx).toBe((290 + 690) / 2)
+    // #375: targetDetourX が source 側 (510) に寄り、中央 H [290,510] が Bt を貫通しない。
+    expect(r.d).toBe('M200,128 L200,142 L290,142 L290,250 L510,250 L510,358 L600,358 L600,372')
+    expect(r.mx).toBe((290 + 510) / 2)
     expect(r.my).toBe(250)
   })
 
@@ -1000,11 +1001,43 @@ describe('detectDiagonalDetour', () => {
     expect(r).toEqual({
       kind: 'both-detour',
       departY: 142,
-      sourceDetourX: 290,
+      sourceDetourX: 290, // 200 + 76 + 14 (source 側 hit を target 方向へ)
       my: 250,
-      targetDetourX: 690,
+      // #375: my (=250) が targetColHit (y=250) の Y 範囲内に残るため、targetDetourX を source 側へ
+      // 寄せる。旧来は 690 (右) で中央 H [290,690] が Bt (x[524,676]) を貫通していた。
+      targetDetourX: 600 - 76 - 14, // 510 (source 側迂回)
       approachY: 358,
     })
+  })
+
+  it('should keep both-detour central H clear of both column nodes (#375 non-penetration)', () => {
+    const Bs: Bbox = { x: 200, y: 250, w: 152, h: 56 } // source col, x[124,276]
+    const Bt: Bbox = { x: 600, y: 250, w: 152, h: 56 } // target col, x[524,676]
+    const r = detectDiagonalDetour(s, e, [Bs, Bt])
+    expect(r?.kind).toBe('both-detour')
+    if (r?.kind === 'both-detour') {
+      // 中央 H = [sourceDetourX, targetDetourX] は順方向 (反転しない) かつ両列ノードを跨がない
+      expect(r.sourceDetourX).toBeLessThan(r.targetDetourX) // 290 < 510 (forward)
+      expect(r.sourceDetourX).toBeGreaterThanOrEqual(Bs.x + Bs.w / 2) // 290 >= 276
+      expect(r.targetDetourX).toBeLessThanOrEqual(Bt.x - Bt.w / 2) // 510 <= 524
+    }
+  })
+
+  it('should not invert both-detour central H when a middle-row hit sits between the columns (#375)', () => {
+    // targetColHit を縦長にして my シフト後も Y 範囲に残す → gate 発火。
+    // 中央 hit は sourceDetourX (target 方向) が回避し、targetDetourX は targetColHit のみを
+    // source 側でクリアするため中央 H は反転しない。
+    const Bs: Bbox = { x: 200, y: 250, w: 152, h: 56 } // source col, right=276
+    const Bt: Bbox = { x: 600, y: 250, w: 152, h: 120 } // target col (縦長), left=524, y[190,310]
+    const L: Bbox = { x: 400, y: 250, w: 152, h: 56 } // middle row hit, right=476
+    const r = detectDiagonalDetour(s, e, [Bs, Bt, L])
+    expect(r?.kind).toBe('both-detour')
+    if (r?.kind === 'both-detour') {
+      expect(r.my).toBe(292) // L 下端 278 + 14
+      expect(r.sourceDetourX).toBe(490) // max(Bs.right=276, L.right=476) + 14 (middle を target 方向で回避)
+      expect(r.targetDetourX).toBe(510) // Bt.left=524 - 14 (targetCol のみ source 側でクリア)
+      expect(r.sourceDetourX).toBeLessThan(r.targetDetourX) // 490 < 510 forward (反転なし)
+    }
   })
 
   it('should shift my when source-detour selected AND middle-row obstacle exists', () => {
@@ -1122,7 +1155,8 @@ describe('detectDiagonalDetour', () => {
     // s=(100, 100), e=(300, 300), my=200。
     // sourceColHit: (100, 200), targetColHit: (300, 200), middleRowHit: (200, 200)
     // 期待: sourceDetourX = max(sourceCol.right=140, middleRow.right=240) + 14 = 254
-    //       targetDetourX = 既存ロジック (本 PR 対象外) = 300 + 40 + 14 = 354
+    //       targetDetourX = 354。#375: my シフト (234) で targetColHit (y=200,h40→y[180,220]) を
+    //       抜けるため gate 不発 → 旧ロジック。中央 H [254,354] は y=234 で全障害をクリアし順方向。
     const obstacles: Bbox[] = [
       { x: 100, y: 200, w: 80, h: 40 }, // sourceColHit
       { x: 300, y: 200, w: 80, h: 40 }, // targetColHit
@@ -1131,8 +1165,8 @@ describe('detectDiagonalDetour', () => {
     const r = detectDiagonalDetour({ x: 100, y: 100 }, { x: 300, y: 300 }, obstacles)
     expect(r?.kind).toBe('both-detour')
     if (r?.kind === 'both-detour') {
-      expect(r.sourceDetourX).toBe(254) // 新ロジック適用
-      expect(r.targetDetourX).toBe(354) // 旧ロジック維持 (issue #375 で対応)
+      expect(r.sourceDetourX).toBe(254) // 新ロジック適用 (#374)
+      expect(r.targetDetourX).toBe(354) // gate 不発 (shift で targetCol を抜ける) → 旧ロジック維持
     }
   })
 

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -414,10 +414,24 @@ export function detectDiagonalDetour(
         ? { detourDirection: targetDirection, middleHitsToClear: middleRowHits }
         : undefined,
     )
-    // targetDetourX: 旧ロジック維持。both-detour は中央行 hit があると sourceDetourX/targetDetourX が
-    // 同じ middle hit を両側から避けて交差しうるため、対称対応は issue #375 で別途扱う。
-    const targetDetourX = pickDetourX(targetColHits, tgtBlockers, [my, e.y], obstacles)
     const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
+    // #375: targetDetourX も target-detour と対称に gate 化する。shiftedMy が targetColHit の Y
+    // 範囲内に残るときだけ detourX を source 方向へ寄せ、中央 H [sourceDetourX, targetDetourX] が
+    // targetColHit を貫通しないようにする。shift で Y 範囲外へ抜けていれば旧ロジック維持で
+    // over-forcing を避ける (target-detour と同じゲート設計)。
+    // middleHitsToClear は [] とする: both-detour では中央行 hit を sourceDetourX が target 方向で
+    // 既に回避済みのため、targetDetourX 側でも回避すると両 detourX が同じ hit を挟んで中央 H が
+    // 反転する。targetDetourX は targetColHit のみを source 側でクリアすればよい。
+    const targetMiddleHThrough = targetColHits.some((b) => Math.abs(b.y - shiftedMy) < b.h / 2 + 2)
+    const targetDetourX = pickDetourX(
+      targetColHits,
+      tgtBlockers,
+      [my, e.y],
+      obstacles,
+      targetMiddleHThrough
+        ? { detourDirection: sourceDirection, middleHitsToClear: [] }
+        : undefined,
+    )
     const departY = clampOffset(s.y, shiftedMy, DEPART_GAP)
     const approachY = clampOffset(e.y, shiftedMy, APPROACH_GAP)
     return { kind: 'both-detour', departY, sourceDetourX, my: shiftedMy, targetDetourX, approachY }

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -332,6 +332,15 @@ function computeShiftedMy(
 }
 
 /**
+ * 中央水平セグメント (y) が targetColHit の Y 範囲を跨ぐか判定する (#353 / #375 のゲート)。
+ * true のときだけ detourX を source 方向へ寄せる必要がある (false なら shift で抜けており旧ロジックで安全)。
+ * target-detour と both-detour.targetDetourX で共通利用。
+ */
+function middleHitsTargetCol(targetColHits: Bbox[], y: number): boolean {
+  return targetColHits.some((b) => Math.abs(b.y - y) < b.h / 2 + 2)
+}
+
+/**
  * 斜め配置矢印 (異行×異レーン) の Z字パス 3 セグメント (source 縦/中央水平/target 縦) と
  * 障害ノードの衝突を判定し、迂回パスを記述する DiagonalDetourResult を返す。
  * 障害なしまたは斜めでない (水平・垂直直線) ときは null を返す。
@@ -415,20 +424,15 @@ export function detectDiagonalDetour(
         : undefined,
     )
     const shiftedMy = computeShiftedMy(s, e, my, middleRowHits, obstacles)
-    // #375: targetDetourX も target-detour と対称に gate 化する。shiftedMy が targetColHit の Y
-    // 範囲内に残るときだけ detourX を source 方向へ寄せ、中央 H [sourceDetourX, targetDetourX] が
-    // targetColHit を貫通しないようにする。shift で Y 範囲外へ抜けていれば旧ロジック維持で
-    // over-forcing を避ける (target-detour と同じゲート設計)。
-    // middleHitsToClear は [] とする: both-detour では中央行 hit を sourceDetourX が target 方向で
-    // 既に回避済みのため、targetDetourX 側でも回避すると両 detourX が同じ hit を挟んで中央 H が
-    // 反転する。targetDetourX は targetColHit のみを source 側でクリアすればよい。
-    const targetMiddleHThrough = targetColHits.some((b) => Math.abs(b.y - shiftedMy) < b.h / 2 + 2)
+    // #375: targetDetourX も target-detour と対称に gate 化 (shiftedMy が targetColHit の Y 範囲に
+    // 残るときだけ source 方向へ寄せる)。middleHitsToClear=[] とするのは、both-detour では中央行 hit を
+    // sourceDetourX が target 方向で既に回避済みで、targetDetourX 側でも回避すると中央 H が反転するため。
     const targetDetourX = pickDetourX(
       targetColHits,
       tgtBlockers,
       [my, e.y],
       obstacles,
-      targetMiddleHThrough
+      middleHitsTargetCol(targetColHits, shiftedMy)
         ? { detourDirection: sourceDirection, middleHitsToClear: [] }
         : undefined,
     )
@@ -443,10 +447,7 @@ export function detectDiagonalDetour(
     // 残るとき、detourX を target 側 (旧ロジックの右優先) へ置くと中央水平が targetColHit を貫通する。
     // この場合のみ detourX を source 側へ強制して貫通を防ぐ。
     // shift で targetColHit の Y 範囲外へ抜けている場合は貫通しないため旧ロジックを維持し over-forcing を避ける。
-    const middleHThroughTargetCol = targetColHits.some(
-      (b) => Math.abs(b.y - shiftedMy) < b.h / 2 + 2,
-    )
-    const detourOpts = middleHThroughTargetCol
+    const detourOpts = middleHitsTargetCol(targetColHits, shiftedMy)
       ? { detourDirection: sourceDirection, middleHitsToClear: middleRowHits }
       : undefined
     const detourX = pickDetourX(targetColHits, obstacles, [my, e.y], obstacles, detourOpts)


### PR DESCRIPTION
## 概要

issue #375 の対応。#374 / #353 で導入した `pickDetourX(opts)` 機構を **both-detour の `targetDetourX`** にも対称適用し、中央水平セグメントが target 列ノードを貫通する不具合を解消する。

target-detour 側は #353 (PR #378) で対応済みのため、本 PR は残スコープの both-detour に絞る。

## 原因

both-detour の中央水平は `[sourceDetourX, targetDetourX]`。旧来 `targetDetourX` は常に target 側 (右優先) に置かれるため、`shiftedMy` が targetColHit の Y 範囲内に残るケースで中央水平が targetColHit を貫通していた (例: source/target 両列に同 row のブロッカーがある斜め矢印 → 690 が Bt(x[524,676]) を貫通)。

## 修正

#353 の target-detour と同じ**ゲート設計**を `targetDetourX` に対称適用:

- `shiftedMy` が targetColHit の Y 範囲内に残るときだけ `detourX` を **source 方向**へ寄せる。
- `my` シフトで Y 範囲外へ抜けている場合は旧ロジック維持 (over-forcing 回避)。
- `computeShiftedMy` を `targetDetourX` 計算前に前倒し。

### `middleHitsToClear` を `[]` にする理由

both-detour では中央行 hit を `sourceDetourX` が target 方向で既に回避済み。`targetDetourX` 側でも middleRowHits を回避すると、両 detourX が同じ hit を逆向きから挟んで中央水平が**反転**(逆走) する。`targetDetourX` は targetColHit のみを source 側でクリアすれば順方向のクリーンなパスになる。

## テスト

- `both-detour` 貫通修正 (690 → 510)、非貫通アサート、中央行 hit ありでの**反転回避**、shift で抜けるケースの gate 不発 (旧ロジック維持) を追加/更新。
- `buildArrowPath` both-detour 統合テストを修正後パスに更新。
- `arrow-routing.test.ts` 全 174 件 pass。変更影響領域 (src/lib, src/features, src/dev) 計 1145 件 pass。

## 目視確認

`/dev/render?fixture=both-detour-375` で both-detour を描画し、中央水平が両列ブロッカーを跨がず順方向 (源ブロッカー right=277 < sourceDetourX=326.5 < targetDetourX=992.5 < 標的ブロッカー left=1035) であることを確認。

## 関連
- closes #375
- #353 (PR #378, target-detour 側) / #374 (pickDetourX opts 基盤)

## 備考
- 既存の WIP ブランチ `feat/arrow-routing-target-detour-375` は #353 マージ前の別設計 (gate なし・over-force で中央 H 反転あり) のため本 PR で置き換え。当該 worktree/branch は未削除で温存。

🤖 Generated with [Claude Code](https://claude.com/claude-code)