### PR TITLE
test(#368): 実 layout 再現の回帰テスト追加（#374 で解消済みを確定）

### DIFF
--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -1191,6 +1191,37 @@ describe('detectDiagonalDetour', () => {
     }
   })
 
+  it('should not penetrate middle-row hit in #368 real layout (RH=84, diamond fromSide:bottom)', () => {
+    // issue #368: 実 layout (RH=84, TH=56, 菱形 DS=34) で shiftedMy の range-check が失敗し
+    // 原 my にフォールバックするケース。row17.y=100 基準:
+    //   s = (100, 134)  菱形下頂点 (row17.y + DS=34)
+    //   e = (300, 240)  target 上辺進入 (row19.y=268 - TH/2=28)
+    //   my = 187 (= (134+240)/2)
+    //   source 列障害 (店舗 row18 確認連絡): (100, 184)
+    //   中央行障害 (グルプラ row18 確認連絡): (200, 184) — x[124,276]
+    // 期待: source-detour。shiftedMy は range-check 失敗で 187 のままだが、#374 の union ロジックで
+    // detourX が中央障害の右端 + DETOUR_MARGIN まで張り出すため中央水平 [detourX, e.x] が貫通しない。
+    const s368 = { x: 100, y: 134 }
+    const e368 = { x: 300, y: 240 }
+    const mid: Bbox = { x: 200, y: 184, w: 152, h: 56 } // x[124,276]
+    const obstacles: Bbox[] = [
+      { x: 100, y: 184, w: 152, h: 56 }, // source 列障害
+      mid, // 中央行障害
+    ]
+    const r = detectDiagonalDetour(s368, e368, obstacles)
+    expect(r?.kind).toBe('source-detour')
+    if (r?.kind === 'source-detour') {
+      // #368 の核心条件: shiftedMy の range-check 失敗で原 my=187 にフォールバックする
+      // (shift-down 候補 226 > hi=211 / shift-up 候補 142 < lo=163 のため範囲外)。
+      expect(r.my).toBe(187)
+      // それでも detourX = max(source.right=176, mid.right=276) + 14 = 290 (中央障害の右外)
+      expect(r.detourX).toBe(290)
+      // 中央水平 [detourX, e.x] が中央障害の x 範囲 [124,276] を侵さないこと
+      const hMin = Math.min(r.detourX, e368.x)
+      expect(hMin).toBeGreaterThanOrEqual(mid.x + mid.w / 2) // 290 >= 276
+    }
+  })
+
   it('should fall back to original my when shiftedMy exceeds row bounds', () => {
     // 行間隔が狭く shiftedMy が source 行 / target 行を侵食するケース
     // s=(100, 100), e=(300, 160), my=130 — 行差 60 で狭い


### PR DESCRIPTION
## 概要

issue #368「菱形 `fromSide:\"bottom\"` 斜め矢印が現実 layout (RH=84) で中央行障害を貫通」は、**#374（PR #376）の source-detour union ロジックで既に解消済み**であることを検証し、実 layout を再現する回帰テストを追加する。

## 調査結果

#368 の推奨修正(a)「`pickDetourX` の `hits` に sourceColHits ∪ middleRowHits を渡し、両者を包含する端まで `detourX` を張り出す」は、#374 で既に実装されている（source-detour 分岐は `middleRowHits` 非空時に `{ detourDirection: targetDirection, middleHitsToClear: middleRowHits }` を渡す）。

そのため #368 の核心条件（`computeShiftedMy` の range-check 失敗 → 原 `my` フォールバック）が成立しても、中央水平は貫通しない。

実 layout (row17.y=100 基準, RH=84/TH=56/菱形 DS=34) での検証:
- `s=(100,134)` 菱形下頂点 / `e=(300,240)` target 上辺進入 / `my=187`
- source 列障害 `(100,184)` + 中央行障害 `(200,184)` (x[124,276])
- 結果: `source-detour`, `my=187`（range-check 失敗でフォールバック＝#368 の条件を再現）, **`detourX=290`**（中央障害の右端 276 + DETOUR_MARGIN）
- 中央水平 `[290, 300]` は中央障害 x[124,276] の**右外** → 貫通しない ✅

## 変更

- `src/lib/arrow-routing.test.ts`: 実 layout 再現の回帰テストを追加（コード変更なし）

## 関連
- closes #368
- #366 (CLOSED) / PR #367（「既知の制約」として #368 を明示） / #374（本件を実質解消した修正）

🤖 Generated with [Claude Code](https://claude.com/claude-code)