### PR TITLE
fix(#328): 迂回パス depart/approach 脚の障害物クリアランスを clamp

### DIFF
--- a/src/lib/arrow-routing.test.ts
+++ b/src/lib/arrow-routing.test.ts
@@ -156,20 +156,88 @@ describe('buildArrowPath - obstacles 引数（迂回モード）', () => {
       expect(lastY).toBe(e.y)
     })
 
-    it('水平距離が DEPART_GAP*2 未満の場合 departX/approachX は中央で接合し自己交差しない', () => {
-      // 水平距離=20, DEPART_GAP=APPROACH_GAP=14。Math.min(14, 10) で 10 に clamp される
-      // s=(100,200), e=(120,200) で間に B (110,200) を置いて迂回を強制
+    it('水平距離が DEPART_GAP*2 未満かつ障害物が密着 → 両脚ゼロ長で s.x/e.x 直上を降下（issue #328）', () => {
+      // 水平距離=20, DEPART_GAP=APPROACH_GAP=14。s=(100,200), e=(120,200) の間を
+      // B span x[102,118] がほぼ埋める密レイアウト。
       const sN = { x: 100, y: 200 }
       const eN = { x: 120, y: 200 }
       const fcN = { x: 80, y: 200 }
       const tcN = { x: 140, y: 200 }
       const B: Bbox = { x: 110, y: 200, w: 16, h: 56 }
       const r = buildArrowPath(sN, eN, fcN, tcN, [B])
-      // departX = 100 + 1 * Math.min(14, 10) = 110
-      // approachX = 120 - 1 * Math.min(14, 10) = 110
-      // → 中央 (110) で接合。departX も approachX も s.x/e.x を越えない
-      expect(r.d).toBe('M100,200 L110,200 L110,242 L110,242 L110,200 L120,200')
+      // 旧挙動は departX=approachX=110（中央接合）で、垂直降下が B(x[102,118]) を貫通していた。
+      // #328 修正後: departGap=approachGap=0 → departX=100, approachX=120。
+      // 降下は B の左外 (100) / 右外 (120) で起こり貫通しない。自己交差もしない (100 ≤ 120)。
+      expect(r.d).toBe('M100,200 L100,200 L100,242 L120,242 L120,200 L120,200')
     })
+  })
+})
+
+describe('buildArrowPath - depart/approach 脚の障害物クリアランス (issue #328)', () => {
+  // PR #327 で追加した 6 セグ迂回パスの depart 脚 (s.x→departX) / approach 脚
+  // (approachX→e.x) は y=s.y / y=e.y のまま水平移動するため、inRow 障害物の手前端が
+  // s.x / e.x から GAP(=14) 以内に来る密レイアウトでは脚が障害物を貫通しうる。
+  // departGap/approachGap を max(0, min(GAP, halfDx, 障害物までの距離 - DETOUR_MARGIN)) で
+  // clamp し、貫通を防ぐ（degenerate 時は脚ゼロ長＝旧 5 セグ路と等価）。
+  const fc = { x: 200, y: 200 }
+  const tc = { x: 700, y: 200 }
+
+  it('depart 脚: 障害物左端が s.x から GAP 未満 → 垂直降下を s.x まで引き戻す（脚ゼロ長）', () => {
+    const s = { x: 276, y: 200 }
+    const e = { x: 600, y: 200 }
+    // B span [284,436]: 左端 284 は s.x(276) から 8px → departGap = max(0,min(14,_,8-14)) = 0
+    const B: Bbox = { x: 360, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B])
+    // departX = 276（脚ゼロ長）, approachX = 600-14 = 586, detourY = 228+14 = 242
+    expect(r.d).toBe('M276,200 L276,200 L276,242 L586,242 L586,200 L600,200')
+  })
+
+  it('depart 脚: 障害物左端が s.x から GAP〜2*GAP → margin を保って departX を縮小', () => {
+    const s = { x: 276, y: 200 }
+    const e = { x: 600, y: 200 }
+    // B span [296,448]: 左端 296 は s.x から 20px → departGap = min(14,20-14) = 6 → departX = 282
+    const B: Bbox = { x: 372, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, fc, tc, [B])
+    expect(r.d).toBe('M276,200 L282,200 L282,242 L586,242 L586,200 L600,200')
+  })
+
+  it('approach 脚: 障害物右端が e.x から GAP〜2*GAP → margin を保って approachX を縮小', () => {
+    const s = { x: 200, y: 200 }
+    const e = { x: 524, y: 200 }
+    // B span [352,504]: 右端 504 は e.x(524) から 20px → approachGap = 6 → approachX = 518
+    const B: Bbox = { x: 428, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, { x: 100, y: 200 }, { x: 600, y: 200 }, [B])
+    // departX = 200+14 = 214, detourY = 242
+    expect(r.d).toBe('M200,200 L214,200 L214,242 L518,242 L518,200 L524,200')
+  })
+
+  it('右→左方向（s.x>e.x）でも depart/approach 脚を clamp（ミラー）', () => {
+    const s = { x: 600, y: 200 }
+    const e = { x: 276, y: 200 }
+    // sign=-1。B span [428,580]: 右端 580 は s.x(600) から 20px → departGap = 6 → departX = 594
+    const B: Bbox = { x: 504, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, { x: 700, y: 200 }, { x: 200, y: 200 }, [B])
+    // approach 側: 左端 428 は e.x(276) から 152px → approachGap = 14 → approachX = 290
+    expect(r.d).toBe('M600,200 L594,200 L594,242 L290,242 L290,200 L276,200')
+  })
+
+  it('縦迂回 depart 脚: 障害物上端が s.y から GAP〜2*GAP → departY を縮小', () => {
+    const s = { x: 200, y: 228 }
+    const e = { x: 200, y: 572 }
+    // B span Y [248,304]: 上端 248 は s.y(228) から 20px → departY = 228+6 = 234
+    const B: Bbox = { x: 200, y: 276, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, { x: 200, y: 200 }, { x: 200, y: 600 }, [B])
+    // detourX = 276+14 = 290, approachY = 572-14 = 558
+    expect(r.d).toBe('M200,228 L200,234 L290,234 L290,558 L200,558 L200,572')
+  })
+
+  it('通常レイアウト（障害物端が 2*GAP 以上離れる）は departX/approachX 不変（回帰ガード）', () => {
+    const s = { x: 276, y: 200 }
+    const e = { x: 524, y: 200 }
+    // B span [324,476]: 両端とも 48px 離れる → 従来どおり departX=290, approachX=510
+    const B: Bbox = { x: 400, y: 200, w: 152, h: 56 }
+    const r = buildArrowPath(s, e, { x: 200, y: 200 }, { x: 600, y: 200 }, [B])
+    expect(r.d).toBe('M276,200 L290,200 L290,242 L510,242 L510,200 L524,200')
   })
 })
 
@@ -452,17 +520,17 @@ describe('buildArrowPath - 縦方向迂回（同一レーン）', () => {
       expect(lastX).toBe(e.x)
     })
 
-    it('垂直距離が DEPART_GAP*2 未満の場合 departY/approachY は中央で接合し自己交差しない', () => {
+    it('垂直距離が DEPART_GAP*2 未満かつ障害物が密着 → 両脚ゼロ長で s.y/e.y 上を移動（issue #328）', () => {
       const sN = { x: 200, y: 100 }
       const eN = { x: 200, y: 120 }
       const fcN = { x: 200, y: 80 }
       const tcN = { x: 200, y: 140 }
-      const B: Bbox = { x: 200, y: 110, w: 152, h: 16 }
+      const B: Bbox = { x: 200, y: 110, w: 152, h: 16 } // span y[102,118]
       const r = buildArrowPath(sN, eN, fcN, tcN, [B])
-      // departY = 100 + 1 * Math.min(14, 10) = 110
-      // approachY = 120 - 1 * Math.min(14, 10) = 110
-      // detourX = 200 + 76 + 14 = 290
-      expect(r.d).toBe('M200,100 L200,110 L290,110 L290,110 L200,110 L200,120')
+      // 旧挙動は departY=approachY=110（中央接合）で、水平移動が B(y[102,118]) を貫通していた。
+      // #328 修正後: departGap=approachGap=0 → departY=100, approachY=120。
+      // 水平移動は B の上外 (100) / 下外 (120) で起こり貫通しない。detourX = 290。
+      expect(r.d).toBe('M200,100 L200,100 L290,100 L290,120 L200,120 L200,120')
     })
   })
 })

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -115,7 +115,9 @@ function escalateDetourTrack(
  *
  * @param origin  脚の起点座標（軸上のスカラー。水平脚なら s.x/e.x、垂直脚なら s.y/e.y）
  * @param dir     進行方向（+1 = 右/下, -1 = 左/上）
- * @param spans   経路上障害物の軸方向占有範囲 [lowEdge, highEdge] の配列
+ * @param spans   経路上障害物の軸方向占有範囲 [lowEdge, highEdge] の配列。
+ *                **空配列を渡してはならない**（Math.min(...[]) = Infinity となり clamp が無効化される）。
+ *                呼び出し側は inRow/inCol が空でないことを保証済みの場合のみ呼ぶこと。
  * @param maxGap  通常時の脚長（DEPART_GAP / APPROACH_GAP）
  * @param halfSpan 始終点間距離の半分（脚が中央を越えて自己交差しないための上限）
  */
@@ -131,6 +133,25 @@ function clampLegGap(
   const distances = spans.map(([lo, hi]) => (dir > 0 ? lo - origin : origin - hi))
   const nearest = Math.min(...distances)
   return Math.max(0, Math.min(maxGap, halfSpan, nearest - DETOUR_MARGIN))
+}
+
+/**
+ * depart 脚 (origin 側) / approach 脚 (target 側) の折れ点座標を対称に算出する (issue #328)。
+ * 横迂回では (origin,target)=(s.x,e.x)・spans は inRow の X 範囲、
+ * 縦迂回では (origin,target)=(s.y,e.y)・spans は inCol の Y 範囲を渡す。
+ * spans は空であってはならない（clampLegGap の契約）。
+ */
+function computeLegEndpoints(
+  origin: number,
+  target: number,
+  spans: Array<[number, number]>,
+): { depart: number; approach: number } {
+  const sign: 1 | -1 = origin < target ? 1 : -1 // origin !== target は呼び出し側が保証
+  const half = Math.abs(target - origin) / 2
+  return {
+    depart: origin + sign * clampLegGap(origin, sign, spans, DEPART_GAP, half),
+    approach: target - sign * clampLegGap(target, -sign as 1 | -1, spans, APPROACH_GAP, half),
+  }
 }
 
 function detectDetour(
@@ -187,11 +208,8 @@ function detectDetour(
 
   // depart/approach 脚クリアランス (issue #328): inRow 障害物の X 占有範囲を使い、
   // 始点側・終点側の水平脚が障害物を貫通しない範囲に departX/approachX を clamp する。
-  const sign: 1 | -1 = s.x < e.x ? 1 : -1 // xLow < xHigh 保証済みなので 0 にならない
-  const halfDx = Math.abs(e.x - s.x) / 2
   const spans = inRow.map((o): [number, number] => [o.x - o.w / 2, o.x + o.w / 2])
-  const departX = s.x + sign * clampLegGap(s.x, sign, spans, DEPART_GAP, halfDx)
-  const approachX = e.x - sign * clampLegGap(e.x, -sign as 1 | -1, spans, APPROACH_GAP, halfDx)
+  const { depart: departX, approach: approachX } = computeLegEndpoints(s.x, e.x, spans)
 
   return { detourY, departX, approachX }
 }
@@ -251,11 +269,8 @@ function detectVerticalDetour(
 
   // depart/approach 脚クリアランス (issue #328): inCol 障害物の Y 占有範囲を使い、
   // 始点側・終点側の垂直脚が障害物を貫通しない範囲に departY/approachY を clamp する。
-  const sign: 1 | -1 = s.y < e.y ? 1 : -1 // yLow < yHigh 保証済みなので 0 にならない
-  const halfDy = Math.abs(e.y - s.y) / 2
   const spans = inCol.map((o): [number, number] => [o.y - o.h / 2, o.y + o.h / 2])
-  const departY = s.y + sign * clampLegGap(s.y, sign, spans, DEPART_GAP, halfDy)
-  const approachY = e.y - sign * clampLegGap(e.y, -sign as 1 | -1, spans, APPROACH_GAP, halfDy)
+  const { depart: departY, approach: approachY } = computeLegEndpoints(s.y, e.y, spans)
 
   return { detourX, departY, approachY }
 }
@@ -724,10 +739,7 @@ export const buildArrowPath = (
   if (obstacles && obstacles.length > 0) {
     const detour = detectDetour(s, e, obstacles)
     if (detour) {
-      // departX/approachX は detectDetour 側で以下を満たすよう算出済み (issue #328):
-      //   - DEPART_GAP/APPROACH_GAP と |dx|/2 で clamp（自己交差防止・対称設計）
-      //   - inRow 障害物の手前端 - DETOUR_MARGIN を越えない（depart/approach 脚の貫通防止）
-      // 縮退ケースでは脚がゼロ長になり、垂直降下が s.x/e.x 直上で起こる（旧 5 セグ路と等価）。
+      // departX/approachX は detectDetour 側で算出済み（障害物クリアランス clamp 含む, issue #328）。
       const { detourY, departX, approachX } = detour
       // 6 セグメント: M → 水平(departX まで) → 垂直(detourY まで) → 水平(approachX まで)
       //               → 垂直(e.y まで) → 水平(e.x へ進入)
@@ -743,10 +755,7 @@ export const buildArrowPath = (
 
     const vDetour = detectVerticalDetour(s, e, obstacles)
     if (vDetour) {
-      // departY/approachY は detectVerticalDetour 側で算出済み (issue #328):
-      //   - DEPART_GAP/APPROACH_GAP と |dy|/2 で clamp（自己交差防止・対称設計）
-      //   - inCol 障害物の手前端 - DETOUR_MARGIN を越えない（depart/approach 脚の貫通防止）
-      // 縮退ケースでは脚がゼロ長になり、水平移動が s.y/e.y 上で起こる（旧 5 セグ路と等価）。
+      // departY/approachY は detectVerticalDetour 側で算出済み（障害物クリアランス clamp 含む, issue #328）。
       const { detourX, departY, approachY } = vDetour
       // 6 セグメント: M → 垂直(departY まで) → 水平(detourX まで) → 垂直(approachY まで)
       //               → 水平(e.x まで) → 垂直(e.y へ進入)

--- a/src/lib/arrow-routing.ts
+++ b/src/lib/arrow-routing.ts
@@ -104,7 +104,40 @@ function escalateDetourTrack(
   return fixed
 }
 
-function detectDetour(s: Point, e: Point, obstacles: Bbox[]): { detourY: number } | null {
+/**
+ * depart / approach 脚（迂回パスの始点側・終点側の水平 or 垂直セグメント）が、
+ * 経路上の最寄り障害物を貫通しないよう脚の長さ(gap)を clamp する (issue #328)。
+ *
+ * 脚は origin から進行方向へ伸び、その先端で直交方向へ折れる。先端が障害物の
+ * 手前端を越えると貫通するため、gap を「最寄り障害物の手前端までの距離 - DETOUR_MARGIN」
+ * 以下に抑える。距離が DETOUR_MARGIN 未満（origin が障害物に密着）なら gap=0 となり、
+ * 折れ点が origin に一致する＝旧 5 セグ路（始点直下/直上で折れる）と等価に縮退する。
+ *
+ * @param origin  脚の起点座標（軸上のスカラー。水平脚なら s.x/e.x、垂直脚なら s.y/e.y）
+ * @param dir     進行方向（+1 = 右/下, -1 = 左/上）
+ * @param spans   経路上障害物の軸方向占有範囲 [lowEdge, highEdge] の配列
+ * @param maxGap  通常時の脚長（DEPART_GAP / APPROACH_GAP）
+ * @param halfSpan 始終点間距離の半分（脚が中央を越えて自己交差しないための上限）
+ */
+function clampLegGap(
+  origin: number,
+  dir: 1 | -1,
+  spans: Array<[number, number]>,
+  maxGap: number,
+  halfSpan: number,
+): number {
+  // dir>0 では手前端 = lowEdge、dir<0 では手前端 = highEdge。
+  // dir を掛けることで「進行方向に見た origin からの符号付き距離」に正規化する。
+  const distances = spans.map(([lo, hi]) => (dir > 0 ? lo - origin : origin - hi))
+  const nearest = Math.min(...distances)
+  return Math.max(0, Math.min(maxGap, halfSpan, nearest - DETOUR_MARGIN))
+}
+
+function detectDetour(
+  s: Point,
+  e: Point,
+  obstacles: Bbox[],
+): { detourY: number; departX: number; approachX: number } | null {
   // 水平直線でなければ迂回しない
   if (Math.abs(e.y - s.y) >= 2) return null
 
@@ -152,10 +185,22 @@ function detectDetour(s: Point, e: Point, obstacles: Bbox[]): { detourY: number 
   const direction: 1 | -1 = goDown ? 1 : -1
   const detourY = escalateDetourTrack(initialDetourY, [s.x, e.x], 'h', obstacles, direction)
 
-  return { detourY }
+  // depart/approach 脚クリアランス (issue #328): inRow 障害物の X 占有範囲を使い、
+  // 始点側・終点側の水平脚が障害物を貫通しない範囲に departX/approachX を clamp する。
+  const sign: 1 | -1 = s.x < e.x ? 1 : -1 // xLow < xHigh 保証済みなので 0 にならない
+  const halfDx = Math.abs(e.x - s.x) / 2
+  const spans = inRow.map((o): [number, number] => [o.x - o.w / 2, o.x + o.w / 2])
+  const departX = s.x + sign * clampLegGap(s.x, sign, spans, DEPART_GAP, halfDx)
+  const approachX = e.x - sign * clampLegGap(e.x, -sign as 1 | -1, spans, APPROACH_GAP, halfDx)
+
+  return { detourY, departX, approachX }
 }
 
-function detectVerticalDetour(s: Point, e: Point, obstacles: Bbox[]): { detourX: number } | null {
+function detectVerticalDetour(
+  s: Point,
+  e: Point,
+  obstacles: Bbox[],
+): { detourX: number; departY: number; approachY: number } | null {
   // 垂直直線でなければ迂回しない
   if (Math.abs(e.x - s.x) >= 2) return null
 
@@ -204,7 +249,15 @@ function detectVerticalDetour(s: Point, e: Point, obstacles: Bbox[]): { detourX:
   const direction: 1 | -1 = goRight ? 1 : -1
   const detourX = escalateDetourTrack(initialDetourX, [s.y, e.y], 'v', obstacles, direction)
 
-  return { detourX }
+  // depart/approach 脚クリアランス (issue #328): inCol 障害物の Y 占有範囲を使い、
+  // 始点側・終点側の垂直脚が障害物を貫通しない範囲に departY/approachY を clamp する。
+  const sign: 1 | -1 = s.y < e.y ? 1 : -1 // yLow < yHigh 保証済みなので 0 にならない
+  const halfDy = Math.abs(e.y - s.y) / 2
+  const spans = inCol.map((o): [number, number] => [o.y - o.h / 2, o.y + o.h / 2])
+  const departY = s.y + sign * clampLegGap(s.y, sign, spans, DEPART_GAP, halfDy)
+  const approachY = e.y - sign * clampLegGap(e.y, -sign as 1 | -1, spans, APPROACH_GAP, halfDy)
+
+  return { detourX, departY, approachY }
 }
 
 type DiagonalDetourResult =
@@ -671,15 +724,11 @@ export const buildArrowPath = (
   if (obstacles && obstacles.length > 0) {
     const detour = detectDetour(s, e, obstacles)
     if (detour) {
-      const { detourY } = detour
-      // |e.x - s.x| / 2 で clamp。ノード幅が縮小しても departX/approachX が反対側を越えて
-      // パスが自己交差するのを防ぐ防御コード（detectDetour で水平距離は保証されるが、レイアウト
-      // 変更時の silent breakage 回避用）。DEPART_GAP/APPROACH_GAP が同値（対称設計）の場合、
-      // clamp が効くと中央で接合する（縮退ケースでは中央水平セグメントがゼロ長になる）。
-      const sign = Math.sign(dx)
-      const halfDx = Math.abs(dx) / 2
-      const departX = s.x + sign * Math.min(DEPART_GAP, halfDx)
-      const approachX = e.x - sign * Math.min(APPROACH_GAP, halfDx)
+      // departX/approachX は detectDetour 側で以下を満たすよう算出済み (issue #328):
+      //   - DEPART_GAP/APPROACH_GAP と |dx|/2 で clamp（自己交差防止・対称設計）
+      //   - inRow 障害物の手前端 - DETOUR_MARGIN を越えない（depart/approach 脚の貫通防止）
+      // 縮退ケースでは脚がゼロ長になり、垂直降下が s.x/e.x 直上で起こる（旧 5 セグ路と等価）。
+      const { detourY, departX, approachX } = detour
       // 6 セグメント: M → 水平(departX まで) → 垂直(detourY まで) → 水平(approachX まで)
       //               → 垂直(e.y まで) → 水平(e.x へ進入)
       const segments: EdgeSegment[] = [
@@ -694,14 +743,11 @@ export const buildArrowPath = (
 
     const vDetour = detectVerticalDetour(s, e, obstacles)
     if (vDetour) {
-      const { detourX } = vDetour
-      // |e.y - s.y| / 2 で clamp。横版（上方の detectDetour ブロック）と対称な防御コードで、
-      // ノード高が縮小しても departY/approachY が反対側を越えて自己交差するのを防ぐ。
-      // 縮退ケースでは中央垂直セグメントがゼロ長になる。
-      const sign = Math.sign(dy)
-      const halfDy = Math.abs(dy) / 2
-      const departY = s.y + sign * Math.min(DEPART_GAP, halfDy)
-      const approachY = e.y - sign * Math.min(APPROACH_GAP, halfDy)
+      // departY/approachY は detectVerticalDetour 側で算出済み (issue #328):
+      //   - DEPART_GAP/APPROACH_GAP と |dy|/2 で clamp（自己交差防止・対称設計）
+      //   - inCol 障害物の手前端 - DETOUR_MARGIN を越えない（depart/approach 脚の貫通防止）
+      // 縮退ケースでは脚がゼロ長になり、水平移動が s.y/e.y 上で起こる（旧 5 セグ路と等価）。
+      const { detourX, departY, approachY } = vDetour
       // 6 セグメント: M → 垂直(departY まで) → 水平(detourX まで) → 垂直(approachY まで)
       //               → 水平(e.x まで) → 垂直(e.y へ進入)
       const segments: EdgeSegment[] = [


### PR DESCRIPTION
## 概要
issue #328: PR #327（issue #323）で追加した 6 セグメント迂回パスの **depart 脚** (`s.x → departX`) は `y = s.y` のまま水平移動するため、同一行 (`inRow`) 障害物の手前端が `s.x` から `DEPART_GAP=14px` 以内に来る密レイアウトで脚が障害物を貫通しうる regression があった。構造的に対称な **approach 脚** (`approachX → e.x`)、および縦迂回 (`detectVerticalDetour`) の depart/approach 脚も同じ問題を持つ。

Closes #328

## 修正内容
- `clampLegGap` ヘルパを追加。`departGap`/`approachGap` を
  `max(0, min(GAP, halfSpan, 最寄り障害物の手前端までの距離 - DETOUR_MARGIN))` で clamp。
- `detectDetour` が `departX`/`approachX` を、`detectVerticalDetour` が `departY`/`approachY` を返すよう拡張し、脚長算出を関数内（障害物情報がある場所）に集約。
- 距離が `DETOUR_MARGIN` 未満（始点が障害物に密着）なら `gap=0` となり、折れ点が `s.x`/`e.x` 直上に一致＝旧 5 セグ路と等価に安全縮退。
- 通常グリッド（`gap >= 2*GAP`）では `departX`/`approachX` 不変＝**回帰なし**（回帰ガードテストで担保）。

## テスト (TDD)
- 密レイアウトでの depart/approach 脚貫通防止テストを 6 件追加（横・縦・右→左ミラー・回帰ガード）。
- 旧 degenerate テスト 2 件は「中央接合」で実際には障害物を貫通していた #328 バグそのものだったため、非貫通パスへ期待値を更新。
- `npx vitest run src/lib/arrow-routing.test.ts` → 181 passed。`src/` 全体 1221 passed。

## 実画面確認
ログイン不要の `/try` エディタで A(lane1)→C(lane3) を作成後、間に B(lane2) を配置。A→C が `M211.5,280 L225.5,280 L225.5,322 L487.5,322 L487.5,280 L501.5,280` の 6 セグ迂回となり、depart/approach 脚とも B を貫通せず下を回り込むことを目視確認。LCP=560ms。

🤖 Generated with [Claude Code](https://claude.com/claude-code)